### PR TITLE
Allow reordering goal tracks within a category

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -57,6 +57,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Track Progress Isolation** — Progress only counts from when a goal becomes active in a track; shared habits don't leak progress forward
 - **Track Advancement** — Completing the active goal automatically activates the next goal in the sequence
 - **Track Detail View** — Dedicated page showing track progress, goal states (completed/active/locked), and drag-and-drop reordering
+- **Track Ordering** — Drag-and-drop reorder of goal tracks within a category group on the Goals page
 - **Track Achievements** — Earn achievements for completing goal tracks (Journey Complete, Triple Step, Grand Journey)
 
 ## Tasks

--- a/src/components/goals/GoalTrackSection.tsx
+++ b/src/components/goals/GoalTrackSection.tsx
@@ -5,7 +5,7 @@
  * Shows track name, progress summary, and ordered goals with visual state indicators.
  */
 import React from 'react';
-import { Route, Lock, Check, ChevronRight } from 'lucide-react';
+import { Route, Lock, Check, ChevronRight, GripVertical } from 'lucide-react';
 import type { GoalWithProgress, GoalTrack, Goal } from '../../types';
 
 interface GoalTrackSectionProps {
@@ -14,6 +14,8 @@ interface GoalTrackSectionProps {
     getGoalWithProgress: (goalId: string) => GoalWithProgress | undefined;
     onViewGoal?: (goalId: string) => void;
     onViewTrack?: (trackId: string) => void;
+    dragHandleProps?: Record<string, unknown>;
+    isDragging?: boolean;
 }
 
 export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
@@ -22,18 +24,35 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
     getGoalWithProgress,
     onViewGoal,
     onViewTrack,
+    dragHandleProps,
+    isDragging,
 }) => {
     const completedCount = goals.filter(g => g.trackStatus === 'completed').length;
     const totalCount = goals.length;
     const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
     return (
-        <div className="bg-neutral-800/30 border border-white/5 rounded-lg overflow-hidden mb-2">
+        <div
+            className={`bg-neutral-800/30 border border-white/5 rounded-lg overflow-hidden mb-2 ${
+                isDragging ? 'opacity-50 shadow-2xl' : ''
+            }`}
+        >
             {/* Track Header */}
-            <button
-                onClick={() => onViewTrack?.(track.id)}
-                className="w-full flex items-center gap-2.5 px-3.5 py-2.5 hover:bg-neutral-800/50 transition-colors text-left"
-            >
+            <div className="flex items-center gap-1 pl-2 pr-0 hover:bg-neutral-800/50 transition-colors">
+                {/* Drag handle */}
+                {dragHandleProps && (
+                    <div
+                        {...dragHandleProps}
+                        className="flex-shrink-0 text-neutral-600 hover:text-neutral-400 cursor-grab active:cursor-grabbing touch-none py-2.5"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <GripVertical size={16} />
+                    </div>
+                )}
+                <button
+                    onClick={() => onViewTrack?.(track.id)}
+                    className="flex-1 flex items-center gap-2.5 px-2 py-2.5 text-left"
+                >
                 <Route size={15} className="text-emerald-400 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
@@ -51,7 +70,8 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
                     </div>
                 </div>
                 <ChevronRight size={14} className="text-neutral-500 flex-shrink-0" />
-            </button>
+                </button>
+            </div>
 
             {/* Track Goals */}
             <div className="px-2 pb-2 space-y-1">

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -1117,6 +1117,18 @@ export async function reorderTrackGoals(trackId: string, goalIds: string[]): Pro
 }
 
 /**
+ * Reorder goal tracks. Pass the full list of track IDs in the new order;
+ * each track's sortOrder is set to its index in the array.
+ */
+export async function reorderGoalTracks(trackIds: string[]): Promise<void> {
+  await apiRequest<{ message: string }>('/goal-tracks/reorder', {
+    method: 'PATCH',
+    body: JSON.stringify({ trackIds }),
+  });
+  invalidateGoalDataCache();
+}
+
+/**
  * Habit Entry (History) Persistence Functions
  */
 

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -1101,6 +1101,13 @@ export interface GoalTrack {
     /** Optional description of the track */
     description?: string;
 
+    /**
+     * Display order within the parent category (lower = earlier).
+     * Assigned when the track is created and updated via the reorder endpoint.
+     * Optional for backward compatibility with tracks created before this field existed.
+     */
+    sortOrder?: number;
+
     /** ISO 8601 timestamp of when the track was created */
     createdAt: string;
 

--- a/src/pages/goals/GoalsPage.tsx
+++ b/src/pages/goals/GoalsPage.tsx
@@ -25,7 +25,7 @@ import { Loader2, AlertCircle } from 'lucide-react';
 import { EditGoalModal } from '../../components/goals/EditGoalModal';
 import { useHabitStore } from '../../store/HabitContext';
 import { buildGoalStacks } from '../../utils/goalUtils';
-import { reorderGoals } from '../../lib/persistenceClient';
+import { reorderGoals, reorderGoalTracks } from '../../lib/persistenceClient';
 import type { GoalWithProgress } from '../../types';
 
 interface GoalsPageProps {
@@ -73,6 +73,45 @@ const SortableGoalCard: React.FC<{
     );
 };
 
+// Sortable wrapper for a track section
+const SortableTrackSection: React.FC<{
+    // Use the same shape as StackProps.stack.tracks items below.
+    trackGroup: { track: { id: string; name: string; categoryId: string; description?: string; createdAt: string; updatedAt: string; completedAt?: string | null }; goals: Array<{ id: string; trackStatus?: string; trackOrder?: number; type?: string; title: string; completedAt?: string | null; activeWindowStart?: string }> };
+    getGoalWithProgress: (goalId: string) => GoalWithProgress | undefined;
+    onViewGoal?: (goalId: string) => void;
+    onViewTrack?: (trackId: string) => void;
+}> = ({ trackGroup, getGoalWithProgress, onViewGoal, onViewTrack }) => {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: trackGroup.track.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        zIndex: isDragging ? 50 : undefined,
+        position: isDragging ? 'relative' as const : undefined,
+    };
+
+    return (
+        <div ref={setNodeRef} style={style} {...attributes}>
+            <GoalTrackSection
+                track={trackGroup.track as any}
+                goals={trackGroup.goals as any}
+                getGoalWithProgress={getGoalWithProgress}
+                onViewGoal={onViewGoal}
+                onViewTrack={onViewTrack}
+                dragHandleProps={listeners}
+                isDragging={isDragging}
+            />
+        </div>
+    );
+};
+
 interface StackProps {
     stack: { category: { id: string; name: string; color: string }; goals: Array<{ id: string; type?: string }>; tracks: Array<{ track: { id: string; name: string; categoryId: string; description?: string; createdAt: string; updatedAt: string; completedAt?: string | null }; goals: Array<{ id: string; trackStatus?: string; trackOrder?: number; type?: string; title: string; completedAt?: string | null; activeWindowStart?: string }> }> };
     isExpanded: boolean;
@@ -84,6 +123,7 @@ interface StackProps {
     onEdit: (goalId: string) => void;
     onNavigateToCompleted?: (goalId: string) => void;
     onDragEnd: (event: DragEndEvent, categoryId: string) => void;
+    onTrackDragEnd: (event: DragEndEvent, categoryId: string) => void;
     sensors: ReturnType<typeof useSensors>;
     /** Whether any goals in this stack are cumulative (need grid layout) */
     hasCumulativeGoals: boolean;
@@ -100,6 +140,7 @@ const Stack: React.FC<StackProps> = ({
     onEdit,
     onNavigateToCompleted,
     onDragEnd,
+    onTrackDragEnd,
     sensors,
     hasCumulativeGoals,
 }) => {
@@ -180,18 +221,28 @@ const Stack: React.FC<StackProps> = ({
 
                     {/* Track sections */}
                     {stack.tracks && stack.tracks.length > 0 && (
-                        <div className={stack.goals.length > 0 ? 'mt-3 space-y-2' : 'space-y-2'}>
-                            {stack.tracks.map((tg) => (
-                                <GoalTrackSection
-                                    key={tg.track.id}
-                                    track={tg.track as any}
-                                    goals={tg.goals as any}
-                                    getGoalWithProgress={getGoalWithProgress}
-                                    onViewGoal={onViewGoal}
-                                    onViewTrack={onViewTrack}
-                                />
-                            ))}
-                        </div>
+                        <DndContext
+                            sensors={sensors}
+                            collisionDetection={closestCenter}
+                            onDragEnd={(event) => onTrackDragEnd(event, stack.category.id)}
+                        >
+                            <SortableContext
+                                items={stack.tracks.map(tg => tg.track.id)}
+                                strategy={verticalListSortingStrategy}
+                            >
+                                <div className={stack.goals.length > 0 ? 'mt-3 space-y-2' : 'space-y-2'}>
+                                    {stack.tracks.map((tg) => (
+                                        <SortableTrackSection
+                                            key={tg.track.id}
+                                            trackGroup={tg}
+                                            getGoalWithProgress={getGoalWithProgress}
+                                            onViewGoal={onViewGoal}
+                                            onViewTrack={onViewTrack}
+                                        />
+                                    ))}
+                                </div>
+                            </SortableContext>
+                        </DndContext>
                     )}
                 </div>
             )}
@@ -287,6 +338,39 @@ export const GoalsPage: React.FC<GoalsPageProps> = ({
         });
     }, [goalStacks, refetch]);
 
+    // Handle drag end for tracks within a category stack
+    const handleTrackDragEnd = useCallback((event: DragEndEvent, categoryId: string) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+
+        const stack = goalStacks.find(s => s.category.id === categoryId);
+        if (!stack) return;
+
+        const oldIndex = stack.tracks.findIndex(tg => tg.track.id === active.id);
+        const newIndex = stack.tracks.findIndex(tg => tg.track.id === over.id);
+        if (oldIndex === -1 || newIndex === -1) return;
+
+        const reorderedTracks = arrayMove(stack.tracks, oldIndex, newIndex);
+
+        // Build the full ordered list of all track IDs across all stacks so the
+        // server's sortOrder assignment remains globally consistent.
+        const allTrackIds: string[] = [];
+        for (const s of goalStacks) {
+            if (s.category.id === categoryId) {
+                allTrackIds.push(...reorderedTracks.map(tg => tg.track.id));
+            } else {
+                allTrackIds.push(...s.tracks.map(tg => tg.track.id));
+            }
+        }
+
+        reorderGoalTracks(allTrackIds).then(() => {
+            refetch();
+        }).catch((err) => {
+            console.error('Failed to reorder goal tracks:', err);
+            refetch(); // Revert on error
+        });
+    }, [goalStacks, refetch]);
+
     if (loading) {
         return (
             <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 py-12">
@@ -359,6 +443,7 @@ export const GoalsPage: React.FC<GoalsPageProps> = ({
                                 onEdit={(goalId) => setEditingGoalId(goalId)}
                                 onNavigateToCompleted={onNavigateToCompleted}
                                 onDragEnd={handleDragEnd}
+                                onTrackDragEnd={handleTrackDragEnd}
                                 sensors={sensors}
                                 hasCumulativeGoals={hasCumulativeGoals}
                             />

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -16,7 +16,7 @@ import { seedDemoEmotionalWellbeingRoute, resetDemoEmotionalWellbeingRoute } fro
 import { getRoutinesRoute, getRoutineRoute, createRoutineRoute, updateRoutineRoute, deleteRoutineRoute, submitRoutineRoute, uploadRoutineImageRoute, uploadRoutineImageMiddleware, getRoutineImageRoute, deleteRoutineImageRoute } from './routes/routines';
 import { getRoutineLogs } from './routes/routineLogs';
 import { getGoals, getGoal, getGoalProgress, getGoalsWithProgress, getCompletedGoals, createGoalRoute, updateGoalRoute, deleteGoalRoute, reorderGoalsRoute, getGoalDetailRoute } from './routes/goals';
-import { getGoalTracks, createGoalTrackRoute, getGoalTrackRoute, updateGoalTrackRoute, deleteGoalTrackRoute, addGoalToTrack, removeGoalFromTrack, reorderTrackGoals } from './routes/goalTracks';
+import { getGoalTracks, createGoalTrackRoute, getGoalTrackRoute, updateGoalTrackRoute, deleteGoalTrackRoute, addGoalToTrack, removeGoalFromTrack, reorderTrackGoals, reorderGoalTracksRoute } from './routes/goalTracks';
 import { getProgressOverview } from './routes/progress';
 import { getIntegrityReport, dedupHabits, recoverHabits, remapOrphanedCategories } from './routes/admin';
 import { getEntriesRoute, createEntryRoute, upsertEntryByKeyRoute, getEntryRoute, updateEntryRoute, deleteEntryRoute } from './routes/journal';
@@ -195,6 +195,7 @@ export function createApp(): Express {
   app.delete('/api/goals/:id', deleteGoalRoute);
   app.get('/api/goal-tracks', getGoalTracks);
   app.post('/api/goal-tracks', createGoalTrackRoute);
+  app.patch('/api/goal-tracks/reorder', reorderGoalTracksRoute);
   app.get('/api/goal-tracks/:id', getGoalTrackRoute);
   app.put('/api/goal-tracks/:id', updateGoalTrackRoute);
   app.delete('/api/goal-tracks/:id', deleteGoalTrackRoute);

--- a/src/server/repositories/goalTrackRepository.ts
+++ b/src/server/repositories/goalTrackRepository.ts
@@ -26,10 +26,25 @@ export async function createGoalTrack(
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
+  // If sortOrder was not provided, append the new track to the end of its
+  // category by using (max existing sortOrder in that category) + 1.
+  let sortOrder = data.sortOrder;
+  if (sortOrder === undefined) {
+    const existing = await collection
+      .find(scopeFilter(householdId, userId, { categoryId: data.categoryId }))
+      .toArray();
+    const maxOrder = existing.reduce((max, doc: any) => {
+      const o = typeof doc.sortOrder === 'number' ? doc.sortOrder : -1;
+      return o > max ? o : max;
+    }, -1);
+    sortOrder = maxOrder + 1;
+  }
+
   const now = new Date().toISOString();
   const document = {
     id: randomUUID(),
     ...data,
+    sortOrder,
     createdAt: now,
     updatedAt: now,
     householdId: scope.householdId,
@@ -49,7 +64,7 @@ export async function getGoalTracksByUser(
 
   const documents = await collection
     .find(scopeFilter(householdId, userId))
-    .sort({ createdAt: 1 })
+    .sort({ sortOrder: 1, createdAt: 1 })
     .toArray();
 
   return documents.map(stripScope);
@@ -110,8 +125,40 @@ export async function getGoalTracksByCategory(
 
   const documents = await collection
     .find(scopeFilter(householdId, userId, { categoryId }))
-    .sort({ createdAt: 1 })
+    .sort({ sortOrder: 1, createdAt: 1 })
     .toArray();
 
   return documents.map(stripScope);
+}
+
+/**
+ * Reorder goal tracks by assigning each provided track a new sortOrder equal
+ * to its position in the list. Tracks can span multiple categories — the
+ * caller is responsible for passing a complete ordering.
+ */
+export async function reorderGoalTracks(
+  householdId: string,
+  userId: string,
+  trackIds: string[]
+): Promise<boolean> {
+  if (trackIds.length === 0) return true;
+
+  const db = await getDb();
+  const collection = db.collection(COLLECTION_NAME);
+  const now = new Date().toISOString();
+
+  const operations = trackIds.map((id, index) => ({
+    updateOne: {
+      filter: scopeFilter(householdId, userId, { id }),
+      update: { $set: { sortOrder: index, updatedAt: now } },
+    },
+  }));
+
+  try {
+    await collection.bulkWrite(operations);
+    return true;
+  } catch (error) {
+    console.error('Failed to reorder goal tracks:', error);
+    return false;
+  }
 }

--- a/src/server/routes/__tests__/goalTracks.test.ts
+++ b/src/server/routes/__tests__/goalTracks.test.ts
@@ -17,6 +17,7 @@ import {
   addGoalToTrack,
   removeGoalFromTrack,
   reorderTrackGoals,
+  reorderGoalTracksRoute,
 } from '../goalTracks';
 import { getGoals, createGoalRoute, updateGoalRoute } from '../goals';
 import { createGoal, getGoalById } from '../../repositories/goalRepository';
@@ -43,6 +44,7 @@ describe('Goal Tracks Routes', () => {
 
     app.get('/api/goal-tracks', getGoalTracks);
     app.post('/api/goal-tracks', createGoalTrackRoute);
+    app.patch('/api/goal-tracks/reorder', reorderGoalTracksRoute);
     app.get('/api/goal-tracks/:id', getGoalTrackRoute);
     app.delete('/api/goal-tracks/:id', deleteGoalTrackRoute);
     app.post('/api/goal-tracks/:id/goals', addGoalToTrack);
@@ -108,6 +110,53 @@ describe('Goal Tracks Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.track.name).toBe('My Track');
       expect(res.body.goals).toEqual([]);
+    });
+
+    it('should assign sortOrder when creating tracks in the same category', async () => {
+      const res1 = await request(app)
+        .post('/api/goal-tracks')
+        .send({ name: 'First', categoryId: TEST_CATEGORY_ID });
+      const res2 = await request(app)
+        .post('/api/goal-tracks')
+        .send({ name: 'Second', categoryId: TEST_CATEGORY_ID });
+      const res3 = await request(app)
+        .post('/api/goal-tracks')
+        .send({ name: 'Third', categoryId: TEST_CATEGORY_ID });
+
+      expect(res1.body.sortOrder).toBe(0);
+      expect(res2.body.sortOrder).toBe(1);
+      expect(res3.body.sortOrder).toBe(2);
+
+      const listRes = await request(app).get('/api/goal-tracks');
+      expect(listRes.body.map((t: { name: string }) => t.name)).toEqual([
+        'First',
+        'Second',
+        'Third',
+      ]);
+    });
+
+    it('should reorder goal tracks within a category', async () => {
+      const t1 = await createGoalTrack({ name: 'Alpha', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const t2 = await createGoalTrack({ name: 'Beta', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const t3 = await createGoalTrack({ name: 'Gamma', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+
+      const res = await request(app)
+        .patch('/api/goal-tracks/reorder')
+        .send({ trackIds: [t3.id, t1.id, t2.id] });
+
+      expect(res.status).toBe(200);
+
+      const listRes = await request(app).get('/api/goal-tracks');
+      expect(listRes.body.map((t: { id: string }) => t.id)).toEqual([t3.id, t1.id, t2.id]);
+      expect(listRes.body.map((t: { sortOrder: number }) => t.sortOrder)).toEqual([0, 1, 2]);
+    });
+
+    it('should reject reorder request with non-array trackIds', async () => {
+      const res = await request(app)
+        .patch('/api/goal-tracks/reorder')
+        .send({ trackIds: 'not-an-array' });
+
+      expect(res.status).toBe(400);
     });
 
     it('should delete a track and release goals', async () => {

--- a/src/server/routes/goalTracks.ts
+++ b/src/server/routes/goalTracks.ts
@@ -14,6 +14,7 @@ import {
   getGoalTrackById,
   updateGoalTrack,
   deleteGoalTrack,
+  reorderGoalTracks,
 } from '../repositories/goalTrackRepository';
 import {
   getGoalById,
@@ -110,6 +111,45 @@ export async function createGoalTrackRoute(req: Request, res: Response): Promise
   } catch (error) {
     console.error('Error creating goal track:', error);
     res.status(500).json({ error: { code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create goal track' } });
+  }
+}
+
+/**
+ * PATCH /api/goal-tracks/reorder
+ * Reorder goal tracks. Body: { trackIds: string[] }
+ * Each track's sortOrder is set to its index in the provided list.
+ */
+export async function reorderGoalTracksRoute(req: Request, res: Response): Promise<void> {
+  try {
+    const { trackIds } = req.body;
+
+    if (!Array.isArray(trackIds) || !trackIds.every(id => typeof id === 'string')) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'trackIds must be an array of track IDs',
+        },
+      });
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+    const success = await reorderGoalTracks(householdId, userId, trackIds);
+
+    if (!success) {
+      res.status(500).json({
+        error: { code: 'INTERNAL_SERVER_ERROR', message: 'Failed to reorder goal tracks' },
+      });
+      return;
+    }
+
+    invalidateUserCaches(userId);
+    res.status(200).json({ message: 'Goal tracks reordered successfully' });
+  } catch (error) {
+    console.error('Error reordering goal tracks:', error);
+    res.status(500).json({
+      error: { code: 'INTERNAL_SERVER_ERROR', message: 'Failed to reorder goal tracks' },
+    });
   }
 }
 

--- a/src/utils/__tests__/goalUtils.tracks.test.ts
+++ b/src/utils/__tests__/goalUtils.tracks.test.ts
@@ -93,6 +93,41 @@ describe('buildGoalStacks with tracks', () => {
     expect(stacks[0].tracks).toHaveLength(0);
   });
 
+  it('sorts tracks by sortOrder (not createdAt) within a category', () => {
+    const tracks: GoalTrack[] = [
+      // Intentionally out of sortOrder, and with createdAt timestamps that
+      // would produce a different order if we fell back to createdAt.
+      { id: 'track-a', name: 'Alpha', categoryId: 'cat-music', sortOrder: 2, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 'track-b', name: 'Beta', categoryId: 'cat-music', sortOrder: 0, createdAt: '2026-02-01T00:00:00Z', updatedAt: '2026-02-01T00:00:00Z' },
+      { id: 'track-c', name: 'Gamma', categoryId: 'cat-music', sortOrder: 1, createdAt: '2026-03-01T00:00:00Z', updatedAt: '2026-03-01T00:00:00Z' },
+    ];
+
+    const goals: Goal[] = [
+      makeGoal('g1', 'cat-music', { trackId: 'track-a', trackOrder: 0, trackStatus: 'active' }),
+      makeGoal('g2', 'cat-music', { trackId: 'track-b', trackOrder: 0, trackStatus: 'active' }),
+      makeGoal('g3', 'cat-music', { trackId: 'track-c', trackOrder: 0, trackStatus: 'active' }),
+    ];
+
+    const stacks = buildGoalStacks({ goals, categories, tracks });
+    expect(stacks).toHaveLength(1);
+    expect(stacks[0].tracks.map(tg => tg.track.id)).toEqual(['track-b', 'track-c', 'track-a']);
+  });
+
+  it('falls back to createdAt order for tracks without sortOrder', () => {
+    const tracks: GoalTrack[] = [
+      { id: 'track-new', name: 'New', categoryId: 'cat-music', createdAt: '2026-03-01T00:00:00Z', updatedAt: '2026-03-01T00:00:00Z' },
+      { id: 'track-old', name: 'Old', categoryId: 'cat-music', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+    ];
+
+    const goals: Goal[] = [
+      makeGoal('g1', 'cat-music', { trackId: 'track-new', trackOrder: 0, trackStatus: 'active' }),
+      makeGoal('g2', 'cat-music', { trackId: 'track-old', trackOrder: 0, trackStatus: 'active' }),
+    ];
+
+    const stacks = buildGoalStacks({ goals, categories, tracks });
+    expect(stacks[0].tracks.map(tg => tg.track.id)).toEqual(['track-old', 'track-new']);
+  });
+
   it('skips completed tracks', () => {
     const tracks: GoalTrack[] = [
       { id: 'track-1', name: 'Done Track', categoryId: 'cat-music', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z', completedAt: '2026-03-01T00:00:00Z' },

--- a/src/utils/goalUtils.ts
+++ b/src/utils/goalUtils.ts
@@ -179,7 +179,12 @@ export function buildGoalStacks({
         stacks.push({
             category,
             goals: sortGoalsByOrder(catStandalone),
-            tracks: catTracks.sort((a, b) => a.track.createdAt.localeCompare(b.track.createdAt)),
+            tracks: catTracks.sort((a, b) => {
+                const orderA = a.track.sortOrder ?? Infinity;
+                const orderB = b.track.sortOrder ?? Infinity;
+                if (orderA !== orderB) return orderA - orderB;
+                return a.track.createdAt.localeCompare(b.track.createdAt);
+            }),
         });
     }
 


### PR DESCRIPTION
Tracks can now be drag-and-dropped in the Goals page the same way goals
can. Previously, tracks were always ordered by createdAt with no way for
the user to change the order; only goals inside a category were movable.

- Add a `sortOrder` field on GoalTrack, assigned at creation (append to
  end of category) and mutated by the new reorder endpoint.
- Add PATCH /api/goal-tracks/reorder backed by `reorderGoalTracks` in
  the repository, mirroring the existing goal reorder flow.
- Sort tracks in `buildGoalStacks` by sortOrder (falling back to
  createdAt for older tracks that predate the field).
- Render each track inside a `SortableTrackSection` wrapper and surface a
  GripVertical drag handle in `GoalTrackSection` so users can grab and
  drop tracks exactly like goal cards.
- Add unit tests for track sort ordering and route tests for the new
  reorder endpoint.

https://claude.ai/code/session_01WnP4fhZCBLY7Hamos5WSX9