### PR TITLE
fix: instant habit toggle and header safe-area on iPhone

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -75,7 +75,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     return (
         <div className="min-h-screen bg-neutral-900 text-white font-sans selection:bg-emerald-500/30">
             {/* Header */}
-            <header className="fixed top-0 left-0 right-0 h-16 bg-neutral-900/80 backdrop-blur-md border-b border-white/5 flex items-center justify-between px-6 z-50">
+            <header className="fixed top-0 left-0 right-0 pt-[env(safe-area-inset-top,0px)] h-[calc(4rem+env(safe-area-inset-top,0px))] bg-neutral-900/80 backdrop-blur-md border-b border-white/5 flex items-center justify-between px-6 z-50">
                 <div className="flex items-center gap-3">
                     <div className="w-8 h-8 bg-gradient-to-br from-emerald-400 to-cyan-500 rounded-lg flex items-center justify-center shadow-lg shadow-emerald-500/20">
                         <LayoutGrid size={18} className="text-white" />

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -779,6 +779,7 @@ export const TrackerGrid = ({
     const {
         deleteHabit,
         reorderHabits,
+        toggleHabit,
         upsertHabitEntry,
         deleteHabitEntryByKey
     } = useHabitStore();
@@ -1002,18 +1003,12 @@ export const TrackerGrid = ({
         }
     };
 
-    // Toggle Handler
+    // Toggle Handler — uses optimistic toggleHabit for instant UI feedback
     const handleToggle = async (habitId: string, date: string) => {
-        const log = logs[`${habitId}-${date}`];
-        const isCompleted = log?.completed || false;
         const habit = habits.find(h => h.id === habitId);
         if (!habit) return;
 
-        if (isCompleted) {
-            await deleteHabitEntryByKey(habitId, date);
-        } else {
-            await upsertHabitEntry(habitId, date, { value: 1 });
-        }
+        await toggleHabit(habitId, date);
         refreshProgress();
     };
 


### PR DESCRIPTION
## Summary
- **Fix ~10s habit toggle delay**: `handleToggle` was calling `upsertHabitEntry`/`deleteHabitEntryByKey` which wait for the full API round-trip before updating the UI. Now uses `toggleHabit` which has optimistic updates (instant UI, background server sync).
- **Fix header overlapping iPhone status bar**: Added `pt-[env(safe-area-inset-top)]` and matching height calc to the fixed header so it pushes below the notch/status bar.

## Test plan
- [ ] Tap a habit cell on iPhone — should toggle instantly
- [ ] Header should not overlap wifi/battery indicators on notched iPhones
- [ ] Desktop experience unchanged

Generated with [Claude Code](https://claude.com/claude-code)