### PR TITLE
Add loading state tracking to setup progress and data stores

### DIFF
--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -70,7 +70,7 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
     const { habits, categories } = useHabitStore();
     const { data: progressData, loading: progressLoading } = useProgressOverview();
     const goalsCount = progressData?.goalsWithProgress?.length ?? 0;
-    const { setupPhase, hasHabits, hasTasks } = useSetupProgress(goalsCount);
+    const { setupPhase, hasHabits, hasTasks, loading: setupLoading } = useSetupProgress(goalsCount);
     const hasJournalEntries = false; // Will be derived from journal data when available
     const [isCheckInOpen, setIsCheckInOpen] = useState(false);
     const { pinnedIds: pinnedGoalIds, togglePin: toggleGoalPin, isPinned: isGoalPinned } = usePinnedGoals();
@@ -118,8 +118,8 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
         updateUrlParams({ categoryRange: range }, 'replace');
     };
 
-    // Zero-state: show guided setup dashboard
-    if (setupPhase === 'zero' && onNavigate) {
+    // Zero-state: show guided setup dashboard (only after data has loaded)
+    if (setupPhase === 'zero' && onNavigate && !setupLoading && !progressLoading) {
         return (
             <SetupDashboard
                 hasHabits={hasHabits}

--- a/src/hooks/useSetupProgress.ts
+++ b/src/hooks/useSetupProgress.ts
@@ -11,6 +11,7 @@ export interface SetupProgress {
   hasTasks: boolean;
   hasEntries: boolean;
   setupPhase: SetupPhase;
+  loading: boolean;
 }
 
 /**
@@ -18,11 +19,12 @@ export interface SetupProgress {
  * Used for dashboard progression and conditional UI.
  */
 export function useSetupProgress(goalsCount: number = 0): SetupProgress {
-  const { habits, logs } = useHabitStore();
-  const { routines } = useRoutineStore();
-  const { tasks } = useTasks();
+  const { habits, logs, loading: habitsLoading } = useHabitStore();
+  const { routines, loading: routinesLoading } = useRoutineStore();
+  const { tasks, loading: tasksLoading } = useTasks();
 
   return useMemo(() => {
+    const loading = habitsLoading || routinesLoading || tasksLoading;
     const hasHabits = habits.filter(h => !h.archived).length > 0;
     const hasRoutines = routines.length > 0;
     const hasTasks = tasks.filter(t => t.status !== 'deleted').length > 0;
@@ -42,6 +44,6 @@ export function useSetupProgress(goalsCount: number = 0): SetupProgress {
       setupPhase = 'early';
     }
 
-    return { hasHabits, hasRoutines, hasTasks, hasEntries, setupPhase };
-  }, [habits, routines, tasks, logs, goalsCount]);
+    return { hasHabits, hasRoutines, hasTasks, hasEntries, setupPhase, loading };
+  }, [habits, routines, tasks, logs, goalsCount, habitsLoading, routinesLoading, tasksLoading]);
 }

--- a/src/store/HabitContext.tsx
+++ b/src/store/HabitContext.tsx
@@ -54,6 +54,7 @@ interface HabitContextType {
     upsertHabitEntry: (habitId: string, dateKey: string, data?: any) => Promise<void>;
     deleteHabitEntryByKey: (habitId: string, dateKey: string) => Promise<void>;
     potentialEvidence: HabitPotentialEvidence[];
+    loading: boolean;
 }
 
 const HabitContext = createContext<HabitContextType | undefined>(undefined);
@@ -78,6 +79,7 @@ export const HabitProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const [wellbeingLogs, setWellbeingLogs] = useState<Record<string, DailyWellbeing>>({});
     const [potentialEvidence, setPotentialEvidence] = useState<HabitPotentialEvidence[]>([]);
     const [lastPersistenceError, setLastPersistenceError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
 
     // Use refs to prevent double execution in React StrictMode
     const initializedRef = useRef(false);
@@ -211,8 +213,10 @@ export const HabitProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                 });
 
                 console.log('[HabitContext] Initialization complete');
+                setLoading(false);
             } catch (error) {
                 console.error('[HabitContext] Error in initialize():', error);
+                setLoading(false);
                 throw error;
             }
         };
@@ -776,6 +780,7 @@ export const HabitProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             potentialEvidence,
             upsertHabitEntry: upsertHabitEntryContext,
             deleteHabitEntryByKey: deleteHabitEntryByKeyContext,
+            loading,
         }}>
             {children}
         </HabitContext.Provider>


### PR DESCRIPTION
## Summary
This PR adds comprehensive loading state tracking across the habit, routine, and task stores, and propagates this information through the setup progress hook to prevent premature rendering of the zero-state setup dashboard.

## Key Changes
- **HabitContext**: Added `loading` state that tracks initialization completion, set to `false` after initial data load or error
- **useSetupProgress hook**: 
  - Extracts `loading` flags from all three stores (habits, routines, tasks)
  - Combines loading states and returns as part of the `SetupProgress` interface
  - Updated dependency array to include all loading flags
- **ProgressDashboard**: 
  - Consumes the new `setupLoading` state from `useSetupProgress`
  - Guards zero-state dashboard rendering with loading checks to prevent flickering before data loads
  - Only shows setup dashboard when `setupPhase === 'zero'` AND data has finished loading

## Implementation Details
- Loading state is initialized to `true` in HabitContext and set to `false` after the initialization promise resolves (success or error)
- The setup progress hook now properly waits for all dependent stores to finish loading before determining the setup phase
- This prevents the UI from showing the zero-state setup dashboard briefly before actual data loads, improving the user experience during app initialization

https://claude.ai/code/session_01FZpWYRAHzfZuViu61Jg7ag