### PR TITLE
Fix Gemini 2.5 Flash errors, add manual goal completion, and misc UX fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#171717" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>habit-flow-ai</title>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -454,7 +454,6 @@ const HabitTrackerContent: React.FC = () => {
             onNavigateToJournal={() => handleNavigate('journal')}
             onNavigateToRoutines={() => handleNavigate('routines')}
             onNavigateToTasks={() => handleNavigate('tasks')}
-            onOpenSettings={() => window.dispatchEvent(new Event('habitflow:open-settings'))}
           />
         ) : view === 'wellbeing-history' ? (
           <WellbeingHistoryPage onBack={() => handleNavigate('dashboard')} />

--- a/src/components/HabitCreationInlineModal.tsx
+++ b/src/components/HabitCreationInlineModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { useHabitStore } from '../store/HabitContext';
 
@@ -6,20 +6,29 @@ interface HabitCreationInlineModalProps {
     isOpen: boolean;
     onClose: () => void;
     onHabitCreated: (habitId: string) => void;
+    defaultCategoryId?: string;
 }
 
 export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> = ({
     isOpen,
     onClose,
     onHabitCreated,
+    defaultCategoryId,
 }) => {
     const { addHabit, categories } = useHabitStore();
     const [name, setName] = useState('');
     const [type, setType] = useState<'binary' | 'quantified'>('binary');
     const [target, setTarget] = useState('');
     const [unit, setUnit] = useState('');
-    const [categoryId, setCategoryId] = useState('');
+    const [categoryId, setCategoryId] = useState(defaultCategoryId || '');
     const [imageUrl, setImageUrl] = useState('');
+
+    // Reset category to default when modal opens
+    useEffect(() => {
+        if (isOpen) {
+            setCategoryId(defaultCategoryId || '');
+        }
+    }, [isOpen, defaultCategoryId]);
 
     if (!isOpen) return null;
 

--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -50,7 +50,6 @@ interface ProgressDashboardProps {
     onNavigateToJournal?: () => void;
     onNavigateToRoutines?: () => void;
     onNavigateToTasks?: () => void;
-    onOpenSettings?: () => void;
 }
 
 export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
@@ -61,7 +60,6 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
     onNavigateToJournal,
     onNavigateToRoutines,
     onNavigateToTasks,
-    onOpenSettings,
 }) => {
     const { habits, categories } = useHabitStore();
     const { data: progressData, loading: progressLoading } = useProgressOverview();
@@ -138,7 +136,7 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
             )}
 
             {/* AI Weekly Summary */}
-            <WeeklySummaryCard onOpenSettings={onOpenSettings} />
+            <WeeklySummaryCard />
 
             {/* Goals at a glance */}
             <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">

--- a/src/components/VariantEditor.tsx
+++ b/src/components/VariantEditor.tsx
@@ -5,7 +5,7 @@
  * Used within RoutineEditorModal for each variant tab.
  */
 import React, { useState } from 'react';
-import { Plus, Trash2, Link2, Clock, Image as ImageIcon, Loader2, ChevronDown, X } from 'lucide-react';
+import { Plus, Trash2, Link2, Clock, Image as ImageIcon, Loader2, ChevronDown, ChevronUp, X } from 'lucide-react';
 import type { RoutineVariant, RoutineStep } from '../models/persistenceTypes';
 import type { Habit } from '../types';
 
@@ -58,6 +58,14 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
         if (expandedStepId === id) setExpandedStepId(null);
     };
 
