### PR TITLE
fix(server): add JSON error handler for diagnosable 500s

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -196,5 +196,12 @@ export function createApp(): Express {
     });
   }
 
+  // Error handler: return JSON with error message so crashes are diagnosable
+  app.use((err: unknown, _req: Request, res: Response, _next: import('express').NextFunction) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[Express error handler]', message, err instanceof Error ? err.stack : '');
+    res.status(500).json({ error: message });
+  });
+
   return app;
 }


### PR DESCRIPTION
Express was returning HTML 500 pages with no error detail. This adds a JSON error handler so crashes return the actual error message.