### PR TITLE
fix(auth): allow bootstrap to specify userId

### DIFF
--- a/src/server/repositories/userRepository.ts
+++ b/src/server/repositories/userRepository.ts
@@ -38,9 +38,10 @@ export async function createUser(params: {
   displayName: string;
   passwordHash: string;
   role: 'admin' | 'member';
+  userId?: string;
 }): Promise<AuthUser> {
   const db = await getDb();
-  const userId = randomUUID();
+  const userId = params.userId ?? randomUUID();
   const now = new Date().toISOString();
   const doc = {
     _id: userId,

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -271,6 +271,7 @@ export async function postBootstrapAdmin(req: Request, res: Response): Promise<v
     displayName: body.displayName != null ? String(body.displayName).trim() || normalizedEmail : normalizedEmail,
     passwordHash,
     role: 'admin',
+    ...(body.userId ? { userId: String(body.userId).trim() } : {}),
   });
 
   res.status(201).json({


### PR DESCRIPTION
Allows passing userId in bootstrap body so existing MongoDB data (habits, categories, etc.) is preserved when creating the admin account.