### PR TITLE
fix: prevent duplicate habit/category records

### DIFF
--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -157,10 +157,12 @@ export async function dedupHabits(req: Request, res: Response): Promise<void> {
       .sort({ createdAt: 1 })
       .toArray();
 
-    // Group by (name, categoryId) — the natural uniqueness key
+    // Group by name only — duplicates were created with different categoryIds
+    // due to the race condition, so (name, categoryId) grouping misses them.
+    // The kept record's categoryId is preserved; duplicates are remapped.
     const habitGroups = new Map<string, Document[]>();
     for (const habit of allHabits) {
-      const key = `${habit.name}|||${habit.categoryId}`;
+      const key = habit.name;
       const group = habitGroups.get(key) ?? [];
       group.push(habit);
       habitGroups.set(key, group);


### PR DESCRIPTION
## Summary
- Replace TOCTOU check-then-insert with atomic MongoDB `findOneAndUpdate` + `upsert: true` in `habitRepository` and `categoryRepository` to prevent race conditions from concurrent requests (React StrictMode double-renders)
- Add `POST /api/admin/dedup-habits` endpoint (admin-only, dry-run by default) to clean up existing 206 → ~31 records, remapping habitEntries and goal linkedHabitIds
- Add unique indexes on `habits(householdId, userId, name, categoryId)` and `categories(householdId, userId, name)` as DB-level safety net
- Frontend `addHabit` now deduplicates state to handle upsert returns

## Test plan
- [x] TypeScript builds cleanly (`tsc --noEmit`)
- [x] Test suite: same pass/fail count as main (no regressions)
- [x] Dev servers start without errors, all API endpoints return 200
- [ ] After deploy: run `POST /api/admin/dedup-habits` dry-run to verify counts
- [ ] After deploy: run `POST /api/admin/dedup-habits?commit=true` to apply cleanup
- [ ] Verify habit count drops from 206 to ~31

🤖 Generated with [Claude Code](https://claude.com/claude-code)