### PR TITLE
Fix tracked-goal edit errors and ghost habit refs; enable multi-goal habits

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -16,9 +16,10 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Habit Bundles (Checklist)** — Group habits together; configure success rule (all, any, count, or percentage)
 - **Habit Bundles (Choice)** — Pick one from a set of alternatives each day
 - **Bundle Membership Management** — Move habits into/out of bundles; end or archive memberships
-- **Habit-Goal Linking** — Link habits to goals so completions count as goal progress
+- **Habit-Goal Linking** — Link habits to goals so completions count as goal progress. A single habit can be linked to multiple goals simultaneously (e.g., one "study session" habit contributing to a sequence of exam goals in a track).
 - **Habit-Routine Linking** — Link habits to routine steps so routine completion auto-logs habits
 - **Archiving** — Archive habits instead of deleting; soft-delete pattern
+- **Deletion with Goal Warning** — Deleting a habit linked to one or more goals surfaces a confirmation modal listing the affected goals. Historical progress on those goals is preserved — past entries continue to count — but the habit is removed from the goal's linked-habits list and can no longer be logged
 - **Reordering** — Drag-and-drop to reorder habits within categories
 
 ## Routines
@@ -54,7 +55,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Goal Ordering** — Drag-and-drop reorder within category groups
 - **Inactivity Coaching** — Rule-based popup suggestions when a goal is stagnant
 - **Goal Tracks** — Create ordered sequences of goals within a category (e.g., Exam 1 → Exam 2 → Exam 3)
-- **Track Progress Isolation** — Progress only counts from when a goal becomes active in a track; shared habits don't leak progress forward
+- **Track Progress Isolation** — Progress only counts from when a goal becomes active in a track; shared habits don't leak progress forward. The same habit can be linked to every goal in a track and each goal computes its own date-windowed contribution using the goal's `activeWindowStart` / `activeWindowEnd`
 - **Track Advancement** — Completing the active goal automatically activates the next goal in the sequence
 - **Track Detail View** — Dedicated page showing track progress, goal states (completed/active/locked), and drag-and-drop reordering
 - **Track Achievements** — Earn achievements for completing goal tracks (Journey Complete, Triple Step, Grand Journey)

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -138,6 +138,7 @@ HabitFlow App
 | Daily Check-in | Modal | Dashboard check-in card | Wellbeing metrics entry (sleep, mood, stress) | Wellbeing Entries |
 | Edit Goal | Modal | Goal context menu "Edit" | Modify goal title, target, deadline | Goals |
 | Delete Goal Confirm | Modal | Goal context menu "Delete" | Deletion confirmation dialog | Goals |
+| Delete Habit Confirm | Modal | Trash button on a habit that is linked to one or more goals (shown after the click-twice confirm so the user sees which goals are affected) | Lists the affected goals and explains historical progress on them is preserved before allowing deletion | Habits, Goals |
 | Completed Habits | Modal | Routine runner completion | Summary of habits logged during routine | Habits, Entries |
 | Settings | Modal | Header settings icon | Preferences, API keys, data management | User config |
 | Info / Tutorial | Modal | Header info icon | App tutorial and feature explanations | — |

