### PR TITLE
Prevent duplicate habits/categories via atomic upsert

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -17,7 +17,7 @@ import { getRoutinesRoute, getRoutineRoute, createRoutineRoute, updateRoutineRou
 import { getRoutineLogs } from './routes/routineLogs';
 import { getGoals, getGoal, getGoalProgress, getGoalsWithProgress, getCompletedGoals, createGoalRoute, updateGoalRoute, deleteGoalRoute, reorderGoalsRoute, getGoalDetailRoute, uploadGoalBadgeRoute, uploadBadgeMiddleware } from './routes/goals';
 import { getProgressOverview } from './routes/progress';
-import { getIntegrityReport } from './routes/admin';
+import { getIntegrityReport, dedupHabits } from './routes/admin';
 import { getEntriesRoute, createEntryRoute, upsertEntryByKeyRoute, getEntryRoute, updateEntryRoute, deleteEntryRoute } from './routes/journal';
 import { getTasksRoute, createTaskRoute, updateTaskRoute, deleteTaskRoute } from './routes/tasks';
 import { getDashboardPrefsRoute, updateDashboardPrefsRoute } from './routes/dashboardPrefs';
@@ -174,6 +174,7 @@ export function createApp(): Express {
   app.get('/api/dayView', getDayView);
   app.use('/api/evidence', habitPotentialEvidenceRoutes);
   app.get('/api/admin/integrity-report', getIntegrityReport);
+  app.post('/api/admin/dedup-habits', requireAdmin, dedupHabits);
   app.post('/api/admin/invites', adminInviteRateLimiter, requireAdmin, postCreateInvite);
   app.get('/api/admin/invites', adminInviteRateLimiter, requireAdmin, getInvites);
   app.post('/api/admin/invites/:id/revoke', adminInviteRateLimiter, requireAdmin, postRevokeInvite);

--- a/src/server/lib/mongoClient.ts
+++ b/src/server/lib/mongoClient.ts
@@ -84,6 +84,42 @@ async function ensureHabitEntriesUniqueIndex(database: Db): Promise<void> {
   }
 }
 
+async function ensureHabitAndCategoryIndexes(database: Db): Promise<void> {
+  const createIndexSafe = async (
+    collectionName: string,
+    keys: Record<string, 1 | -1>,
+    options?: CreateIndexesOptions
+  ) => {
+    try {
+      await database.collection(collectionName).createIndex(keys, options);
+    } catch (error) {
+      const code = (error as { code?: number })?.code;
+      // 85 = index with same name exists with different options
+      // 86 = index with same key spec exists with different name
+      if (code === 85 || code === 86) return;
+      // 11000 = duplicate key error — duplicates exist, need to run dedup first
+      if (code === 11000) {
+        console.warn(`[MongoDB] Cannot create unique index on ${collectionName}: duplicates exist. Run POST /api/admin/dedup-habits?commit=true first.`);
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[MongoDB] Failed to ensure index on ${collectionName}: ${message}`);
+    }
+  };
+
+  // Prevent duplicate habits: same user can't have two habits with same name in same category
+  await createIndexSafe('habits',
+    { householdId: 1, userId: 1, name: 1, categoryId: 1 },
+    { unique: true, name: 'idx_habits_user_name_category_unique' }
+  );
+
+  // Prevent duplicate categories: same user can't have two categories with same name
+  await createIndexSafe('categories',
+    { householdId: 1, userId: 1, name: 1 },
+    { unique: true, name: 'idx_categories_user_name_unique' }
+  );
+}
+
 async function ensureCoreIndexes(database: Db): Promise<void> {
   if (indexesEnsuredForDbName === database.databaseName) {
     return;
@@ -106,10 +142,11 @@ async function ensureCoreIndexes(database: Db): Promise<void> {
   await createIndexSafe('habitEntries', { userId: 1, habitId: 1, timestamp: -1 }, { name: 'idx_habitEntries_user_habit_timestamp' });
 
   await ensureHabitEntriesUniqueIndex(database);
+  await ensureHabitAndCategoryIndexes(database);
   await ensureAuthIndexes(database);
 
   if (!isTestEnv()) {
-    console.log('[MongoDB] Indexes ensured (habitEntries unique: householdId, userId, habitId, dayKey)');
+    console.log('[MongoDB] Indexes ensured (habitEntries, habits, categories, auth)');
   }
   indexesEnsuredForDbName = database.databaseName;
 }

--- a/src/server/repositories/categoryRepository.ts
+++ b/src/server/repositories/categoryRepository.ts
@@ -24,26 +24,28 @@ export async function createCategory(
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
-  const existing = await collection.findOne(
-    scopeFilter(householdId, userId, { name: data.name })
+  const id = randomUUID();
+
+  // Atomic upsert: prevents TOCTOU race where concurrent requests both
+  // pass a findOne check and then both insert, creating duplicates.
+  const result = await collection.findOneAndUpdate(
+    scopeFilter(householdId, userId, { name: data.name }),
+    {
+      $setOnInsert: {
+        id,
+        ...data,
+        householdId: scope.householdId,
+        userId: scope.userId,
+      },
+    },
+    { upsert: true, returnDocument: 'after' }
   );
 
-  if (existing) {
-    const { _id, userId: _, householdId: __, ...category } = existing as any;
-    return category as Category;
+  if (!result) {
+    throw new Error(`Failed to create or find category '${data.name}'`);
   }
 
-  const id = randomUUID();
-  const document = {
-    id,
-    ...data,
-    householdId: scope.householdId,
-    userId: scope.userId,
-  } as any;
-
-  await collection.insertOne(document);
-
-  const { _id, userId: _, householdId: __, ...category } = document;
+  const { _id, userId: _, householdId: __, ...category } = result as any;
   return category as Category;
 }
 

--- a/src/server/repositories/habitRepository.ts
+++ b/src/server/repositories/habitRepository.ts
@@ -25,30 +25,37 @@ export async function createHabit(
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
-  const existing = await collection.findOne(
-    scopeFilter(householdId, userId, { name: data.name, categoryId: data.categoryId })
-  );
-
-  if (existing) {
-    return stripScope(existing);
-  }
-
   const id = crypto.randomUUID();
   const createdAt = new Date().toISOString();
 
-  const document = {
-    id,
-    ...data,
-    archived: false,
-    createdAt,
-    householdId: scope.householdId,
-    userId: scope.userId,
-  } as any;
+  // Atomic upsert: prevents TOCTOU race where concurrent requests both
+  // pass a findOne check and then both insert, creating duplicates.
+  // $setOnInsert only applies fields when a new document is created.
+  const result = await collection.findOneAndUpdate(
+    scopeFilter(householdId, userId, { name: data.name, categoryId: data.categoryId }),
+    {
+      $setOnInsert: {
+        id,
+        ...data,
+        archived: false,
+        createdAt,
+        householdId: scope.householdId,
+        userId: scope.userId,
+      },
+    },
+    { upsert: true, returnDocument: 'after' }
+  );
 
-  await collection.insertOne(document);
-  console.log(`[Persistence] Created habit '${data.name}' (ID: ${id}) for User: ${userId}`);
+  if (!result) {
+    throw new Error(`Failed to create or find habit '${data.name}'`);
+  }
 
-  return stripScope(document);
+  // Log only if we actually created a new document (id matches what we generated)
+  if ((result as any).id === id) {
+    console.log(`[Persistence] Created habit '${data.name}' (ID: ${id}) for User: ${userId}`);
+  }
+
+  return stripScope(result);
 }
 
 export async function getHabitsByUser(householdId: string, userId: string): Promise<Habit[]> {

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import { validateDayKey } from '../domain/canonicalValidators';
 import { getRequestIdentity } from '../middleware/identity';
 import { getDb } from '../lib/mongoClient';
+import type { Document } from 'mongodb';
 
 type HabitDoc = {
   id: string;
@@ -125,6 +126,202 @@ export async function getIntegrityReport(req: Request, res: Response): Promise<v
       error: {
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to generate integrity report',
+        details: process.env.NODE_ENV === 'development' ? message : undefined,
+      },
+    });
+  }
+}
+
+/**
+ * POST /api/admin/dedup-habits
+ *
+ * Deduplicates habits and categories for the authenticated user.
+ * For each group of duplicates (same name + categoryId + user scope):
+ *   1. Keeps the oldest record (earliest createdAt)
+ *   2. Remaps any habitEntries referencing deleted IDs to the kept ID
+ *   3. Remaps any goal linkedHabitIds referencing deleted IDs
+ *   4. Deletes the duplicate records
+ *
+ * Returns a dry-run summary by default. Pass ?commit=true to actually apply changes.
+ */
+export async function dedupHabits(req: Request, res: Response): Promise<void> {
+  try {
+    const { householdId, userId } = getRequestIdentity(req);
+    const commit = req.query.commit === 'true';
+    const db = await getDb();
+
+    // --- Deduplicate habits ---
+    const habitsColl = db.collection('habits');
+    const allHabits = await habitsColl
+      .find({ householdId, userId })
+      .sort({ createdAt: 1 })
+      .toArray();
+
+    // Group by (name, categoryId) — the natural uniqueness key
+    const habitGroups = new Map<string, Document[]>();
+    for (const habit of allHabits) {
+      const key = `${habit.name}|||${habit.categoryId}`;
+      const group = habitGroups.get(key) ?? [];
+      group.push(habit);
+      habitGroups.set(key, group);
+    }
+
+    const habitDuplicateIds: string[] = [];
+    const habitIdRemapMap = new Map<string, string>(); // duplicateId -> keepId
+    let habitGroupsWithDupes = 0;
+
+    for (const [, group] of habitGroups) {
+      if (group.length <= 1) continue;
+      habitGroupsWithDupes++;
+      const keep = group[0]; // oldest by createdAt (sorted above)
+      for (let i = 1; i < group.length; i++) {
+        habitDuplicateIds.push(group[i].id);
+        habitIdRemapMap.set(group[i].id, keep.id);
+      }
+    }
+
+    // --- Deduplicate categories ---
+    const categoriesColl = db.collection('categories');
+    const allCategories = await categoriesColl
+      .find({ householdId, userId })
+      .sort({ createdAt: 1, _id: 1 })
+      .toArray();
+
+    const categoryGroups = new Map<string, Document[]>();
+    for (const cat of allCategories) {
+      const key = cat.name;
+      const group = categoryGroups.get(key) ?? [];
+      group.push(cat);
+      categoryGroups.set(key, group);
+    }
+
+    const categoryDuplicateIds: string[] = [];
+    const categoryIdRemapMap = new Map<string, string>();
+    let categoryGroupsWithDupes = 0;
+
+    for (const [, group] of categoryGroups) {
+      if (group.length <= 1) continue;
+      categoryGroupsWithDupes++;
+      const keep = group[0];
+      for (let i = 1; i < group.length; i++) {
+        categoryDuplicateIds.push(group[i].id);
+        categoryIdRemapMap.set(group[i].id, keep.id);
+      }
+    }
+
+    // Summary for dry-run
+    const summary = {
+      habits: {
+        total: allHabits.length,
+        uniqueGroups: habitGroups.size,
+        groupsWithDuplicates: habitGroupsWithDupes,
+        duplicatesToRemove: habitDuplicateIds.length,
+        afterDedup: allHabits.length - habitDuplicateIds.length,
+      },
+      categories: {
+        total: allCategories.length,
+        uniqueGroups: categoryGroups.size,
+        groupsWithDuplicates: categoryGroupsWithDupes,
+        duplicatesToRemove: categoryDuplicateIds.length,
+        afterDedup: allCategories.length - categoryDuplicateIds.length,
+      },
+    };
+
+    if (!commit) {
+      res.status(200).json({
+        mode: 'dry-run',
+        message: 'Pass ?commit=true to apply changes',
+        summary,
+        habitIdRemapping: Object.fromEntries(habitIdRemapMap),
+        categoryIdRemapping: Object.fromEntries(categoryIdRemapMap),
+      });
+      return;
+    }
+
+    // --- Apply changes ---
+    const results: Record<string, number> = {};
+
+    // 1. Remap habitEntries.habitId from duplicate -> kept
+    if (habitIdRemapMap.size > 0) {
+      let remappedEntries = 0;
+      for (const [oldId, newId] of habitIdRemapMap) {
+        const r = await db.collection('habitEntries').updateMany(
+          { householdId, userId, habitId: oldId },
+          { $set: { habitId: newId } }
+        );
+        remappedEntries += r.modifiedCount;
+      }
+      results.remappedHabitEntries = remappedEntries;
+    }
+
+    // 2. Remap goal linkedHabitIds
+    if (habitIdRemapMap.size > 0) {
+      const goals = await db.collection('goals')
+        .find({ householdId, userId, linkedHabitIds: { $exists: true } })
+        .toArray();
+
+      let remappedGoalLinks = 0;
+      for (const goal of goals) {
+        const linked: string[] = goal.linkedHabitIds ?? [];
+        const updated = linked.map(id => habitIdRemapMap.get(id) ?? id);
+        // Deduplicate in case remap creates dupes within the array
+        const deduped = [...new Set(updated)];
+        if (JSON.stringify(linked) !== JSON.stringify(deduped)) {
+          await db.collection('goals').updateOne(
+            { householdId, userId, id: goal.id },
+            { $set: { linkedHabitIds: deduped } }
+          );
+          remappedGoalLinks++;
+        }
+      }
+      results.remappedGoalLinks = remappedGoalLinks;
+    }
+
+    // 3. Remap habit categoryId from duplicate category -> kept category
+    if (categoryIdRemapMap.size > 0) {
+      let remappedHabitCategories = 0;
+      for (const [oldId, newId] of categoryIdRemapMap) {
+        const r = await habitsColl.updateMany(
+          { householdId, userId, categoryId: oldId },
+          { $set: { categoryId: newId } }
+        );
+        remappedHabitCategories += r.modifiedCount;
+      }
+      results.remappedHabitCategories = remappedHabitCategories;
+    }
+
+    // 4. Delete duplicate habits
+    if (habitDuplicateIds.length > 0) {
+      const r = await habitsColl.deleteMany({
+        householdId,
+        userId,
+        id: { $in: habitDuplicateIds },
+      });
+      results.deletedDuplicateHabits = r.deletedCount;
+    }
+
+    // 5. Delete duplicate categories
+    if (categoryDuplicateIds.length > 0) {
+      const r = await categoriesColl.deleteMany({
+        householdId,
+        userId,
+        id: { $in: categoryDuplicateIds },
+      });
+      results.deletedDuplicateCategories = r.deletedCount;
+    }
+
+    res.status(200).json({
+      mode: 'committed',
+      summary,
+      results,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Error in dedup-habits:', message);
+    res.status(500).json({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to deduplicate habits',
         details: process.env.NODE_ENV === 'development' ? message : undefined,
       },
     });

--- a/src/store/HabitContext.tsx
+++ b/src/store/HabitContext.tsx
@@ -320,8 +320,11 @@ export const HabitProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const addHabit = async (habit: Omit<Habit, 'id' | 'createdAt' | 'archived'>): Promise<Habit> => {
         try {
             const newHabit = await saveHabit(habit);
-            // Updating state with functional update to ensure latest state
-            setHabits(prev => [...prev, newHabit]);
+            // Server uses atomic upsert — may return an existing habit instead of creating a new one.
+            // Only append if not already in state to prevent duplicate entries.
+            setHabits(prev =>
+                prev.some(h => h.id === newHabit.id) ? prev : [...prev, newHabit]
+            );
             return newHabit;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Changes

### Database
- Add unique indexes on habits (householdId, userId, name, categoryId) and categories (householdId, userId, name)
- Add safe index creation that handles existing duplicates gracefully

### Repositories
- Replace findOne + insert pattern with atomic `findOneAndUpdate` + upsert in both `habitRepository` and `categoryRepository`
- This eliminates TOCTOU race conditions where concurrent requests could both pass a findOne check and then both insert, creating duplicates

### Admin Routes
- Add new `POST /api/admin/dedup-habits` endpoint to repair existing duplicate data
- Supports dry-run mode (default) and commit mode (?commit=true)
- Deduplication process:
  1. Groups duplicates by unique key (name + categoryId for habits, name for categories)
  2. Keeps oldest record per group
  3. Remaps habitEntries, goal linkedHabitIds, and habit categoryIds to use kept IDs
  4. Deletes duplicate records

### Frontend
- Update HabitContext to deduplicate state when receiving habits from server (handles case where upsert returns existing habit)

### Server
- Register new admin dedup endpoint in app.ts