### PR TITLE
Fix journal free-write tab: remove unnecessary container and header c…

### DIFF
--- a/src/components/Journal/JournalEditor.tsx
+++ b/src/components/Journal/JournalEditor.tsx
@@ -13,6 +13,8 @@ interface JournalEditorProps {
     onSave: () => void;
     onCancel?: () => void;
     initialTemplateId?: string;
+    /** When true, renders without the card container, header row, and footer — just the editor content. */
+    minimal?: boolean;
 }
 
 // Map template/category IDs to Icons
@@ -41,7 +43,7 @@ const ICONS: Record<string, LucideIcon> = {
  * JournalEditor with Query Parameter Navigation support.
  * Uses 'jView', 'jCat', 'jTmp' query params to persist state.
  */
-export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplateId }: JournalEditorProps) {
+export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplateId, minimal }: JournalEditorProps) {
     // --- State Initialization ---
     // We read from URL params on mount/render to determine state, but also keep local state for instant UI updates.
 
@@ -399,6 +401,59 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
     const WritingIcon = (selectedTemplateId === 'free-write')
         ? PenLine
         : (ICONS[selectedTemplateId] || ICONS[currentTemplate.categoryId] || Brain);
+
+    // Minimal mode: render just the editor content without container/header/footer chrome
+    if (minimal) {
+        return (
+            <div className="flex flex-col h-[calc(100vh-12rem)]">
+                <div className="flex-1 overflow-y-auto custom-scrollbar">
+                    {selectedTemplateId === 'free-write' ? (
+                        <div className="relative h-full">
+                            <textarea
+                                className="w-full h-full min-h-[400px] bg-white/[0.02] border border-white/5 rounded-xl p-6 text-white/90 text-lg leading-relaxed focus:bg-white/[0.04] focus:border-white/10 focus:ring-0 focus:outline-none resize-none font-sans placeholder:text-white/20"
+                                placeholder="Start writing..."
+                                value={content['free-write'] || ''}
+                                onChange={(e) => handleAnswerChange('free-write', e.target.value)}
+                                autoFocus
+                            />
+                        </div>
+                    ) : (
+                        <div className="space-y-6">
+                            {prompts.map((prompt) => (
+                                <div key={prompt.id} className="group">
+                                    <label className="block text-white/90 text-lg font-medium mb-3">
+                                        {prompt.text}
+                                    </label>
+                                    <textarea
+                                        className="w-full bg-[#151515] border border-white/10 hover:border-white/20 focus:border-emerald-500/50 rounded-xl p-4 text-white/90 placeholder:text-white/10 focus:outline-none focus:bg-[#1a1a1a] transition-all resize-none min-h-[120px]"
+                                        placeholder="Type your thoughts here..."
+                                        value={content[prompt.id] || ''}
+                                        onChange={(e) => handleAnswerChange(prompt.id, e.target.value)}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+                <div className="flex justify-between items-center pt-4">
+                    <button
+                        onClick={handleDiscard}
+                        className="text-white/40 hover:text-red-400 text-sm font-medium transition-colors px-2 py-1"
+                    >
+                        Discard Draft
+                    </button>
+                    <button
+                        onClick={handleSave}
+                        disabled={isSubmitting}
+                        className="flex items-center gap-2 px-6 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold rounded-xl shadow-lg shadow-emerald-500/20 transition-all hover:scale-105 disabled:opacity-50 disabled:scale-100"
+                    >
+                        <Save size={18} />
+                        {isSubmitting ? 'Saving...' : 'Save Entry'}
+                    </button>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="bg-zinc-900 border border-white/10 rounded-2xl p-0 shadow-2xl relative max-w-4xl mx-auto h-[85vh] flex flex-col overflow-hidden">

--- a/src/pages/JournalPage.tsx
+++ b/src/pages/JournalPage.tsx
@@ -82,6 +82,7 @@ export function JournalPage() {
                         <JournalEditor
                             initialTemplateId="free-write"
                             onSave={handleSave}
+                            minimal
                         />
                     </div>
                 ) : activeTab === 'templates' ? (


### PR DESCRIPTION
…hrome

The Free Write tab redundantly wrapped the textarea in a card container with a header row showing "Back to Templates", "Free Write" title, and date picker — all unnecessary since the page tabs already provide context.

Added a `minimal` prop to JournalEditor that renders just the editor content without the card wrapper, header, or styled footer.

https://claude.ai/code/session_01WpGevSE2gvzncrkBpu8bkn