+    const moveStep = (index: number, direction: -1 | 1) => {
+        const target = index + direction;
+        if (target < 0 || target >= steps.length) return;
+        const reordered = [...steps];
+        [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+        updateVariantField({ steps: reordered });
+    };
+
     const handleStepImageUpload = async (file: File, stepId: string) => {
         setUploadingStepId(stepId);
         try {
@@ -103,12 +111,20 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                         <input
                             type="number"
                             min="1"
-                            value={variant.estimatedDurationMinutes || ''}
+                            value={variant.estimatedDurationMinutes ?? ''}
                             onChange={e => {
-                                const val = parseInt(e.target.value);
-                                updateVariantField({
-                                    estimatedDurationMinutes: isNaN(val) ? 1 : Math.max(1, val)
-                                });
+                                const raw = e.target.value;
+                                if (raw === '') {
+                                    updateVariantField({ estimatedDurationMinutes: undefined as unknown as number });
+                                } else {
+                                    const val = parseInt(raw);
+                                    if (!isNaN(val)) updateVariantField({ estimatedDurationMinutes: Math.max(1, val) });
+                                }
+                            }}
+                            onBlur={() => {
+                                if (!variant.estimatedDurationMinutes || variant.estimatedDurationMinutes < 1) {
+                                    updateVariantField({ estimatedDurationMinutes: 1 });
+                                }
                             }}
                             className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                             placeholder="15"
@@ -150,13 +166,29 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                     <div className="flex-1 font-medium text-white truncate">
                                         {step.title || <span className="text-neutral-500 italic">Untitled Step</span>}
                                     </div>
-                                    <div className="flex items-center gap-2">
+                                    <div className="flex items-center gap-1">
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); moveStep(index, -1); }}
+                                            className="p-1.5 text-neutral-600 hover:text-white transition-colors disabled:opacity-20 disabled:hover:text-neutral-600"
+                                            title="Move Up"
+                                            disabled={index === 0}
+                                        >
+                                            <ChevronUp size={14} />
+                                        </button>
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); moveStep(index, 1); }}
+                                            className="p-1.5 text-neutral-600 hover:text-white transition-colors disabled:opacity-20 disabled:hover:text-neutral-600"
+                                            title="Move Down"
+                                            disabled={index === steps.length - 1}
+                                        >
+                                            <ChevronDown size={14} />
+                                        </button>
                                         <button
                                             onClick={(e) => {
                                                 e.stopPropagation();
                                                 removeStep(step.id);
                                             }}
-                                            className="p-2 text-neutral-600 hover:text-red-400 transition-colors"
+                                            className="p-1.5 text-neutral-600 hover:text-red-400 transition-colors"
                                             title="Delete Step"
                                         >
                                             <Trash2 size={16} />

--- a/src/components/dashboard/WeeklySummaryCard.tsx
+++ b/src/components/dashboard/WeeklySummaryCard.tsx
@@ -1,12 +1,8 @@
 import React, { useState } from 'react';
