### PR TITLE
fix(auth): SameSite=None cookie + remove Vercel rewrite

### DIFF
--- a/src/server/lib/sessionCookie.ts
+++ b/src/server/lib/sessionCookie.ts
@@ -12,7 +12,7 @@ export function getSessionCookieOptions(): { httpOnly: boolean; secure: boolean;
   return {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
     maxAge: SESSION_MAX_AGE_MS,
     path: '/',
   };
@@ -23,5 +23,5 @@ export function setSessionCookie(res: Response, token: string): void {
 }
 
 export function clearSessionCookie(res: Response): void {
-  res.clearCookie(SESSION_COOKIE_NAME, { path: '/', httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax' });
+  res.clearCookie(SESSION_COOKIE_NAME, { path: '/', httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax' });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [
-    {
-      "source": "/api/:path*",
-      "destination": "https://YOUR_BACKEND_ORIGIN/api/:path*"
-    }
-  ]
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }


### PR DESCRIPTION
Required for browser login to work from Vercel to Render (cross-origin).

## Changes
- Session cookie SameSite=None in production (required for cross-origin credentials: include)
- Remove broken Vercel rewrite from vercel.json

## After merging
Trigger a Render redeploy so the new cookie settings take effect.