### PR TITLE
feat: allow moving a habit to a different category without losing progress

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { HabitProvider, useHabitStore } from './store/HabitContext';
 import { RoutineProvider } from './store/RoutineContext';
 import { TaskProvider } from './context/TaskContext';
+import { ToastProvider } from './components/Toast';
 import { Layout } from './components/Layout';
 import { CategoryTabs } from './components/CategoryTabs';
 import { TrackerGrid } from './components/TrackerGrid';
@@ -506,15 +507,17 @@ const HabitTrackerContent: React.FC = () => {
 
 function App() {
   return (
-    <HabitProvider>
-      <RoutineProvider>
-        <TaskProvider>
-          <Layout>
-            <HabitTrackerContent />
-          </Layout>
-        </TaskProvider>
-      </RoutineProvider>
-    </HabitProvider>
+    <ToastProvider>
+      <HabitProvider>
+        <RoutineProvider>
+          <TaskProvider>
+            <Layout>
+              <HabitTrackerContent />
+            </Layout>
+          </TaskProvider>
+        </RoutineProvider>
+      </HabitProvider>
+    </ToastProvider>
   );
 }
 

--- a/src/components/CategoryPickerModal.tsx
+++ b/src/components/CategoryPickerModal.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+import { X, FolderInput, Search, Check } from 'lucide-react';
+import { cn } from '../utils/cn';
+import { useHabitStore } from '../store/HabitContext';
+import { useToast } from './Toast';
+
+interface CategoryPickerModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    habitId: string;
+    currentCategoryId: string;
+}
+
+export const CategoryPickerModal = ({
+    isOpen,
+    onClose,
+    habitId,
+    currentCategoryId,
+}: CategoryPickerModalProps) => {
+    const { categories, habits, moveHabitToCategory } = useHabitStore();
+    const { showToast } = useToast();
+    const [search, setSearch] = useState('');
+    const [isMoving, setIsMoving] = useState(false);
+
+    if (!isOpen) return null;
+
+    const habit = habits.find(h => h.id === habitId);
+    if (!habit) return null;
+
+    const currentCategory = categories.find(c => c.id === currentCategoryId);
+    const filtered = categories.filter(c =>
+        c.name.toLowerCase().includes(search.toLowerCase())
+    );
+
+    const handleSelect = async (targetCategoryId: string) => {
+        if (targetCategoryId === currentCategoryId || isMoving) return;
+
+        setIsMoving(true);
+        const targetCategory = categories.find(c => c.id === targetCategoryId);
+
+        try {
+            await moveHabitToCategory(habitId, targetCategoryId);
+            showToast(
+                `Moved "${habit.name}" to ${targetCategory?.name ?? 'category'}`,
+                'success'
+            );
+            onClose();
+        } catch {
+            showToast('Failed to move habit. Please try again.', 'error');
+        } finally {
+            setIsMoving(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
+            <div
+                className={cn(
+                    "bg-neutral-900 border border-white/10 rounded-t-2xl sm:rounded-2xl w-full sm:max-w-sm shadow-2xl",
+                    "animate-in slide-in-from-bottom-4 fade-in duration-200",
+                    "max-h-[80vh] flex flex-col"
+                )}
+                onClick={e => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between p-4 border-b border-white/5">
+                    <div className="flex items-center gap-2">
+                        <FolderInput size={18} className="text-emerald-400" />
+                        <h3 className="text-base font-semibold text-white">Move to Category</h3>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="p-1.5 rounded-lg hover:bg-white/10 text-neutral-400 hover:text-white transition-colors"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {/* Current location */}
+                <div className="px-4 pt-3 pb-2">
+                    <p className="text-xs text-neutral-500">
+                        Moving <span className="text-neutral-300 font-medium">{habit.name}</span>
+                        {currentCategory && (
+                            <> from <span className="text-neutral-300 font-medium">{currentCategory.name}</span></>
+                        )}
+                    </p>
+                </div>
+
+                {/* Search (only show when >=6 categories) */}
+                {categories.length >= 6 && (
+                    <div className="px-4 pb-2">
+                        <div className="relative">
+                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500" />
+                            <input
+                                type="text"
+                                placeholder="Search categories..."
+                                value={search}
+                                onChange={e => setSearch(e.target.value)}
+                                className="w-full pl-9 pr-3 py-2 bg-neutral-800 border border-white/5 rounded-lg text-sm text-white placeholder-neutral-500 focus:outline-none focus:border-emerald-500/50"
+                                autoFocus
+                            />
+                        </div>
+                    </div>
+                )}
+
+                {/* Category list */}
+                <div className="flex-1 overflow-y-auto px-2 pb-4">
+                    {filtered.length === 0 ? (
+                        <p className="text-center text-sm text-neutral-500 py-6">No categories found</p>
+                    ) : (
+                        <div className="flex flex-col gap-0.5">
+                            {filtered.map(category => {
+                                const isCurrent = category.id === currentCategoryId;
+                                const isTailwindClass = category.color.startsWith('bg-');
+                                const dotColor = isTailwindClass
+                                    ? category.color
+                                    : undefined;
+                                const dotStyle = !isTailwindClass
+                                    ? { backgroundColor: category.color }
+                                    : undefined;
+
+                                return (
+                                    <button
+                                        key={category.id}
+                                        onClick={() => handleSelect(category.id)}
+                                        disabled={isCurrent || isMoving}
+                                        className={cn(
+                                            "flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left transition-colors",
+                                            isCurrent
+                                                ? "bg-white/5 text-neutral-500 cursor-default"
+                                                : "hover:bg-white/5 text-neutral-200 active:bg-white/10"
+                                        )}
+                                    >
+                                        <div
+                                            className={cn("w-3 h-3 rounded-full flex-shrink-0", dotColor)}
+                                            style={dotStyle}
+                                        />
+                                        <span className="text-sm font-medium flex-1 truncate">
+                                            {category.name}
+                                        </span>
+                                        {isCurrent && (
+                                            <span className="flex items-center gap-1 text-xs text-neutral-500">
+                                                <Check size={12} /> Current
+                                            </span>
+                                        )}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,78 @@
+import { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
+import { cn } from '../utils/cn';
+import { CheckCircle2, XCircle, Info, X } from 'lucide-react';
+
+type ToastType = 'success' | 'error' | 'info';
+
+interface Toast {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+interface ToastContextType {
+    showToast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const useToast = () => {
+    const ctx = useContext(ToastContext);
+    if (!ctx) throw new Error('useToast must be used within ToastProvider');
+    return ctx;
+};
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [toasts, setToasts] = useState<Toast[]>([]);
+    const idCounter = useRef(0);
+
+    const showToast = useCallback((message: string, type: ToastType = 'info') => {
+        const id = `toast-${++idCounter.current}`;
+        setToasts(prev => [...prev, { id, message, type }]);
+    }, []);
+
+    const dismiss = useCallback((id: string) => {
+        setToasts(prev => prev.filter(t => t.id !== id));
+    }, []);
+
+    return (
+        <ToastContext.Provider value={{ showToast }}>
+            {children}
+            <div className="fixed bottom-6 right-6 z-[9999] flex flex-col gap-2 pointer-events-none">
+                {toasts.map(toast => (
+                    <ToastItem key={toast.id} toast={toast} onDismiss={dismiss} />
+                ))}
+            </div>
+        </ToastContext.Provider>
+    );
+};
+
+const ToastItem = ({ toast, onDismiss }: { toast: Toast; onDismiss: (id: string) => void }) => {
+    useEffect(() => {
+        const timer = setTimeout(() => onDismiss(toast.id), 3500);
+        return () => clearTimeout(timer);
+    }, [toast.id, onDismiss]);
+
+    const Icon = toast.type === 'success' ? CheckCircle2 : toast.type === 'error' ? XCircle : Info;
+
+    return (
+        <div
+            className={cn(
+                "pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-xl border shadow-lg backdrop-blur-sm",
+                "animate-in slide-in-from-right-5 fade-in duration-300 min-w-[260px] max-w-[380px]",
+                toast.type === 'success' && "bg-emerald-500/10 border-emerald-500/20 text-emerald-300",
+                toast.type === 'error' && "bg-red-500/10 border-red-500/20 text-red-300",
+                toast.type === 'info' && "bg-neutral-800 border-white/10 text-neutral-200",
+            )}
+        >
+            <Icon size={18} className="flex-shrink-0" />
+            <span className="text-sm font-medium flex-1">{toast.message}</span>
+            <button
+                onClick={() => onDismiss(toast.id)}
+                className="flex-shrink-0 p-0.5 rounded hover:bg-white/10 transition-colors"
+            >
+                <X size={14} />
+            </button>
+        </div>
+    );
+};

--- a/src/components/day-view/DayCategorySection.tsx
+++ b/src/components/day-view/DayCategorySection.tsx
@@ -18,21 +18,14 @@ interface DayViewHabitStatus {
 
 interface DayCategorySectionProps {
     category: Category;
-    habits: Habit[]; // Just the habits (roots) for this category
-    habitStatusMap: Map<string, DayViewHabitStatus>; // Status from truthQuery dayView
+    habits: Habit[];
+    habitStatusMap: Map<string, DayViewHabitStatus>;
     dateStr: string;
     onToggle: (habitId: string) => void;
     onPin: (habitId: string) => void;
     onUpdateEstimate: (habitId: string, minutes: number) => void;
-
-    // Pass entire habits list to resolve subHabits if needed?
-    // Or simpler: We expect `habits` to be the *root* habits to display.
-    // If a habit is a bundle, we need to be able to find its children.
-    // Let's assume the parent `DayView` passes a lookup or we use context?
-    // Passing allHabits is safest for bundle resolution.
+    onMoveToCategory?: (habit: Habit) => void;
     allHabitsLookup: Map<string, Habit>;
-
-    // Choice bundle selection
     onUpdateHabitEntry: (habitId: string, dateKey: string, data: any) => Promise<void>;
     deleteHabitEntryByKey: (habitId: string, dateKey: string) => Promise<void>;
 }
@@ -45,6 +38,7 @@ export const DayCategorySection = ({
     onToggle,
     onPin,
     onUpdateEstimate,
+    onMoveToCategory,
     allHabitsLookup,
     onUpdateHabitEntry,
     deleteHabitEntryByKey
@@ -148,17 +142,18 @@ export const DayCategorySection = ({
                         // For now, we'll need to fetch entries separately or include in dayView response
                         const selectedChoice = undefined; // TODO: Get from EntryView if needed
 
-                        return (
+                            return (
                             <HabitGridCell
                                 key={habit.id}
                                 habit={habit}
-                                log={undefined} // No longer using DayLog
+                                log={undefined}
                                 isCompleted={isCompleted}
                                 isExpanded={expandedHabitId === habit.id}
                                 onToggle={() => onToggle(habit.id)}
                                 onExpand={() => setExpandedHabitId(prev => prev === habit.id ? null : habit.id)}
                                 onPin={onPin}
                                 onUpdateEstimate={onUpdateEstimate}
+                                onMoveToCategory={onMoveToCategory}
                                 subHabits={subHabits}
 
                                 // Helper for choice select

--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -3,6 +3,7 @@ import { useHabitStore } from '../../store/HabitContext';
 import { getHabitsForDate } from '../../utils/habitUtils';
 import { PinnedHabitsStrip } from './PinnedHabitsStrip';
 import { DayCategorySection } from './DayCategorySection';
+import { CategoryPickerModal } from '../CategoryPickerModal';
 import { format } from 'date-fns';
 import { Calendar } from 'lucide-react';
 import { fetchDayView, getLocalTimeZone } from '../../lib/persistenceClient';
@@ -44,6 +45,7 @@ export const DayView = () => {
     const [dayViewData, setDayViewData] = useState<DayViewData | null>(null);
     const [dayViewLoading, setDayViewLoading] = useState(true);
     const [dayViewError, setDayViewError] = useState<string | null>(null);
+    const [categoryPickerHabit, setCategoryPickerHabit] = useState<Habit | null>(null);
 
     // Fetch day view from truthQuery endpoint
     useEffect(() => {
@@ -188,6 +190,7 @@ export const DayView = () => {
                                 onToggle={handleToggle}
                                 onPin={handlePin}
                                 onUpdateEstimate={handleUpdateEstimate}
+                                onMoveToCategory={(h) => setCategoryPickerHabit(h)}
                                 allHabitsLookup={allHabitsLookup}
                                 onUpdateHabitEntry={upsertHabitEntry}
                                 deleteHabitEntryByKey={deleteHabitEntryByKey}
@@ -199,6 +202,14 @@ export const DayView = () => {
 
             {/* Footer / Empty Space for scrolling */}
             <div className="h-12" />
+
+            {/* Category Picker Modal */}
+            <CategoryPickerModal
+                isOpen={!!categoryPickerHabit}
+                onClose={() => setCategoryPickerHabit(null)}
+                habitId={categoryPickerHabit?.id ?? ''}
+                currentCategoryId={categoryPickerHabit?.categoryId ?? ''}
+            />
         </div>
     );
 };

--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, Target, Clock, Pin, PinOff, ListTodo, Disc } from 'lucide-react';
+import { Check, Target, Clock, Pin, PinOff, ListTodo, Disc, FolderInput } from 'lucide-react';
 import type { Habit, DayLog } from '../../types';
 import { cn } from '../../utils/cn';
 
@@ -12,6 +12,7 @@ interface HabitGridCellProps {
     onExpand: () => void;
     onPin: (id: string) => void;
     onUpdateEstimate: (id: string, minutes: number) => void;
+    onMoveToCategory?: (habit: Habit) => void;
 
     // Bundle Props
     subHabits?: Habit[];
@@ -29,6 +30,7 @@ export const HabitGridCell = ({
     onExpand,
     onPin,
     onUpdateEstimate,
+    onMoveToCategory,
     subHabits,
     onChoiceSelect,
     selectedChoice
@@ -177,8 +179,17 @@ export const HabitGridCell = ({
                         </div>
                     )}
 
-                    {/* 4. Actions (Pin) */}
-                    <div className="flex items-center justify-end mt-1 pt-2 border-t border-white/5">
+                    {/* 4. Actions (Pin, Move) */}
+                    <div className="flex items-center justify-end gap-1 mt-1 pt-2 border-t border-white/5">
+                        {onMoveToCategory && (
+                            <button
+                                onClick={() => onMoveToCategory(habit)}
+                                className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                            >
+                                <FolderInput size={12} />
+                                <span>Move</span>
+                            </button>
+                        )}
                         <button
                             onClick={() => onPin(habit.id)}
                             className={cn(

--- a/src/server/routes/__tests__/habits.moveCategory.test.ts
+++ b/src/server/routes/__tests__/habits.moveCategory.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Habit Move-to-Category Tests
+ *
+ * Validates that PATCH /api/habits/:id with { categoryId } correctly
+ * reassigns a habit's category while preserving all other data.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+if (!process.env.MONGODB_URI) {
+  process.env.MONGODB_URI = 'mongodb://localhost:27017';
+}
+process.env.USE_MONGO_PERSISTENCE = 'true';
+
+import {
+  getHabits,
+  createHabitRoute,
+  updateHabitRoute,
+} from '../habits';
+import {
+  createCategoryRoute,
+  getCategories,
+} from '../categories';
+import { getDb, closeConnection } from '../../lib/mongoClient';
+
+const TEST_DB_NAME = 'habitflowai_test_move';
+const TEST_USER_ID = 'test-move-user';
+
+let originalDbName: string | undefined;
+
+describe('Habit Move-to-Category', () => {
+  let app: Express;
+  let categoryA: any;
+  let categoryB: any;
+  let habit: any;
+
+  beforeAll(async () => {
+    originalDbName = process.env.MONGODB_DB_NAME;
+    process.env.MONGODB_DB_NAME = TEST_DB_NAME;
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).userId = TEST_USER_ID;
+      next();
+    });
+
+    app.get('/api/habits', getHabits);
+    app.post('/api/habits', createHabitRoute);
+    app.patch('/api/habits/:id', updateHabitRoute);
+    app.get('/api/categories', getCategories);
+    app.post('/api/categories', createCategoryRoute);
+  });
+
+  afterAll(async () => {
+    const testDb = await getDb();
+    await testDb.dropDatabase();
+    await closeConnection();
+    if (originalDbName) {
+      process.env.MONGODB_DB_NAME = originalDbName;
+    } else {
+      delete process.env.MONGODB_DB_NAME;
+    }
+  });
+
+  beforeEach(async () => {
+    const testDb = await getDb();
+    await testDb.collection('habits').deleteMany({});
+    await testDb.collection('categories').deleteMany({});
+
+    // Seed two categories
+    const resA = await request(app)
+      .post('/api/categories')
+      .send({ name: 'Fitness', color: 'bg-red-500' });
+    categoryA = resA.body.category;
+
+    const resB = await request(app)
+      .post('/api/categories')
+      .send({ name: 'Mental Health', color: 'bg-blue-500' });
+    categoryB = resB.body.category;
+
+    // Seed a habit in Category A
+    const resH = await request(app)
+      .post('/api/habits')
+      .send({
+        name: 'Meditate',
+        categoryId: categoryA.id,
+        goal: { type: 'boolean', frequency: 'daily' },
+      });
+    habit = resH.body.habit;
+  });
+
+  it('200: moves habit to a valid category', async () => {
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}`)
+      .send({ categoryId: categoryB.id });
+
+    expect(res.status).toBe(200);
+    expect(res.body.habit.categoryId).toBe(categoryB.id);
+    expect(res.body.habit.name).toBe('Meditate');
+  });
+
+  it('preserves all other habit fields after move', async () => {
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}`)
+      .send({ categoryId: categoryB.id });
+
+    const moved = res.body.habit;
+    expect(moved.id).toBe(habit.id);
+    expect(moved.name).toBe(habit.name);
+    expect(moved.goal).toEqual(habit.goal);
+    expect(moved.createdAt).toBe(habit.createdAt);
+    expect(moved.archived).toBe(false);
+  });
+
+  it('404: habit not found', async () => {
+    const res = await request(app)
+      .patch('/api/habits/nonexistent-id')
+      .send({ categoryId: categoryB.id });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('400: target category does not exist', async () => {
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}`)
+      .send({ categoryId: 'nonexistent-category-id' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_CATEGORY');
+  });
+
+  it('does not appear in old category after move', async () => {
+    await request(app)
+      .patch(`/api/habits/${habit.id}`)
+      .send({ categoryId: categoryB.id });
+
+    const res = await request(app)
+      .get('/api/habits')
+      .query({ categoryId: categoryA.id });
+
+    const habitsInA = res.body.habits;
+    expect(habitsInA.find((h: any) => h.id === habit.id)).toBeUndefined();
+  });
+
+  it('appears in new category after move', async () => {
+    await request(app)
+      .patch(`/api/habits/${habit.id}`)
+      .send({ categoryId: categoryB.id });
+
+    const res = await request(app)
+      .get('/api/habits')
+      .query({ categoryId: categoryB.id });
+
+    const habitsInB = res.body.habits;
+    expect(habitsInB.find((h: any) => h.id === habit.id)).toBeDefined();
+  });
+});


### PR DESCRIPTION
Add end-to-end support for reassigning a habit's category via a small overflow/settings entry point on each habit row — no modal enlargement required. HabitEntries (the sole behavioral truth) are never modified; only the Habit's categoryId is updated, preserving all history, streaks, and derived metrics.

Backend:
- Add category existence validation to PATCH /api/habits/:id when categoryId is in the payload. Returns 400 INVALID_CATEGORY for non-existent targets.
- Import getCategoryById into habit routes for server-side validation.
- Add comprehensive test suite (habits.moveCategory.test.ts) covering 200 valid move, 404 habit not found, 400 invalid category, and post-move category membership assertions.

Frontend — State:
- Add moveHabitToCategory(habitId, targetCategoryId) to HabitContext with optimistic update and rollback on failure. Computes order (bottom of destination category) so habit appends deterministically.
- For bundles, only the selected habit moves; sub-habits retain their own categoryId (documented in code comment).

Frontend — UI:
- New CategoryPickerModal component: responsive bottom-sheet on mobile, centered dialog on desktop. Shows category list with color dots, current-category badge, optional search filter (≥6 categories), and loading/disabled states during move.
- New Toast notification system (ToastProvider + useToast hook): success/error/info types with auto-dismiss (3.5s), slide-in animation, and manual dismiss. Wrapped at app root in App.tsx.
- TrackerGrid: "Move to Category…" added to right-click context menu and hover action buttons (FolderInput icon) on each habit row.
- DayView: "Move" button added to expanded HabitGridCell actions, threaded through DayCategorySection.

Edge cases:
- Same-category move is a no-op (silently ignored).
- Ordering: habit placed at bottom of target category (max order + 1).
- Bundle parent move does not cascade to sub-habits.
- Optimistic state rolls back with error toast on API failure.

Made-with: Cursor