### PR TITLE
Goal redesign + fix inflated habit counts on dashboard

### DIFF
--- a/src/components/ProgressRings.tsx
+++ b/src/components/ProgressRings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
 import { useHabitStore } from '../store/HabitContext';
 import { format, subDays } from 'date-fns';
@@ -50,14 +50,22 @@ export const ProgressRings: React.FC = React.memo(() => {
     const { habits, logs, wellbeingLogs } = useHabitStore();
     const today = format(new Date(), 'yyyy-MM-dd');
 
-    // Calculate Habit Completion
-    const activeHabits = habits.filter(h => !h.archived);
-    const completedCount = activeHabits.filter(h => {
+    // Calculate Habit Completion (exclude bundle sub-habits)
+    const rootHabits = useMemo(() => {
+        const childIds = new Set<string>();
+        habits.forEach(h => {
+            if (h.type === 'bundle' && h.subHabitIds) {
+                h.subHabitIds.forEach((id: string) => childIds.add(id));
+            }
+        });
+        return habits.filter(h => !h.archived && !childIds.has(h.id));
+    }, [habits]);
+    const completedCount = rootHabits.filter(h => {
         const log = logs[`${h.id}-${today}`];
         return log?.completed;
     }).length;
-    const completionRate = activeHabits.length > 0
-        ? Math.round((completedCount / activeHabits.length) * 100)
+    const completionRate = rootHabits.length > 0
+        ? Math.round((completedCount / rootHabits.length) * 100)
         : 0;
 
     const habitData = [

--- a/src/components/RecentHeatmapGrid.tsx
+++ b/src/components/RecentHeatmapGrid.tsx
@@ -28,12 +28,20 @@ export const RecentHeatmapGrid: React.FC<RecentHeatmapGridProps> = React.memo(({
 
         const dateInterval = eachDayOfInterval({ start: startDate, end: today });
 
+        // Exclude bundle sub-habits from counting
+        const childIds = new Set<string>();
+        habits.forEach(h => {
+            if (h.type === 'bundle' && h.subHabitIds) {
+                h.subHabitIds.forEach((id: string) => childIds.add(id));
+            }
+        });
+
         // Calculate max daily count for normalization
         let maxDailyCount = 0;
 
         const processedDays = dateInterval.map(date => {
             const dateStr = format(date, 'yyyy-MM-dd');
-            const activeHabits = habits.filter(h => new Date(h.createdAt) <= date && !h.archived);
+            const activeHabits = habits.filter(h => new Date(h.createdAt) <= date && !h.archived && !childIds.has(h.id));
 
             let completionCount = 0;
             const categoryIds = new Set<string>();

--- a/src/components/YearHeatmapGrid.tsx
+++ b/src/components/YearHeatmapGrid.tsx
@@ -19,11 +19,19 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
 
         const days = eachDayOfInterval({ start: startDate, end: endDate });
 
+        // Exclude bundle sub-habits from counting
+        const childIds = new Set<string>();
+        habits.forEach(h => {
+            if (h.type === 'bundle' && h.subHabitIds) {
+                h.subHabitIds.forEach((id: string) => childIds.add(id));
+            }
+        });
+
         // First pass: Calculate activity counts and find max
         let maxCount = 0;
         const processedDays = days.map(date => {
             const dateStr = format(date, 'yyyy-MM-dd');
-            const activeHabits = habits.filter(h => new Date(h.createdAt) <= date && !h.archived);
+            const activeHabits = habits.filter(h => new Date(h.createdAt) <= date && !h.archived && !childIds.has(h.id));
 
             let completionCount = 0;
             const categoryIds = new Set<string>();


### PR DESCRIPTION
## Summary
- **Fix inflated habit counts**: Bundle sub-habits were counted as individual habits across dashboard components (DailyOverviewCard, ProgressRings, YearHeatmapGrid, RecentHeatmapGrid), showing 187 instead of ~31. Now all components use rootHabits filtering to exclude bundle children.
- **Goal system improvements**: Opt-in auto-iteration, post-completion decision chooser, boolean habit counting in cumulative goals, parallelized entry fetching
- **Performance**: Replace 100ms polling with event-based cache invalidation for goal data
- **Fixes**: Timezone validator accepts all valid IANA timezones, correct routing for goals/routines views

## Test plan
- [ ] Verify dashboard overview ring shows correct habit count (not inflated by bundle sub-habits)
- [ ] Verify ProgressRings completion % is based on root habits only
- [ ] Verify heatmaps reflect accurate completion counts
- [ ] Verify goal progress tracking works with boolean habits
- [ ] Verify post-completion decision chooser appears after goal completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)