### PR TITLE
Updated the habit choice bundle interaction

### DIFF
--- a/docs/📘 HabitFlowAI PRD - Choice Habit Update.md
+++ b/docs/📘 HabitFlowAI PRD - Choice Habit Update.md
@@ -1,0 +1,335 @@
+# HabitFlow PRD
+
+## Choice Bundle v2 — Option Habits, Entries, Metrics, and Goal Attribution
+
+---
+
+## 1. Overview
+
+### Feature Name
+
+**Choice Habit Bundle v2 (Option Habits + Metric Entries)**
+
+### Status
+
+Proposed – Ready for implementation planning
+
+### Owner
+
+HabitFlow Core
+
+---
+
+## 2. Problem Statement
+
+Users often practice a *category of behavior* (e.g., Calisthenics, Learning, Cardio) using multiple specific actions (pushups, pull-ups, squats). Today, HabitFlow allows a binary “choice” habit, but:
+
+* It hides *which* actions were taken
+* It does not allow meaningful contribution tracking toward goals
+* It conflates “did the habit” with “how the habit was done”
+* It prevents flexible historical analysis (days vs totals)
+
+Users want:
+
+* One **parent habit** for consistency and streaks
+* Multiple **option habits** representing real actions
+* A **single source of truth** for historical data
+* Metrics that are optional at creation but **strictly enforced once defined**
+* Goal progress that reflects *how* they showed up, not just *if*
+
+---
+
+## 3. Design Philosophy
+
+This feature is guided by four core principles:
+
+1. **Habits are habits**
+   Option choices are real habits, not “sub-events” or “metadata.”
+
+2. **Entries are the source of truth**
+   All historical insights (days, totals, averages) derive from entries.
+
+3. **Consistency ≠ Uniformity**
+   A habit can be completed in multiple valid ways without fragmenting the habit list.
+
+4. **Explicit beats clever**
+   Metric expectations must be clear and enforced to avoid ambiguous history.
+
+---
+
+## 4. Key Concepts & Terminology
+
+### Parent Habit
+
+A top-level habit tracked for consistency.
+
+* Example: *Calisthenics*
+* Completion is **binary per day**
+* Completion is **derived**, not manually entered
+
+### Option Habit
+
+A habit that exists **within** a parent habit’s bundle.
+
+* Example: *Pushups*, *Pull-ups*, *Squats*
+* Optional on any given day
+* Can contribute to goals independently
+
+### Entry
+
+The atomic record of something the user did on a day.
+
+* One entry = one option habit on one date
+* Entries power all aggregations
+
+---
+
+## 5. User Scenarios
+
+### Scenario 1: Binary consistency + rich attribution
+
+* User tracks *Calisthenics*
+* On Monday: does pull-ups and squats
+* Calisthenics = complete
+* History shows:
+
+  * Pull-ups: 15 reps
+  * Squats: 60 reps
+
+### Scenario 2: Optional metric habits
+
+* User creates *Running* option habit
+* Metric = miles (required)
+* Every time Running is selected, miles must be entered
+* User can later see:
+
+  * Total miles
+  * Days run
+  * Average miles per run
+
+### Scenario 3: Goal linkage
+
+* Goal: *Run 500 miles*
+* Linked directly to option habit *Running*
+* Goal progress derives from entry totals, not parent habit completion
+
+---
+
+## 6. Functional Requirements
+
+### 6.1 Choice Bundle Configuration
+
+A Parent Habit can be configured as a **Choice Bundle**.
+
+#### Bundle Properties
+
+* `bundleType = "choice"`
+* `multiSelect = true` (always enabled in v2)
+
+#### Option Habit Definition
+
+Each option includes:
+
+* `id`
+* `name`
+* `metricMode`
+
+  * `"none"` – completion only
+  * `"required"` – numeric value required for every entry
+* If `metricMode = required`:
+
+  * `unitName` (string, e.g., reps, miles, minutes)
+  * `allowDecimal` (boolean)
+  * `suggestedIncrements` (optional UX helper)
+
+> **Important rule**
+> Metric mode is optional at creation, but once set to `required`, **all entries must include a value**. Mixed-mode entries are not allowed.
+
+---
+
+### 6.2 Logging Behavior (Daily)
+
+#### Entry Creation Rules
+
+* A user may select **0..N option habits** per day
+* For each selected option habit:
+
+  * Create or update **one entry** for that date
+* If option habit requires metric:
+
+  * Value input is mandatory
+  * Save is blocked without valid value
+
+#### Parent Habit Completion
+
+* Parent habit is **complete** on a date **iff**
+
+  * ≥ 1 option habit entry exists for that parent on that date
+
+Parent completion is **derived**, not independently set.
+
+---
+
+### 6.3 Entry Model (Source of Truth)
+
+#### OptionHabitEntry
+
+```
+optionHabitId
+parentHabitId
+dateKey
+value? (number)
+unit? (string, stored for historical integrity)
+source (manual, routine, activity)
+createdAt
+updatedAt
+```
+
+#### Constraints
+
+* Max one entry per (optionHabitId, dateKey)
+* Value required iff option habit metricMode = required
+
+---
+
+## 7. Historical Aggregations (Derived, Not Stored)
+
+All analytics derive from entries:
+
+### Supported Aggregations
+
+For a given option habit:
+
+* **Days used**
+  = count of distinct dateKeys with entries
+* **Total units**
+  = sum of `value` (metric habits only)
+* **Average per day used**
+* **Best / max day**
+* **Trends over time**
+
+For parent habit:
+
+* **Days completed**
+* **Streaks**
+* **Completion rate**
+
+No separate counters or caches should introduce conflicting logic.
+
+---
+
+## 8. Goal Integration
+
+### Goal Linking Sources
+
+A Goal may link to:
+
+1. Parent Habit (binary completion)
+2. Option Habit (preferred for metrics)
+
+### Aggregation Mode
+
+Derived automatically:
+
+* If option habit has metric → `sum(value)`
+* If no metric → `count(days with entry)`
+
+### GoalLink Model
+
+```
+goalId
+sourceType = "habit" | "optionHabit"
+habitId?
+optionHabitId?
+aggregationMode
+```
+
+---
+
+## 9. UI / UX Requirements
+
+### 9.1 Habit Logging Modal
+
+#### Layout
+
+* Title: Parent Habit name
+* Subtext: “Select what you did today (you can choose multiple)”
+
+#### Option Rows
+
+Each row includes:
+
+* Checkbox
+* Option habit name
+* If metric required:
+
+  * Numeric input + unit label
+  * Increment chips (optional)
+
+#### Validation
+
+* Save disabled until:
+
+  * At least one option selected
+  * All required-metric options have valid values
+
+---
+
+### 9.2 Habit Details Page
+
+#### Sections
+
+1. **Today’s Breakdown**
+
+   * Chips showing selected options + values
+2. **Option Habit Breakdown**
+
+   * Toggle: Days | Total | Average
+3. **Chart**
+
+   * Stacked or grouped by option habit
+4. **Linked Goals**
+
+   * Shows which option habits contribute where
+
+---
+
+## 10. Non-Goals (Explicitly Out of Scope)
+
+* Multiple entries per option per day
+* Option habit streaks (future enhancement)
+* Free-text or mixed metric entries
+* Auto-completion via routines without user confirmation
+
+---
+
+## 11. Edge Cases & Rules
+
+* Changing metric units does **not** retroactively alter old entries
+* Deleting an option habit deletes its entries (with confirmation)
+* Parent habit cannot be completed manually if no option entries exist
+* If all option entries are deleted for a day, parent completion disappears
+
+---
+
+## 12. Success Metrics
+
+* Users can answer:
+
+  * “Did I do this habit?”
+  * “How did I do it?”
+  * “How much did I do?”
+* Reduced habit list clutter
+* Increased goal attribution clarity
+* No ambiguous historical data
+
+---
+
+## 13. Implementation Readiness
+
+This PRD is designed to:
+
+* Map cleanly to existing HabitFlow concepts (Habits, Entries, Goals)
+* Avoid dual sources of truth
+* Scale to future features (weekly habits, routines, streak variants)
+* Remain explainable to users without jargon