-import { Sparkles, Loader2, X, ChevronDown, ChevronUp, Settings } from 'lucide-react';
+import { Sparkles, Loader2, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { hasGeminiApiKey, fetchWeeklySummary } from '../../lib/geminiClient';
 
-interface WeeklySummaryCardProps {
-  onOpenSettings?: () => void;
-}
-
-export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = ({ onOpenSettings }) => {
+export const WeeklySummaryCard: React.FC = () => {
   const [summary, setSummary] = useState<string | null>(null);
   const [period, setPeriod] = useState<{ start: string; end: string } | null>(null);
   const [loading, setLoading] = useState(false);
@@ -29,29 +25,9 @@ export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = ({ onOpenSett
     }
   };
 
-  // No key configured — show setup prompt
+  // No key configured — hide the card entirely
   if (!hasKey) {
-    return (
-      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
-        <div className="flex items-center gap-2 mb-3">
-          <Sparkles size={18} className="text-purple-400" />
-          <h3 className="text-lg font-semibold text-white">AI Weekly Summary</h3>
-        </div>
-        <p className="text-sm text-neutral-400 mb-4">
-          Get personalized weekly summaries of your habits and journal entries, powered by Google Gemini.
-          Add your API key in Settings to get started.
-        </p>
-        {onOpenSettings && (
-          <button
-            onClick={onOpenSettings}
-            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600/20 text-purple-300 border border-purple-500/20 hover:bg-purple-600/30 text-sm transition-colors"
-          >
-            <Settings size={14} />
-            Add Gemini API Key
-          </button>
-        )}
-      </div>
-    );
+    return null;
   }
 
   return (

--- a/src/pages/goals/CreateGoalLinkHabits.tsx
+++ b/src/pages/goals/CreateGoalLinkHabits.tsx
@@ -9,6 +9,7 @@ interface GoalDraft {
     targetValue: number;
     unit?: string;
     deadline?: string;
+    categoryId?: string;
 }
 
 interface CreateGoalLinkHabitsProps {
@@ -204,6 +205,7 @@ export const CreateGoalLinkHabits: React.FC<CreateGoalLinkHabitsProps> = ({
                 isOpen={isCreateModalOpen}
                 onClose={() => setIsCreateModalOpen(false)}
                 onHabitCreated={handleHabitCreated}
+                defaultCategoryId={goalDraft.categoryId}
             />
         </div>
     );

--- a/src/pages/goals/GoalDetailPage.tsx
+++ b/src/pages/goals/GoalDetailPage.tsx
@@ -11,7 +11,7 @@
 import React, { useMemo, useState, useEffect, useRef } from 'react';
 import { useGoalDetail } from '../../lib/useGoalDetail';
 import { useHabitStore } from '../../store/HabitContext';
-import { Loader2, ArrowLeft, Check, Edit, Trash2 } from 'lucide-react';
+import { Loader2, ArrowLeft, Check, Edit, Trash2, Trophy } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { DeleteGoalConfirmModal } from '../../components/goals/DeleteGoalConfirmModal';
 import { EditGoalModal } from '../../components/goals/EditGoalModal';
@@ -41,6 +41,8 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
     const [activeTab, setActiveTab] = useState<Tab>('cumulative');
     const [showEditModal, setShowEditModal] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [showCompleteConfirm, setShowCompleteConfirm] = useState(false);
+    const [isMarkingComplete, setIsMarkingComplete] = useState(false);
 
     // Habit Entries State
     const [linkedHabitEntries, setLinkedHabitEntries] = useState<HabitEntry[]>([]);
@@ -193,6 +195,20 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
         }
     };
 
+    const handleMarkComplete = async () => {
+        setIsMarkingComplete(true);
+        try {
+            await markGoalAsCompleted(goalId);
+            invalidateAllGoalCaches();
+            setShowCompleteConfirm(false);
+            if (onNavigateToCompleted) onNavigateToCompleted(goalId);
+            else refetch();
+        } catch (err) {
+            console.error('Error marking goal complete:', err);
+            setIsMarkingComplete(false);
+        }
+    };
+
     // Auto-completion Effect
     useEffect(() => {
         if (!data || loading || isCompletingRef.current) return;
@@ -326,6 +342,38 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                     )}
                 </div>
             </div>
+
+            {/* Mark Complete Button (for active goals) */}
+            {!goal.completedAt && (
+                <div className="mb-8">
+                    {!showCompleteConfirm ? (
+                        <button
+                            onClick={() => setShowCompleteConfirm(true)}
+                            className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 rounded-lg hover:bg-emerald-500/20 transition-colors font-medium text-sm"
+                        >
+                            <Trophy size={16} />
+                            Mark as Complete
+                        </button>
+                    ) : (
+                        <div className="flex items-center gap-3 p-4 bg-emerald-500/10 border border-emerald-500/30 rounded-lg">
+                            <span className="text-sm text-emerald-300">Mark this goal as achieved?</span>
+                            <button
+                                onClick={handleMarkComplete}
+                                disabled={isMarkingComplete}
+                                className="px-4 py-1.5 bg-emerald-500 text-neutral-900 font-medium text-sm rounded-lg hover:bg-emerald-400 transition-colors disabled:opacity-50"
+                            >
+                                {isMarkingComplete ? 'Completing...' : 'Yes, I did it!'}
+                            </button>
+                            <button
+                                onClick={() => setShowCompleteConfirm(false)}
+                                className="px-3 py-1.5 text-neutral-400 hover:text-white text-sm transition-colors"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
 
             {/* Tabs */}
             <div className="flex border-b border-white/10 mb-8">

--- a/src/server/routes/aiSummary.ts
+++ b/src/server/routes/aiSummary.ts
@@ -113,7 +113,7 @@ ${journalSummaryLines.length > 0 ? journalSummaryLines.join('\n') : '(No journal
 Please write a weekly summary now. Use markdown formatting for readability.`;
 
     // Call Gemini API
-    const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${encodeURIComponent(geminiApiKey.trim())}`;
+    const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(geminiApiKey.trim())}`;
 
     const geminiResponse = await fetch(geminiUrl, {
       method: 'POST',
@@ -123,6 +123,8 @@ Please write a weekly summary now. Use markdown formatting for readability.`;
         generationConfig: {
           temperature: 0.7,
           maxOutputTokens: 1024,
+          // Disable thinking for direct text output
+          thinkingConfig: { thinkingBudget: 0 },
         },
       }),
     });
@@ -151,10 +153,13 @@ Please write a weekly summary now. Use markdown formatting for readability.`;
     }
 
     const geminiData = await geminiResponse.json() as {
-      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string; thought?: boolean }> } }>;
     };
+    // Extract output text (skip any "thought" parts from thinking models)
+    const parts = geminiData?.candidates?.[0]?.content?.parts || [];
+    const outputPart = parts.find(p => !p.thought && p.text) || parts[0];
     const summaryText =
-      geminiData?.candidates?.[0]?.content?.parts?.[0]?.text ||
+      outputPart?.text ||
       'Unable to generate summary. Please try again.';
 
     res.status(200).json({

--- a/src/server/routes/aiVariantSuggestion.ts
+++ b/src/server/routes/aiVariantSuggestion.ts
@@ -80,7 +80,7 @@ Rules:
 - Variants should meaningfully differ in scope, duration, or focus
 - Do NOT wrap in markdown code blocks. Return raw JSON only.`;
 
-        const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${encodeURIComponent(body.geminiApiKey.trim())}`;
+        const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(body.geminiApiKey.trim())}`;
 
         const geminiResponse = await fetch(geminiUrl, {
             method: 'POST',
@@ -90,6 +90,8 @@ Rules:
                 generationConfig: {
                     temperature: 0.8,
                     maxOutputTokens: 4096,
+                    // Disable thinking for structured JSON output
+                    thinkingConfig: { thinkingBudget: 0 },
                 },
             }),
         });
@@ -118,10 +120,13 @@ Rules:
         }
 
         const geminiData = await geminiResponse.json() as {
-            candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+            candidates?: Array<{ content?: { parts?: Array<{ text?: string; thought?: boolean }> } }>;
         };
 
-        const rawText = geminiData?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+        // Extract the output text (skip any "thought" parts from thinking models)
+        const parts = geminiData?.candidates?.[0]?.content?.parts || [];
+        const outputPart = parts.find(p => !p.thought && p.text) || parts[0];
+        const rawText = outputPart?.text || '';
 
         // Parse the JSON from Gemini's response (strip markdown fences if present)
         let cleaned = rawText.trim();

--- a/src/store/HabitContext.tsx
+++ b/src/store/HabitContext.tsx
@@ -297,7 +297,7 @@ export const HabitProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const addCategory = async (category: Omit<Category, 'id'>) => {
         try {
             const newCategory = await saveCategory(category);
-            setCategories([...categories, newCategory]);
+            setCategories(prev => [...prev, newCategory]);
             return newCategory;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Summary

- **Fix Gemini API 502 errors**: Upgrade model from `gemini-2.0-flash` to `gemini-2.5-flash` and handle thinking model response format by disabling thinking (`thinkingBudget: 0`) and skipping `thought` parts in response parsing
- **Add manual goal completion**: New "Mark as Complete" button with two-step confirmation on GoalDetailPage, solving the chicken-and-egg problem where one-time/milestone goals could never be auto-completed
- **Fix VariantEditor duration input**: Replace controlled input that lost focus on keystroke with proper empty-string handling and onBlur fallback
- **Add step reordering in routines**: Up/down chevron buttons on each routine step for drag-free reordering
- **Hide AI Weekly Summary card** when no Gemini API key is configured (previously showed a setup prompt)
- **Fix stale closure in addCategory**: Use functional state update (`prev => [...prev, newCategory]`) to prevent newly created categories from being lost
- **Fix goal creation flow**: Pass `defaultCategoryId` to `HabitCreationInlineModal` so new habits created during goal setup pre-select the correct category
- **Fix deprecated meta tag**: Replace `apple-mobile-web-app-capable` with `mobile-web-app-capable`

## Files Changed (9)

| File | Change |
|------|--------|
| `src/server/routes/aiSummary.ts` | Gemini 2.5 Flash + thinking config + thought part parsing |
| `src/server/routes/aiVariantSuggestion.ts` | Gemini 2.5 Flash + thinking config + thought part parsing |
| `src/pages/goals/GoalDetailPage.tsx` | "Mark as Complete" button with Trophy icon and confirmation |
| `src/components/VariantEditor.tsx` | Duration input fix + step reorder buttons (ChevronUp/Down) |
| `src/components/dashboard/WeeklySummaryCard.tsx` | Hide card when no API key (return null) |
| `src/store/HabitContext.tsx` | Functional state update in addCategory |
| `src/components/HabitCreationInlineModal.tsx` | defaultCategoryId prop + useEffect sync |
| `src/pages/goals/CreateGoalLinkHabits.tsx` | Pass categoryId through GoalDraft to inline modal |
| `index.html` | Meta tag deprecation fix |

## Test plan

- [ ] Verify "Suggest with AI" in Create Routine works with a valid Gemini API key (no more 502)
- [ ] Verify AI Weekly Summary generates correctly on Dashboard
- [ ] Navigate to a goal detail page and confirm "Mark as Complete" button appears for active goals
- [ ] Click "Mark as Complete" and verify two-step confirmation (Yes, I did it! / Cancel)
- [ ] Confirm completing a goal navigates to the GoalCompletedPage
- [ ] Create a routine and test duration input (type, clear, blur behavior)
- [ ] Create a routine with steps and test up/down reordering
- [ ] Verify Dashboard hides AI Weekly Summary when no Gemini key is set
- [ ] Create a goal with a new category, then create a habit inline — confirm category pre-selected
- [ ] Check no `apple-mobile-web-app-capable` deprecation warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)