--- a/src/components/DeleteHabitConfirmModal.tsx
+++ b/src/components/DeleteHabitConfirmModal.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { X, AlertTriangle, Loader2, Target } from 'lucide-react';
+
+interface DeleteHabitConfirmModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void>;
+    habitName: string;
+    linkedGoalTitles: string[];
+}
+
+/**
+ * Confirmation modal for deleting a habit that is linked to one or more goals.
+ *
+ * This modal surfaces the link to the user — deleting a habit without warning
+ * was a trust issue because goals continued to reference the now-missing habit
+ * silently. We explicitly tell the user:
+ *   1. Which goals are affected, by title.
+ *   2. That historical progress on those goals is PRESERVED — past entries
+ *      continue to count toward progress even after the habit is deleted.
+ *   3. That the habit will no longer appear in the goal's habit list and
+ *      can't be logged going forward.
+ *
+ * For habits that are NOT linked to any goal, the caller keeps the lighter
+ * "click trash twice to confirm" flow — this modal is only shown when there's
+ * actually a linkage the user should know about.
+ */
+export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = ({
+    isOpen,
+    onClose,
+    onConfirm,
+    habitName,
+    linkedGoalTitles,
+}) => {
+    const [isDeleting, setIsDeleting] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+
+    if (!isOpen) return null;
+
+    const handleConfirm = async () => {
+        setIsDeleting(true);
+        setError(null);
+        try {
+            await onConfirm();
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to delete habit';
+            setError(errorMessage);
+            console.error('Error deleting habit:', err);
+        } finally {
+            setIsDeleting(false);
+        }
+    };
+
+    const handleCancel = () => {
+        setError(null);
+        onClose();
+    };
+
+    return (
+        <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+                <div className="flex items-center justify-between mb-6">
+                    <h3 className="text-xl font-bold text-white">Delete Habit</h3>
+                    <button
+                        onClick={handleCancel}
+                        disabled={isDeleting}
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors disabled:opacity-50 -mr-2"
+                        aria-label="Close"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <div className="space-y-4">
+                    {/* Warning */}
+                    <div className="p-4 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-start gap-3">
+                        <AlertTriangle className="text-amber-400 flex-shrink-0 mt-0.5" size={20} />
+                        <div className="flex-1">
+                            <div className="text-amber-400 font-medium mb-1">This habit is linked to a goal</div>
+                            <div className="text-white text-sm">
+                                Deleting <span className="font-semibold">"{habitName}"</span> will remove it from the following goal{linkedGoalTitles.length === 1 ? '' : 's'}. Past entries continue to count toward goal progress — historical progress is preserved — but you won't be able to log new entries for this habit.
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Linked goals list */}
+                    <div className="p-3 bg-neutral-800/50 rounded-lg">
+                        <div className="text-neutral-400 text-xs mb-2">Linked goal{linkedGoalTitles.length === 1 ? '' : 's'}</div>
+                        <ul className="space-y-1.5">
+                            {linkedGoalTitles.map((title, idx) => (
+                                <li key={idx} className="flex items-center gap-2 text-white text-sm">
+                                    <Target size={14} className="text-emerald-400 flex-shrink-0" />
+                                    <span className="truncate">{title}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    {/* Error display */}
+                    {error && (
+                        <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg flex items-start gap-3">
+                            <AlertTriangle className="text-red-400 flex-shrink-0 mt-0.5" size={16} />
+                            <div className="flex-1">
+                                <div className="text-red-400 text-sm">{error}</div>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Buttons */}
+                    <div className="flex items-center gap-3 pt-2">
+                        <button
+                            type="button"
+                            onClick={handleCancel}
+                            disabled={isDeleting}
+                            className="flex-1 px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleConfirm}
+                            disabled={isDeleting}
+                            className="flex-1 px-4 py-2 bg-red-500 hover:bg-red-400 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                        >
+                            {isDeleting ? (
+                                <>
+                                    <Loader2 className="animate-spin" size={16} />
+                                    Deleting...
+                                </>
+                            ) : (
+                                'Delete Habit'
+                            )}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -9,10 +9,12 @@ import { BundlePickerModal } from './BundlePickerModal';
 import { NumericInputPopover } from './NumericInputPopover';
 import { HabitHistoryModal } from './HabitHistoryModal';
 import { HabitLogModal } from './HabitLogModal';
+import { DeleteHabitConfirmModal } from './DeleteHabitConfirmModal';
 import { useToast } from './Toast';
 import { useHabitStore } from '../store/HabitContext';
 import { useRoutineStore } from '../store/RoutineContext';
 import { useProgressOverview } from '../lib/useProgressOverview';
+import { useGoalsWithProgress } from '../lib/useGoalsWithProgress';
 import { useDashboardPrefs } from '../store/DashboardPrefsContext';
 
 
@@ -812,6 +814,7 @@ export const TrackerGrid = ({
     } = useHabitStore();
     const { routines } = useRoutineStore(); // Ensure we have routines for context menu
     const { data: progressData, refresh: refreshProgress } = useProgressOverview();
+    const { data: goalsWithProgress } = useGoalsWithProgress();
     const { showToast } = useToast();
 
     // Debounce refreshProgress to coalesce rapid mutations (e.g., toggling multiple cells)
@@ -882,6 +885,44 @@ export const TrackerGrid = ({
 
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
     const [deleteMode, setDeleteMode] = useState(false);
+    // Pending confirmation for deleting a habit that is linked to one or more
+    // goals. Shown via DeleteHabitConfirmModal after the user clicks trash twice
+    // — the modal surfaces affected goals so the user understands what gets
+    // disconnected (historical progress is still preserved by design).
+    const [pendingDeleteHabit, setPendingDeleteHabit] = useState<{
+        habit: Habit;
+        linkedGoalTitles: string[];
+    } | null>(null);
+
+    /**
+     * Wrapper around deleteHabit that surfaces a confirmation modal when the
+     * habit is linked to any goal. Used in place of the raw deleteHabit when
+     * passing down to child rows.
+     *
+     * - Unlinked habit → delete immediately (existing "click-twice" flow in
+     *   HabitActionButtons still protects against accidental clicks).
+     * - Linked habit → open DeleteHabitConfirmModal listing affected goals.
+     *   Returns a resolved Promise so the child's click-twice state resets.
+     */
+    const handleDeleteHabitRequest = useCallback(async (id: string): Promise<void> => {
+        const habit = habits.find(h => h.id === id);
+        if (!habit) {
+            await deleteHabit(id);
+            return;
+        }
+        const linkedGoals = (goalsWithProgress || []).filter(gwp =>
+            gwp.goal.linkedHabitIds?.includes(id)
+        );
+        if (linkedGoals.length === 0) {
+            await deleteHabit(id);
+            return;
+        }
+        setPendingDeleteHabit({
+            habit,
+            linkedGoalTitles: linkedGoals.map(gwp => gwp.goal.title),
+        });
+    }, [habits, goalsWithProgress, deleteHabit]);
+
     const [historyModalHabitId, setHistoryModalHabitId] = useState<string | null>(null);
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
     const [choiceLogState, setChoiceLogState] = useState<{ habit: Habit; date: string } | null>(null);
@@ -1264,7 +1305,7 @@ export const TrackerGrid = ({
                                                 logs={logs}
                                                 dates={dates}
                                                 handleCellClick={handleCellClickDirect}
-                                                deleteHabit={deleteHabit}
+                                                deleteHabit={handleDeleteHabitRequest}
                                                 deleteConfirmId={deleteConfirmId}
                                                 setDeleteConfirmId={setDeleteConfirmId}
                                                 onEditHabit={onEditHabit}
@@ -1547,6 +1588,19 @@ export const TrackerGrid = ({
                 onClose={() => setBundlePickerHabit(null)}
                 habitId={bundlePickerHabit?.id ?? ''}
                 habitName={bundlePickerHabit?.name ?? ''}
+            />
+
+            {/* Delete Habit Confirmation Modal (shown only for habits linked to goals) */}
+            <DeleteHabitConfirmModal
+                isOpen={!!pendingDeleteHabit}
+                onClose={() => setPendingDeleteHabit(null)}
+                onConfirm={async () => {
+                    if (!pendingDeleteHabit) return;
+                    await deleteHabit(pendingDeleteHabit.habit.id);
+                    setPendingDeleteHabit(null);
+                }}
+                habitName={pendingDeleteHabit?.habit.name ?? ''}
+                linkedGoalTitles={pendingDeleteHabit?.linkedGoalTitles ?? []}
             />
         </div>
     );

--- a/src/components/goals/EditGoalModal.tsx
+++ b/src/components/goals/EditGoalModal.tsx
@@ -123,17 +123,15 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
         // Event date is optional for one-time goals
         // No validation needed
 
-        // --- FIX FOR GHOST HABIT IDs ---
-        // Filter out any IDs that don't exist in the current habits list.
-        // This removes deleted/stale habits that cause backend validation errors.
-        // We only filter if we have loaded habits to avoid accidental clearing.
-        let validSelectedIds = selectedHabitIds;
-        if (habits.length > 0) {
-            validSelectedIds = selectedHabitIds.filter(id => habits.some(h => h.id === id));
-        }
-
-        if (validSelectedIds.length === 0) {
-            setError('At least one valid habit must be linked');
+        // Require at least one ACTIVE (non-deleted) habit linked. Deleted-habit
+        // IDs that were already in linkedHabitIds are allowed to persist on save
+        // — the backend accepts pre-existing stale IDs so that deleted habits'
+        // historical entries continue to contribute to goal progress. Stripping
+        // them here previously silently erased historical progress on every edit.
+        const hasActiveLinkedHabit = habits.length === 0
+            || selectedHabitIds.some(id => habits.some(h => h.id === id));
+        if (!hasActiveLinkedHabit) {
+            setError('At least one active habit must be linked');
             return;
         }
 
@@ -145,7 +143,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                 notes: description,
                 targetValue: goal.type === 'onetime' ? undefined : numTarget,
                 unit: goal.type === 'onetime' ? undefined : unit,
-                linkedHabitIds: validSelectedIds, // Use sanitized IDs
+                linkedHabitIds: selectedHabitIds,
                 deadline: deadline || undefined,
                 categoryId: categoryId || undefined,
             });

--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -222,7 +222,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                                         {progress.percent}%
                                     </span>
                                     <span className={goalMetadataClasses}>
-                                        {goal.linkedHabitIds.length} {goal.linkedHabitIds.length === 1 ? 'habit' : 'habits'}
+                                        {linkedHabits.length} {linkedHabits.length === 1 ? 'habit' : 'habits'}
                                     </span>
                                     {goal.deadline && (
                                         <span className="px-2 py-0.5 bg-neutral-700/50 text-neutral-300 rounded text-xs">

--- a/src/server/repositories/habitRepository.ts
+++ b/src/server/repositories/habitRepository.ts
@@ -8,9 +8,10 @@
 import type { ClientSession } from 'mongodb';
 import { getDb } from '../lib/mongoClient';
 import { scopeFilter, requireScope } from '../lib/scoping';
-import type { Habit } from '../../models/persistenceTypes';
+import { MONGO_COLLECTIONS, type Habit, type Goal } from '../../models/persistenceTypes';
 
 const COLLECTION_NAME = 'habits';
+const GOALS_COLLECTION = MONGO_COLLECTIONS.GOALS;
 
 function stripScope(doc: any): Habit {
   const { _id, userId: _, householdId: __, ...habit } = doc;
@@ -241,8 +242,17 @@ export async function recoverCategoryDeletedHabits(
 }
 
 /**
- * Set linkedGoalId on all specified habits.
- * Called when a goal is created or updated to keep the bidirectional link in sync.
+ * Set linkedGoalId on specified habits as a "primary goal" UI hint — but
+ * ONLY on habits that don't already point at another goal that still
+ * references them. This preserves the multi-goal case: one habit linked
+ * to multiple goals keeps a stable, valid primary-goal badge instead of
+ * flipping every time any of those goals is edited.
+ *
+ * Note: `linkedGoalId` is purely UI metadata. Progress computation uses
+ * `Goal.linkedHabitIds` (the authoritative many-to-many side). This helper
+ * just keeps the UI hint from going stale.
+ *
+ * Called when a goal is created or updated.
  */
 export async function linkHabitsToGoal(
   habitIds: string[],
@@ -253,10 +263,56 @@ export async function linkHabitsToGoal(
   if (habitIds.length === 0) return 0;
 
   const db = await getDb();
-  const collection = db.collection(COLLECTION_NAME);
+  const habitsCollection = db.collection(COLLECTION_NAME);
+  const goalsCollection = db.collection(GOALS_COLLECTION);
 
-  const result = await collection.updateMany(
-    scopeFilter(householdId, userId, { id: { $in: habitIds } }),
+  // Fetch the habits we're linking and their existing linkedGoalId values.
+  const habits = await habitsCollection
+    .find(scopeFilter(householdId, userId, { id: { $in: habitIds } }))
+    .project({ id: 1, linkedGoalId: 1 })
+    .toArray();
+
+  // Collect existing linkedGoalIds that are NOT the goal we're now linking to.
+  const existingLinkedGoalIds = Array.from(
+    new Set(
+      habits
+        .map((h: any) => h.linkedGoalId as string | undefined)
+        .filter((gid): gid is string => !!gid && gid !== goalId)
+    )
+  );
+
+  // Fetch those goals so we can check whether they still reference the habit.
+  const existingGoals = existingLinkedGoalIds.length > 0
+    ? await goalsCollection
+        .find(scopeFilter(householdId, userId, { id: { $in: existingLinkedGoalIds } }))
+        .project({ id: 1, linkedHabitIds: 1 })
+        .toArray()
+    : [];
+  const goalsById = new Map<string, { linkedHabitIds?: string[] }>(
+    existingGoals.map((g: any) => [g.id, { linkedHabitIds: g.linkedHabitIds }])
+  );
+
+  // Decide which habits should receive linkedGoalId = goalId.
+  // Update only habits whose current linkedGoalId is missing OR points to a
+  // goal that no longer contains this habit in linkedHabitIds.
+  const habitIdsToUpdate: string[] = [];
+  for (const h of habits) {
+    const current = (h as any).linkedGoalId as string | undefined;
+    if (!current || current === goalId) {
+      habitIdsToUpdate.push((h as any).id);
+      continue;
+    }
+    const otherGoal = goalsById.get(current);
+    const stillLinked = otherGoal?.linkedHabitIds?.includes((h as any).id) ?? false;
+    if (!stillLinked) {
+      habitIdsToUpdate.push((h as any).id);
+    }
+  }
+
+  if (habitIdsToUpdate.length === 0) return 0;
+
+  const result = await habitsCollection.updateMany(
+    scopeFilter(householdId, userId, { id: { $in: habitIdsToUpdate } }),
     { $set: { linkedGoalId: goalId } }
   );
 
@@ -264,8 +320,13 @@ export async function linkHabitsToGoal(
 }
 
 /**
- * Clear linkedGoalId from all habits that reference a given goal.
- * Called when a goal is deleted to prevent orphaned references.
+ * Clear linkedGoalId from habits that currently point at the given goal —
+ * but only if no OTHER goal still references the habit. If another goal does
+ * reference it, switch linkedGoalId to that other goal instead of clearing
+ * it, so the "primary goal" UI hint stays valid for multi-goal habits.
+ *
+ * Called when a goal is deleted, or when a habit is removed from a goal's
+ * linkedHabitIds list.
  */
 export async function unlinkHabitsFromGoal(
   goalId: string,
@@ -273,12 +334,57 @@ export async function unlinkHabitsFromGoal(
   userId: string
 ): Promise<number> {
   const db = await getDb();
-  const collection = db.collection(COLLECTION_NAME);
+  const habitsCollection = db.collection(COLLECTION_NAME);
+  const goalsCollection = db.collection(GOALS_COLLECTION);
 
-  const result = await collection.updateMany(
-    scopeFilter(householdId, userId, { linkedGoalId: goalId }),
-    { $unset: { linkedGoalId: '' } }
-  );
+  // Find habits currently pointing at this goal.
+  const habitsPointingHere = await habitsCollection
+    .find(scopeFilter(householdId, userId, { linkedGoalId: goalId }))
+    .project({ id: 1 })
+    .toArray();
 
-  return result.modifiedCount;
+  if (habitsPointingHere.length === 0) return 0;
+
+  const affectedHabitIds = habitsPointingHere.map((h: any) => h.id as string);
+
+  // Find other goals that still reference any of these habits.
+  const otherGoals = (await goalsCollection
+    .find(
+      scopeFilter(householdId, userId, {
+        id: { $ne: goalId },
+        linkedHabitIds: { $in: affectedHabitIds },
+      })
+    )
+    .project({ id: 1, linkedHabitIds: 1 })
+    .toArray()) as unknown as Array<Pick<Goal, 'id' | 'linkedHabitIds'>>;
+
+  // For each affected habit, pick a replacement goal (deterministically: the
+  // first other goal that references it) or clear linkedGoalId if none found.
+  const bulkOps: any[] = [];
+  let modified = 0;
+  for (const habitId of affectedHabitIds) {
+    const replacement = otherGoals.find(g => g.linkedHabitIds?.includes(habitId));
+    if (replacement) {
+      bulkOps.push({
+        updateOne: {
+          filter: scopeFilter(householdId, userId, { id: habitId }),
+          update: { $set: { linkedGoalId: replacement.id } },
+        },
+      });
+    } else {
+      bulkOps.push({
+        updateOne: {
+          filter: scopeFilter(householdId, userId, { id: habitId }),
+          update: { $unset: { linkedGoalId: '' } },
+        },
+      });
+    }
+    modified += 1;
+  }
+
+  if (bulkOps.length > 0) {
+    await habitsCollection.bulkWrite(bulkOps);
+  }
+
+  return modified;
 }

--- a/src/server/routes/__tests__/goals.trackedEdit.test.ts
+++ b/src/server/routes/__tests__/goals.trackedEdit.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for tracked-goal edit validation and ghost habit-ID preservation.
+ *
+ * These cover three tightly-related fixes:
+ *
+ *  1. PART A — The category gate for tracked goals should only reject when the
+ *     category is ACTUALLY changing. Previously, re-sending the unchanged
+ *     categoryId (the Edit Goal modal does this on every save) would
+ *     incorrectly trip a "Cannot change category of a goal that belongs to a
+ *     track" error on any edit to a tracked goal.
+ *
+ *  2. PART B — The linkedHabitIds validator should only reject NEWLY-added
+ *     IDs that don't resolve to a live habit. Pre-existing stale IDs (IDs of
+ *     habits that were deleted after being linked) must be allowed to persist
+ *     so that deleted habits' historical entries continue to contribute to
+ *     goal progress — that is the documented design intent in
+ *     `deleteHabitRoute` and `computeGoalProgressV2`.
+ *
+ *  3. PART E — The multi-goal-aware bidirectional sync helpers
+ *     (`linkHabitsToGoal` / `unlinkHabitsFromGoal`) must preserve a stable
+ *     `Habit.linkedGoalId` UI hint when the habit is linked to multiple goals.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import { updateGoalRoute } from '../goals';
+import { createGoal } from '../../repositories/goalRepository';
+import { createGoalTrack } from '../../repositories/goalTrackRepository';
+import {
+  createHabit,
+  deleteHabit,
+  getHabitById,
+  linkHabitsToGoal,
+  unlinkHabitsFromGoal,
+} from '../../repositories/habitRepository';
+import { MONGO_COLLECTIONS, type Goal } from '../../../models/persistenceTypes';
+
+const HOUSEHOLD = 'test-household-goals-tracked-edit';
+const USER = 'test-user-goals-tracked-edit';
+const CATEGORY_MUSIC = 'cat-music';
+const CATEGORY_FITNESS = 'cat-fitness';
+
+let app: Express;
+
+describe('Tracked goal edit validation & multi-goal sync', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).householdId = HOUSEHOLD;
+      (req as any).userId = USER;
+      next();
+    });
+    app.put('/api/goals/:id', updateGoalRoute);
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await Promise.all([
+      db.collection(MONGO_COLLECTIONS.GOALS).deleteMany({ householdId: HOUSEHOLD, userId: USER }),
+      db.collection(MONGO_COLLECTIONS.GOAL_TRACKS).deleteMany({ householdId: HOUSEHOLD, userId: USER }),
+      db.collection('habits').deleteMany({ householdId: HOUSEHOLD, userId: USER }),
+    ]);
+  });
+
+  async function makeHabit(name: string, categoryId: string) {
+    return createHabit(
+      {
+        name,
+        categoryId,
+        goal: { type: 'boolean', frequency: 'daily', target: 1 },
+      },
+      HOUSEHOLD,
+      USER
+    );
+  }
+
+  async function makeTrack(name: string, categoryId: string) {
+    return createGoalTrack({ name, categoryId }, HOUSEHOLD, USER);
+  }
+
+  async function makeGoal(
+    title: string,
+    categoryId: string,
+    linkedHabitIds: string[] = [],
+    extra: Partial<Goal> = {}
+  ) {
+    return createGoal(
+      {
+        title,
+        type: 'onetime',
+        linkedHabitIds,
+        categoryId,
+        ...extra,
+      } as Omit<Goal, 'id' | 'createdAt'>,
+      HOUSEHOLD,
+      USER
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Part A — Category gate only fires when category actually changes
+  // -------------------------------------------------------------------------
+
+  describe('Part A: tracked-goal category gate', () => {
+    it('allows PATCH that re-sends the unchanged categoryId on a tracked goal', async () => {
+      const habit = await makeHabit('Deep work on music', CATEGORY_MUSIC);
+      const track = await makeTrack('Music Releases', CATEGORY_MUSIC);
+      const goal = await makeGoal('Release Tribe Wobble', CATEGORY_MUSIC, [habit.id], {
+        trackId: track.id,
+        trackStatus: 'active',
+      });
+
+      const res = await request(app)
+        .put(`/api/goals/${goal.id}`)
+        .send({
+          title: 'Release Tribe Wobble (updated)',
+          categoryId: CATEGORY_MUSIC, // unchanged — should NOT trip the gate
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.goal.title).toBe('Release Tribe Wobble (updated)');
+      expect(res.body.goal.categoryId).toBe(CATEGORY_MUSIC);
+    });
+
+    it('rejects PATCH that tries to change the categoryId on a tracked goal', async () => {
+      const habit = await makeHabit('Deep work on music', CATEGORY_MUSIC);
+      const track = await makeTrack('Music Releases', CATEGORY_MUSIC);
+      const goal = await makeGoal('Release Tribe Wobble', CATEGORY_MUSIC, [habit.id], {
+        trackId: track.id,
+        trackStatus: 'active',
+      });
+
+      const res = await request(app)
+        .put(`/api/goals/${goal.id}`)
+        .send({ categoryId: CATEGORY_FITNESS });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+      expect(res.body.error.message).toMatch(/Cannot change category of a goal that belongs to a track/);
+    });
+
+    it('allows categoryId changes on NON-tracked goals', async () => {
+      const habit = await makeHabit('Random habit', CATEGORY_FITNESS);
+      const goal = await makeGoal('Random goal', CATEGORY_FITNESS, [habit.id]);
+
+      const res = await request(app)
+        .put(`/api/goals/${goal.id}`)
+        .send({ categoryId: CATEGORY_MUSIC });
+
+      expect(res.status).toBe(200);
+      expect(res.body.goal.categoryId).toBe(CATEGORY_MUSIC);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Part B — Pre-existing stale habit IDs may persist in linkedHabitIds
+  // -------------------------------------------------------------------------
+
+  describe('Part B: ghost habit-ID preservation in linkedHabitIds', () => {
+    it('allows PATCH that keeps a pre-existing linkedHabitId whose habit has been deleted', async () => {
+      const habitA = await makeHabit('Habit A', CATEGORY_MUSIC);
+      const habitB = await makeHabit('Habit B', CATEGORY_MUSIC);
+      const goal = await makeGoal('Music goal', CATEGORY_MUSIC, [habitA.id, habitB.id]);
+
+      // Delete habitA — its ID is now stale but must be allowed to persist
+      await deleteHabit(habitA.id, HOUSEHOLD, USER);
+
+      const res = await request(app)
+        .put(`/api/goals/${goal.id}`)
+        .send({
+          title: 'Music goal (edited)',
+          linkedHabitIds: [habitA.id, habitB.id], // stale + live, unchanged from goal
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.goal.linkedHabitIds).toEqual([habitA.id, habitB.id]);
+    });
+
+    it('rejects PATCH that ADDS a non-existent habit ID', async () => {
+      const habitA = await makeHabit('Habit A', CATEGORY_MUSIC);
+      const goal = await makeGoal('Music goal', CATEGORY_MUSIC, [habitA.id]);
+
+      const res = await request(app)
+        .put(`/api/goals/${goal.id}`)
+        .send({
+          linkedHabitIds: [habitA.id, 'nonexistent-habit-id'],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toMatch(/nonexistent-habit-id/);
+    });
+
+    it('allows PATCH mixing pre-existing stale IDs with newly added valid IDs', async () => {
+      const habitA = await makeHabit('Habit A', CATEGORY_MUSIC);
+      const habitB = await makeHabit('Habit B', CATEGORY_MUSIC);
+      const goal = await makeGoal('Music goal', CATEGORY_MUSIC, [habitA.id]);
+
+      // Delete habitA so it becomes stale
+      await deleteHabit(habitA.id, HOUSEHOLD, USER);
+
+      // Now add habitB alongside the stale habitA reference
+      const res = await request(app)
+        .put(`/api/goals/${goal.id}`)
+        .send({
+          linkedHabitIds: [habitA.id, habitB.id],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.goal.linkedHabitIds).toEqual([habitA.id, habitB.id]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Part E — Multi-goal-aware linkedGoalId sync
+  // -------------------------------------------------------------------------
+
+  describe('Part E: multi-goal-aware linkedGoalId sync helpers', () => {
+    it('linkHabitsToGoal does not clobber linkedGoalId when another goal still references the habit', async () => {
+      const habit = await makeHabit('Deep work on music', CATEGORY_MUSIC);
+      const goalA = await makeGoal('Song A', CATEGORY_MUSIC, [habit.id]);
+      const goalB = await makeGoal('Song B', CATEGORY_MUSIC, []);
+
+      // Link habit to goalA first
+      await linkHabitsToGoal([habit.id], goalA.id, HOUSEHOLD, USER);
+
+      // Refresh goalB to include the habit in its linkedHabitIds, then sync
+      const db = await getTestDb();
+      await db.collection(MONGO_COLLECTIONS.GOALS).updateOne(
+        { id: goalB.id, householdId: HOUSEHOLD, userId: USER },
+        { $set: { linkedHabitIds: [habit.id] } }
+      );
+      await linkHabitsToGoal([habit.id], goalB.id, HOUSEHOLD, USER);
+
+      // linkedGoalId should still point at goalA, because goalA still references the habit
+      const h = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(h?.linkedGoalId).toBe(goalA.id);
+    });
+
+    it('unlinkHabitsFromGoal switches linkedGoalId to another referencing goal instead of clearing', async () => {
+      const habit = await makeHabit('Deep work on music', CATEGORY_MUSIC);
+      const goalA = await makeGoal('Song A', CATEGORY_MUSIC, [habit.id]);
+      const goalB = await makeGoal('Song B', CATEGORY_MUSIC, [habit.id]);
+
+      // habit is initially linked to goalA via linkHabitsToGoal
+      await linkHabitsToGoal([habit.id], goalA.id, HOUSEHOLD, USER);
+      let h = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(h?.linkedGoalId).toBe(goalA.id);
+
+      // Now unlink from goalA — goalB still references the habit, so linkedGoalId
+      // should switch to goalB, not be cleared
+      await unlinkHabitsFromGoal(goalA.id, HOUSEHOLD, USER);
+
+      h = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(h?.linkedGoalId).toBe(goalB.id);
+    });
+
+    it('unlinkHabitsFromGoal clears linkedGoalId when no other goal references the habit', async () => {
+      const habit = await makeHabit('Orphan habit', CATEGORY_MUSIC);
+      const goalA = await makeGoal('Only goal', CATEGORY_MUSIC, [habit.id]);
+
+      await linkHabitsToGoal([habit.id], goalA.id, HOUSEHOLD, USER);
+      let h = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(h?.linkedGoalId).toBe(goalA.id);
+
+      await unlinkHabitsFromGoal(goalA.id, HOUSEHOLD, USER);
+      h = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(h?.linkedGoalId).toBeUndefined();
+    });
+
+    it('full multi-goal lifecycle: link to 3 goals, unlink progressively', async () => {
+      const habit = await makeHabit('Deep work on music', CATEGORY_MUSIC);
+      const goalA = await makeGoal('Song A', CATEGORY_MUSIC, [habit.id]);
+      const goalB = await makeGoal('Song B', CATEGORY_MUSIC, [habit.id]);
+      const goalC = await makeGoal('Song C', CATEGORY_MUSIC, [habit.id]);
+
+      // Start: goalA, goalB, goalC all reference habit via linkedHabitIds.
+      // Link to goalA first — habit.linkedGoalId = goalA
+      await linkHabitsToGoal([habit.id], goalA.id, HOUSEHOLD, USER);
+      expect((await getHabitById(habit.id, HOUSEHOLD, USER))?.linkedGoalId).toBe(goalA.id);
+
+      // Link to goalB — should NOT overwrite (goalA still references habit)
+      await linkHabitsToGoal([habit.id], goalB.id, HOUSEHOLD, USER);
+      expect((await getHabitById(habit.id, HOUSEHOLD, USER))?.linkedGoalId).toBe(goalA.id);
+
+      // Link to goalC — still should not overwrite
+      await linkHabitsToGoal([habit.id], goalC.id, HOUSEHOLD, USER);
+      expect((await getHabitById(habit.id, HOUSEHOLD, USER))?.linkedGoalId).toBe(goalA.id);
+
+      // Now remove habit from goalA (via goal update path: reset linkedHabitIds = [])
+      const db = await getTestDb();
+      await db.collection(MONGO_COLLECTIONS.GOALS).updateOne(
+        { id: goalA.id, householdId: HOUSEHOLD, userId: USER },
+        { $set: { linkedHabitIds: [] } }
+      );
+      await unlinkHabitsFromGoal(goalA.id, HOUSEHOLD, USER);
+
+      // linkedGoalId should switch to goalB or goalC (both still reference the habit)
+      const afterUnlinkA = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect([goalB.id, goalC.id]).toContain(afterUnlinkA?.linkedGoalId);
+
+      // Remove from whichever goal linkedGoalId currently points at
+      const currentOwner = afterUnlinkA?.linkedGoalId as string;
+      await db.collection(MONGO_COLLECTIONS.GOALS).updateOne(
+        { id: currentOwner, householdId: HOUSEHOLD, userId: USER },
+        { $set: { linkedHabitIds: [] } }
+      );
+      await unlinkHabitsFromGoal(currentOwner, HOUSEHOLD, USER);
+
+      // One goal still references it
+      const afterSecond = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(afterSecond?.linkedGoalId).toBeDefined();
+      expect([goalB.id, goalC.id]).toContain(afterSecond?.linkedGoalId);
+      expect(afterSecond?.linkedGoalId).not.toBe(currentOwner);
+
+      // Remove from the last one
+      const lastOwner = afterSecond?.linkedGoalId as string;
+      await db.collection(MONGO_COLLECTIONS.GOALS).updateOne(
+        { id: lastOwner, householdId: HOUSEHOLD, userId: USER },
+        { $set: { linkedHabitIds: [] } }
+      );
+      await unlinkHabitsFromGoal(lastOwner, HOUSEHOLD, USER);
+
+      // Now linkedGoalId should be cleared
+      const finalState = await getHabitById(habit.id, HOUSEHOLD, USER);
+      expect(finalState?.linkedGoalId).toBeUndefined();
+    });
+  });
+});

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -642,11 +642,16 @@ export async function updateGoalRoute(req: Request, res: Response): Promise<void
       patch.categoryId = req.body.categoryId || undefined;
     }
 
-    // Block category changes for tracked goals (must match track category)
+    // Block category changes for tracked goals (must match track category).
+    // Only reject when the category is ACTUALLY changing — the Edit Goal modal
+    // re-sends the existing categoryId on every save, so checking presence alone
+    // produces false-positive errors on ordinary edits (title, habits, deadline).
     if (patch.categoryId !== undefined) {
       const { householdId: hid, userId: uid } = getRequestIdentity(req);
       const existingForCategoryCheck = await getGoalById(id, hid, uid);
-      if (existingForCategoryCheck?.trackId) {
+      const currentCat = existingForCategoryCheck?.categoryId ?? undefined;
+      const newCat = patch.categoryId ?? undefined;
+      if (existingForCategoryCheck?.trackId && newCat !== currentCat) {
         res.status(400).json({
           error: {
             code: 'VALIDATION_ERROR',
@@ -707,9 +712,21 @@ export async function updateGoalRoute(req: Request, res: Response): Promise<void
       }
     }
 
-    // If linkedHabitIds is being updated, validate that all IDs exist
+    // If linkedHabitIds is being updated, validate only the NEWLY-ADDED IDs.
+    // Pre-existing IDs are allowed through even if they now reference a deleted
+    // habit: deleted habits' entries are intentionally preserved as historical
+    // contributions to goal progress (see `computeGoalProgressV2` and the comment
+    // in `deleteHabitRoute`). Stripping those refs on every edit would silently
+    // erase historical progress, which was the cause of the previous "GHOST HABIT
+    // IDs" frontend workaround.
+    let previousLinkedHabitIds: string[] | null = null;
     if (patch.linkedHabitIds) {
-      const invalidHabitIds = await validateHabitIdsExist(patch.linkedHabitIds, householdId, userId);
+      const existing = existingGoal || await getGoalById(id, householdId, userId);
+      previousLinkedHabitIds = existing?.linkedHabitIds || [];
+
+      const priorSet = new Set(previousLinkedHabitIds);
+      const newlyAddedIds = patch.linkedHabitIds.filter((hid) => !priorSet.has(hid));
+      const invalidHabitIds = await validateHabitIdsExist(newlyAddedIds, householdId, userId);
       if (invalidHabitIds.length > 0) {
         res.status(400).json({
           error: {
@@ -719,13 +736,6 @@ export async function updateGoalRoute(req: Request, res: Response): Promise<void
         });
         return;
       }
-    }
-
-    // Fetch existing goal to diff linkedHabitIds if they're changing
-    let previousLinkedHabitIds: string[] | null = null;
-    if (patch.linkedHabitIds) {
-      const existing = existingGoal || await getGoalById(id, householdId, userId);
-      previousLinkedHabitIds = existing?.linkedHabitIds || [];
     }
 
     let goal = await updateGoal(id, householdId, userId, patch);

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -19,3 +19,21 @@
 **Problem**: `EditGoalModal` displayed ALL habits (no `archived` filter) while every other view filtered with `!h.archived`. This made archived habits visible only in the goal modal, confusing users.
 
 **Pattern**: Always filter `!h.archived` when displaying habits. If a component uses `habits` from the store, apply the archived filter consistently.
+
+## "Workarounds" That Destroy Data (2026-04-10)
+
+**Problem**: `EditGoalModal` had a comment-labeled "FIX FOR GHOST HABIT IDs" that stripped any linkedHabitId not present in the active habits list before saving. It existed to work around a backend `validateHabitIdsExist` that rejected any save whose `linkedHabitIds` contained a now-deleted habit. The workaround quietly erased historical progress contributions from deleted habits — the EXACT opposite of the documented invariant ("entries from deleted habits are preserved so goal progress still includes historical contributions" — see `deleteHabitRoute` and `computeGoalProgressV2`). Every edit of a tracked goal silently dropped preserved history.
+
+**Pattern**: When a client-side workaround exists to sidestep a backend validation error, treat it as a symptom, not a fix. Ask: *what invariant is the validator protecting, and does stripping data to appease it violate a different invariant?* The correct fix was in the backend — only validate NEWLY-added IDs, allow pre-existing stale IDs to persist.
+
+## Category Gate on Unchanged Values (2026-04-10)
+
+**Problem**: The tracked-goal category gate rejected any PATCH whose body contained `categoryId` on a goal belonging to a track, without comparing the new value to the existing one. The Edit Goal modal always re-sent `categoryId` on every save — so every edit to a tracked goal (title, description, linked habits, deadline) tripped a "Cannot change category of a goal that belongs to a track" error. Users could not edit tracked goals at all.
+
+**Pattern**: Immutability gates in PATCH handlers must compare the new value to the existing value before rejecting. `!== undefined` tells you the field is *present* in the patch, not that it's *changing*. Fetch the existing row, compute `if (existing.x !== patch.x)`, then gate.
+
+## Bidirectional Sync That Breaks Many-to-Many (2026-04-10)
+
+**Problem**: `Goal.linkedHabitIds` supports many-to-many (one habit contributing to many goals — the core workflow behind Goal Tracks), but `Habit.linkedGoalId` is singular. The sync helpers `linkHabitsToGoal` / `unlinkHabitsFromGoal` treated the singular side as authoritative: linking a shared habit to a second goal overwrote `linkedGoalId`, and removing a shared habit from any goal cleared `linkedGoalId` wholesale — even if other goals still referenced the habit. Progress math was unaffected (it uses `linkedHabitIds`), but the "primary goal" UI hint lied to users.
+
+**Pattern**: When the authoritative relationship is many-to-many (array on one side) but there's also a singular denormalized "primary" hint on the other side, the sync helpers MUST consult BOTH sides. When setting: only update if the current value is missing or stale. When clearing: only clear if no other owner still references it; otherwise switch to a remaining owner. A blind `updateMany({ linkedX: oldId }, { $unset })` is a silent multi-tenant bug.


### PR DESCRIPTION
Three related fixes to the habit/goal/track system that were undermining
trust in the app:

1. Tracked-goal category gate only fires on actual changes. The Edit Goal
   modal re-sends the existing categoryId on every save, which was
   tripping "Cannot change category of a goal that belongs to a track" on
   any edit (title, habits, deadline) of a tracked goal. Now compares new
   vs. old value before rejecting.

2. Pre-existing stale linkedHabitIds may persist. The ghost-ID stripper in
   EditGoalModal was silently erasing historical progress every time a
   user edited a goal that referenced a deleted habit — violating the
   documented invariant that deleted habits' entries continue to count
   toward goal progress. Backend now only validates NEWLY-added habit IDs;
   frontend no longer strips the refs.

3. Multi-goal habits now work correctly. linkHabitsToGoal and
   unlinkHabitsFromGoal are now multi-goal-aware: they preserve a stable
   Habit.linkedGoalId UI hint when the habit is linked to multiple goals
   (e.g., one "study session" habit across a sequence of exam goals in a
   track). Progress math already supported this via the per-goal
   activeWindowStart/End filter; now the metadata matches.

Plus a DeleteHabitConfirmModal that warns when deleting a habit linked to
any goal, listing affected goals and explaining that historical progress
is preserved. Defense-in-depth display filter on GoalCard counts only
active linked habits.

Tests: src/server/routes/__tests__/goals.trackedEdit.test.ts covers all
three fixes plus the multi-goal link/unlink lifecycle.

https://claude.ai/code/session_01K22EvnkfLPbyWgwfQgeduN