--- a/src/components/HabitHistoryModal.tsx
+++ b/src/components/HabitHistoryModal.tsx
@@ -114,6 +114,11 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                         </div>
                                         <div className="text-xs text-gray-500 dark:text-gray-400">
                                             {new Date(entry.timestamp).toLocaleTimeString()} • {entry.source}
+                                            {entry.bundleOptionLabel && (
+                                                <span className="block mt-1 font-medium text-emerald-600 dark:text-emerald-400">
+                                                    Selected: {entry.bundleOptionLabel}
+                                                </span>
+                                            )}
                                         </div>
                                     </div>
 

--- a/src/components/HabitLogModal.tsx
+++ b/src/components/HabitLogModal.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import { X, CheckCircle2, ChevronRight, Hash } from 'lucide-react';
+import type { Habit } from '../types';
+import { cn } from '../utils/cn';
+
+interface HabitLogModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    habit: Habit;
+    date: string;
+    existingEntry?: {
+        bundleOptionId?: string;
+        value?: number;
+    };
+    onSave: (payload: {
+        habitId: string;
+        date: string;
+        bundleOptionId: string;
+        bundleOptionLabel: string;
+        value?: number | null; // null for explicit 'no metric'
+        unitSnapshot?: string;
+    }) => Promise<void>;
+}
+
+export const HabitLogModal: React.FC<HabitLogModalProps> = ({ isOpen, onClose, habit, date, existingEntry, onSave }) => {
+    const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+    const [metricValue, setMetricValue] = useState<string>('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // Initialize state when modal opens
+    useEffect(() => {
+        if (isOpen) {
+            if (existingEntry?.bundleOptionId) {
+                setSelectedOptionId(existingEntry.bundleOptionId);
+                // If it had a value, pre-fill it
+                if (existingEntry.value !== undefined && existingEntry.value !== null) {
+                    setMetricValue(String(existingEntry.value));
+                } else {
+                    setMetricValue('');
+                }
+            } else {
+                setSelectedOptionId(null);
+                setMetricValue('');
+            }
+        }
+    }, [isOpen, existingEntry, habit]);
+
+    if (!isOpen) return null;
+
+    const options = habit.bundleOptions || [];
+    const selectedOption = options.find(o => o.id === selectedOptionId);
+    const isMetricRequired = selectedOption?.metricConfig?.mode === 'required';
+
+    const handleSave = async () => {
+        if (!selectedOptionId || !selectedOption) return;
+
+        setIsSubmitting(true);
+        try {
+            await onSave({
+                habitId: habit.id,
+                date: date,
+                bundleOptionId: selectedOption.id,
+                bundleOptionLabel: selectedOption.label,
+                value: isMetricRequired && metricValue ? Number(metricValue) : null,
+                unitSnapshot: isMetricRequired ? selectedOption.metricConfig?.unit : undefined
+            });
+            onClose();
+        } catch (error) {
+            console.error("Failed to log entry", error);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+            <div className="w-full max-w-sm bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl scale-100 animate-in zoom-in-95 duration-200">
+
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6">
+                    <div>
+                        <h3 className="text-lg font-bold text-white">{habit.name}</h3>
+                        <p className="text-xs text-neutral-400">{date}</p>
+                    </div>
+                    <button onClick={onClose} className="text-neutral-400 hover:text-white transition-colors">
+                        <X size={20} />
+                    </button>
+                </div>
+
+                {/* Option List */}
+                <div className="space-y-3 mb-6 max-h-[50vh] overflow-y-auto custom-scrollbar">
+                    {options.map(option => {
+                        const isSelected = selectedOptionId === option.id;
+                        const hasMetric = option.metricConfig?.mode === 'required';
+
+                        return (
+                            <button
+                                key={option.id}
+                                onClick={() => setSelectedOptionId(option.id)}
+                                className={cn(
+                                    "w-full flex items-center justify-between p-4 rounded-xl border transition-all duration-200",
+                                    isSelected
+                                        ? "bg-amber-500/10 border-amber-500/50 shadow-[0_0_15px_rgba(245,158,11,0.1)]"
+                                        : "bg-neutral-800/50 border-white/5 hover:bg-neutral-800 hover:border-white/10"
+                                )}
+                            >
+                                <div className="flex items-center gap-3">
+                                    <div className={cn(
+                                        "w-5 h-5 rounded-full border flex items-center justify-center transition-colors",
+                                        isSelected ? "border-amber-500 bg-amber-500" : "border-neutral-600"
+                                    )}>
+                                        {isSelected && <CheckCircle2 size={12} className="text-black" strokeWidth={3} />}
+                                    </div>
+                                    <span className={cn(
+                                        "text-sm font-medium",
+                                        isSelected ? "text-amber-400" : "text-neutral-300"
+                                    )}>
+                                        {option.label}
+                                    </span>
+                                </div>
+
+                                {hasMetric && (
+                                    <span className="text-xs text-neutral-500 flex items-center gap-1">
+                                        <Hash size={12} />
+                                        {option.metricConfig?.unit || 'value'}
+                                    </span>
+                                )}
+                            </button>
+                        );
+                    })}
+                </div>
+
+                {/* Metric Input (Conditional) */}
+                {selectedOption && isMetricRequired && (
+                    <div className="mb-6 animate-in slide-in-from-top-2 fade-in">
+                        <label className="block text-xs font-semibold text-neutral-500 uppercase tracking-wider mb-2">
+                            Enter Amount ({selectedOption.metricConfig?.unit || 'value'})
+                        </label>
+                        <input
+                            type="number"
+                            value={metricValue}
+                            onChange={(e) => setMetricValue(e.target.value)}
+                            // Auto-focus when appearing
+                            autoFocus
+                            className="w-full bg-neutral-800 border border-white/10 rounded-xl px-4 py-3 text-white text-lg font-bold focus:outline-none focus:border-amber-500 transition-colors"
+                            placeholder="0"
+                        />
+                    </div>
+                )}
+
+                {/* Footer Handlers */}
+                <button
+                    onClick={handleSave}
+                    disabled={!selectedOptionId || (isMetricRequired && !metricValue) || isSubmitting}
+                    className="w-full py-3 rounded-xl font-bold text-sm bg-amber-500 text-neutral-900 hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-[0_0_20px_rgba(245,158,11,0.2)] hover:shadow-[0_0_25px_rgba(245,158,11,0.4)]"
+                >
+                    {isSubmitting ? 'Saving...' : 'Log Entry'}
+                </button>
+
+            </div>
+        </div>
+    );
+};

--- a/src/server/utils/habitValidation.ts
+++ b/src/server/utils/habitValidation.ts
@@ -1,0 +1,50 @@
+import type { Habit, HabitEntry } from '../../models/persistenceTypes';
+
+export interface ValidationResult {
+    valid: boolean;
+    error?: string;
+}
+
+/**
+ * Validates a habit entry against the habit definition.
+ * Enforces Choice Habit V2 invariants:
+ * 1. Metric Requirement: If option requires metric, value must be present.
+ * 2. Metric Prohibition: If option has no metric, value must be undefined/null.
+ * 3. Option Existence: bundleOptionId must exist in habit.bundleOptions.
+ */
+export function validateHabitEntryPayload(habit: Habit, entryPayload: Partial<HabitEntry>): ValidationResult {
+    // 1. Check if it's a Choice Bundle
+    if (habit.bundleType === 'choice' && habit.bundleOptions) {
+
+        // If it's a choice bundle, bundleOptionId is required for the entry
+        // (Unless it's a legacy entry or some other edge case, but for new entries it's required)
+        if (!entryPayload.bundleOptionId) {
+            // Allow parent-level binary completions? PRD says "Entries are the source of truth".
+            // If manual log for parent, maybe? But PRD says "Parent completion is derived".
+            // So users should only log options.
+            return { valid: false, error: 'Choice habits require a selected option (bundleOptionId).' };
+        }
+
+        const option = habit.bundleOptions.find(opt => opt.id === entryPayload.bundleOptionId);
+        if (!option) {
+            return { valid: false, error: `Invalid option ID: ${entryPayload.bundleOptionId}` };
+        }
+
+        // Metric Logic
+        const metricMode = option.metricConfig?.mode || 'none';
+
+        if (metricMode === 'required') {
+            if (entryPayload.value === undefined || entryPayload.value === null) {
+                return { valid: false, error: `Value is required for option "${option.label}"` };
+            }
+        } else if (metricMode === 'none') {
+            if (entryPayload.value !== undefined && entryPayload.value !== null) {
+                // We could strictly fail, or just warn. PRD says "No ambiguous history".
+                // Let's fail to keep data clean.
+                return { valid: false, error: `Value should not be provided for non-metric option "${option.label}"` };
+            }
+        }
+    }
+
+    return { valid: true };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,20 +69,30 @@ export interface Habit {
 
     bundleType?: 'checklist' | 'choice';
     bundleOptions?: Array<{
-        key: string;
+        id: string;
         label: string;
         icon?: string;
+        metricConfig?: {
+            mode: 'none' | 'required';
+            unit?: string;
+            step?: number;
+        };
+        key?: string; // Legacy
     }>;
 
     // Day View Fields
     pinned?: boolean; // For "Today's Focus"
     timeEstimate?: number; // In minutes
+
+    // Virtual Fields (Frontend Only)
+    isVirtual?: boolean;
+    associatedOptionId?: string; // Links a virtual habit back to its source option
 }
 
 export interface DayLog {
     habitId: string;
     date: string; // YYYY-MM-DD
-    value: number; // 0 or 1 for boolean, actual value for number
+    value?: number; // 0 or 1 for boolean, actual value for number, null for choice parents
     completed: boolean;
     source?: 'manual' | 'routine';
     routineId?: string;
@@ -93,6 +103,9 @@ export interface DayLog {
 
     /** Optional: Choice Bundle Option ID */
     bundleOptionId?: string;
+
+    /** Map of Option interactions (OptionID -> Value) */
+    completedOptions?: Record<string, number>;
 }
 
 // Re-export Routine types


### PR DESCRIPTION

***

### 🚀 Branch: `153-improve-the-choice-habit-bundle-functionality`
**PR Title Suggestion:** `feat: Choice Habit Bundles V2 - Metrics & Expandable Grid`

---

## 📋 Feature Overview: Choice Habit Bundles V2
This branch implements a major upgrade to **"Choice Habits"** (habits where the user picks one option from a list, e.g., "Movement" $\to$ "Run" / "Swim" / "Yoga").

Previously, choices were simple selections. Now, they function as **expandable bundles** within the Tracker Grid, allowing for granular metric tracking per option.

## ✨ Key Features

**1. Metric Tracking for Options**
* Each option within a Choice Habit can now have its own specific configuration:
    * **Metric:** Input a value (e.g., "Run" tracks `km`, "Swim" tracks `laps`).
    * **Boolean:** Simple toggle (e.g., "Rest Day" tracks completion only).

**2. Expandable Grid View**
* Choice Habits now behave like Checklist Bundles in the `TrackerGrid`.
* Users can expand the parent habit to see all available options as individual rows.

**3. Direct Grid Interaction**
* **Metric Options:** Clicking an option (e.g., "Run") opens the `NumericInputPopover` to log specific values.
* **Simple Options:** Clicking an option (e.g., "Rest Day") instantly toggles it as complete.
* **Granular Status:** The Grid displays completion status for individual options, not just the parent aggregator.

---

## 🛠 Technical Implementation

### 1. Data Model & Types
* **`src/types/index.ts` & `persistenceTypes.ts`**:
    * **Habit Interface:** Updated `bundleOptions` to support `metricConfig` (props: `mode: 'required' | 'none'`, `unit`).
    * **Virtual Props:** Added `isVirtual` and `associatedOptionId` to support frontend "Virtual Habit" rendering.
    * **DayLog Interface:** Added `completedOptions` map (`Record<string, number>`) to track the status/value of each option within a parent's log.
* **`src/server/utils/habitValidation.ts`**: Created validation logic to enforce data integrity (e.g., ensuring an entry provides a value if the specific option requires metrics).

### 2. Frontend Architecture
* **Virtual Habits (`src/utils/habitUtils.ts`)**:
    * Updated `flattenHabitList` to generate **"Virtual Habit"** objects for Choice Options. This allows them to be rendered as standard rows in the generic `TrackerGrid` without duplicating rendering logic.
* **Tracker Grid (`src/components/TrackerGrid.tsx`)**:
    * **`SortableHabitRow`**: Updated to render virtual children rows when the parent is expanded.
    * **`HabitRowContent`**: Refactored to apply specific styling to virtual habits (italic text, transparent background, removed indentation).
    * **`handleCellClick`**: Intercepts interactions on virtual rows:
        * *Toggle:* Calls `upsertHabitEntry` with a boolean.
        * *Popover:* Opens `NumericInputPopover` passing the specific `bundleOptionId`.

### 3. Backend Logic
* **Recompute Utils (`src/server/utils/recomputeUtils.ts`)**: Updated `recomputeDayLogForHabit` to aggregate `HabitEntry` data into the new `completedOptions` map on the `DayLog`.
* **Routes (`src/server/routes/habitEntries.ts`)**: Added validation middleware. It rejects payloads that do not match the parent habit's configuration (e.g., trying to log a boolean for an option that requires a numeric value).

### 4. Components
* **`AddHabitModal.tsx`**: Updated UI to allow users to add/remove options, toggle "Track Metrics," and define Units per option.
* **`HabitLogModal.tsx`**: Created a new dedicated modal for detailed logging (supports backup flows/mobile view).
* **`HabitHistoryModal.tsx`**: Updated to indicate exactly which option was selected in the history log.

---

## 🎨 UX Improvements
* **Visual Hierarchy:** Choice Options are visually distinct (italicized) but aligned with the parent to keep the grid clean.
* **Seamless Entry:** Users can log metrics (like '5 km') directly from the grid without leaving the context of the day view.
* **Expansion Indicators:** Parent rows clearly show they can be expanded/collapsed.

---