### PR TITLE
Add pinnedGoalIds to DashboardPrefs backend

### DIFF
--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -14,28 +14,74 @@ import { JournalSummaryCard } from './Journal/JournalSummaryCard';
 import { SetupDashboard } from './dashboard/SetupDashboard';
 import { useSetupProgress } from '../hooks/useSetupProgress';
 import { useAuth } from '../store/AuthContext';
+import { fetchDashboardPrefs, updateDashboardPrefs } from '../lib/persistenceClient';
 import type { Routine } from '../models/persistenceTypes';
 
 const BETA_EMAIL = 'tj.galloway1@gmail.com';
-const PINNED_GOALS_KEY = 'hf_pinned_dashboard_goals';
+export const PINNED_GOALS_STORAGE_KEY = 'hf_pinned_dashboard_goals';
 const SETUP_GUIDE_DISMISSED_KEY = 'hf_setup_guide_dismissed';
+
+// Module-level cache so pinned IDs survive component unmounts (mirrors usePinnedRoutines)
+let _cachedPinnedGoalIds: string[] | null = null;
+
+function readLocalStoragePinnedGoalIds(): string[] {
+    try {
+        const stored = localStorage.getItem(PINNED_GOALS_STORAGE_KEY);
+        return stored ? JSON.parse(stored) : [];
+    } catch {
+        return [];
+    }
+}
+
+export function __resetPinnedGoalsCacheForTests() {
+    _cachedPinnedGoalIds = null;
+}
 
 function usePinnedGoals() {
     const [pinnedIds, setPinnedIds] = useState<string[]>(() => {
-        try {
-            const stored = localStorage.getItem(PINNED_GOALS_KEY);
-            return stored ? JSON.parse(stored) : [];
-        } catch {
-            return [];
-        }
+        // Use module-level cache first (survives unmount), then localStorage
+        if (_cachedPinnedGoalIds !== null) return _cachedPinnedGoalIds;
+        const fromStorage = readLocalStoragePinnedGoalIds();
+        _cachedPinnedGoalIds = fromStorage;
+        return fromStorage;
     });
+
+    // Keep module cache in sync with state
+    useEffect(() => {
+        _cachedPinnedGoalIds = pinnedIds;
+    }, [pinnedIds]);
+
+    // Hydrate from backend on mount — but don't clobber local data with empty backend
+    useEffect(() => {
+        let cancelled = false;
+        fetchDashboardPrefs()
+            .then(prefs => {
+                if (cancelled) return;
+                const backendIds = prefs.pinnedGoalIds ?? [];
+                // Only overwrite local state if backend actually has data,
+                // or if local cache is empty (first load)
+                if (backendIds.length > 0 || _cachedPinnedGoalIds === null || _cachedPinnedGoalIds.length === 0) {
+                    setPinnedIds(backendIds);
+                    _cachedPinnedGoalIds = backendIds;
+                    localStorage.setItem(PINNED_GOALS_STORAGE_KEY, JSON.stringify(backendIds));
+                }
+            })
+            .catch(() => {
+                // Keep localStorage/cache fallback on network failure
+            });
+        return () => { cancelled = true; };
+    }, []);
 
     const togglePin = useCallback((id: string) => {
         setPinnedIds(prev => {
             const next = prev.includes(id)
                 ? prev.filter(x => x !== id)
                 : [...prev, id];
-            localStorage.setItem(PINNED_GOALS_KEY, JSON.stringify(next));
+            // Update all caches immediately for responsiveness
+            _cachedPinnedGoalIds = next;
+            localStorage.setItem(PINNED_GOALS_STORAGE_KEY, JSON.stringify(next));
+            // Persist to backend (fire-and-forget; localStorage is fallback)
+            updateDashboardPrefs({ pinnedGoalIds: next }).catch(() => {});
             return next;
         });
     }, []);

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -338,7 +338,7 @@ export async function fetchDashboardPrefs(): Promise<DashboardPrefs> {
   return response.dashboardPrefs;
 }
 
-export async function updateDashboardPrefs(patch: Partial<Pick<DashboardPrefs, 'pinnedRoutineIds' | 'pinnedJournalTemplateIds' | 'checkinExtraMetricKeys' | 'hideStreaks'>>): Promise<DashboardPrefs> {
+export async function updateDashboardPrefs(patch: Partial<Pick<DashboardPrefs, 'pinnedRoutineIds' | 'pinnedGoalIds' | 'pinnedJournalTemplateIds' | 'checkinExtraMetricKeys' | 'hideStreaks'>>): Promise<DashboardPrefs> {
   const response = await apiRequest<{ dashboardPrefs: DashboardPrefs }>('/dashboardPrefs', {
     method: 'PUT',
     body: JSON.stringify(patch),

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -648,6 +648,9 @@ export interface DashboardPrefs {
     /** Global pinned routine IDs (not persona-specific yet) */
     pinnedRoutineIds: string[];
 
+    /** Global pinned goal IDs used by the dashboard "Goals at a glance" card */
+    pinnedGoalIds?: string[];
+
     /**
      * Extra wellbeing metric keys to show in Daily Check-in (user-controlled).
      * Persona-agnostic (applies across personas) by design.

--- a/src/server/repositories/__tests__/dashboardPrefsRepository.test.ts
+++ b/src/server/repositories/__tests__/dashboardPrefsRepository.test.ts
@@ -26,6 +26,7 @@ describe('DashboardPrefsRepository', () => {
     const db = await getTestDb();
     await db.collection('dashboardPrefs').deleteMany({});
     await db.collection('routines').deleteMany({});
+    await db.collection('goals').deleteMany({});
   });
 
   it('should return defaults when none exist', async () => {
@@ -46,6 +47,37 @@ describe('DashboardPrefsRepository', () => {
 
     const roundTrip = await getDashboardPrefs(TEST_HOUSEHOLD_ID, TEST_USER_ID);
     expect(roundTrip.pinnedRoutineIds).toEqual(['r1', 'r2']);
+  });
+
+  it('should save and retrieve pinnedGoalIds (and validate against existing goals)', async () => {
+    const db = await getTestDb();
+    await db.collection('goals').insertMany([
+      { id: 'g1', householdId: TEST_HOUSEHOLD_ID, userId: TEST_USER_ID, title: 'G1', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 'g2', householdId: TEST_HOUSEHOLD_ID, userId: TEST_USER_ID, title: 'G2', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ]);
+
+    const saved = await updateDashboardPrefs(TEST_HOUSEHOLD_ID, TEST_USER_ID, { pinnedGoalIds: ['g1', 'g2', 'missing'] });
+    expect(saved.pinnedGoalIds).toEqual(['g1', 'g2']); // missing filtered
+
+    const roundTrip = await getDashboardPrefs(TEST_HOUSEHOLD_ID, TEST_USER_ID);
+    expect(roundTrip.pinnedGoalIds).toEqual(['g1', 'g2']);
+  });
+
+  it('pinnedGoalIds and pinnedRoutineIds coexist without overwriting each other', async () => {
+    const db = await getTestDb();
+    await db.collection('routines').insertOne(
+      { id: 'r1', householdId: TEST_HOUSEHOLD_ID, userId: TEST_USER_ID, title: 'R1', linkedHabitIds: [], steps: [], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    );
+    await db.collection('goals').insertOne(
+      { id: 'g1', householdId: TEST_HOUSEHOLD_ID, userId: TEST_USER_ID, title: 'G1', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    );
+
+    await updateDashboardPrefs(TEST_HOUSEHOLD_ID, TEST_USER_ID, { pinnedRoutineIds: ['r1'] });
+    await updateDashboardPrefs(TEST_HOUSEHOLD_ID, TEST_USER_ID, { pinnedGoalIds: ['g1'] });
+
+    const roundTrip = await getDashboardPrefs(TEST_HOUSEHOLD_ID, TEST_USER_ID);
+    expect(roundTrip.pinnedRoutineIds).toEqual(['r1']);
+    expect(roundTrip.pinnedGoalIds).toEqual(['g1']);
   });
 
   it('should save and retrieve checkinExtraMetricKeys (filtering invalid keys and notes)', async () => {

--- a/src/server/repositories/dashboardPrefsRepository.ts
+++ b/src/server/repositories/dashboardPrefsRepository.ts
@@ -9,6 +9,7 @@ import { getDb } from '../lib/mongoClient';
 import { MONGO_COLLECTIONS, WELLBEING_METRIC_KEYS, isWellbeingMetricKey, type DashboardPrefs } from '../../models/persistenceTypes';
 import { JOURNAL_TEMPLATES } from '../../data/journalTemplates';
 import { getRoutines } from './routineRepository';
+import { getGoalsByUser } from './goalRepository';
 import { requireScope, scopeFilter } from '../lib/scoping';
 
 const COLLECTION = MONGO_COLLECTIONS.DASHBOARD_PREFS;
@@ -41,7 +42,7 @@ export async function getDashboardPrefs(householdId: string, userId: string): Pr
 export async function updateDashboardPrefs(
   householdId: string,
   userId: string,
-  patch: { pinnedRoutineIds?: string[]; pinnedJournalTemplateIds?: string[]; checkinExtraMetricKeys?: string[]; hideStreaks?: boolean }
+  patch: { pinnedRoutineIds?: string[]; pinnedGoalIds?: string[]; pinnedJournalTemplateIds?: string[]; checkinExtraMetricKeys?: string[]; hideStreaks?: boolean }
 ): Promise<DashboardPrefs> {
   const scope = requireScope(householdId, userId);
   await ensureIndexes();
@@ -66,6 +67,22 @@ export async function updateDashboardPrefs(
     const filtered = ids.filter((id) => validIdSet.has(id));
 
     update.pinnedRoutineIds = filtered;
+  }
+
+  if (patch.pinnedGoalIds !== undefined) {
+    if (!Array.isArray(patch.pinnedGoalIds)) {
+      throw new Error('pinnedGoalIds must be an array of goal IDs');
+    }
+    const ids = patch.pinnedGoalIds
+      .filter((x) => typeof x === 'string')
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0);
+
+    const goals = await getGoalsByUser(scope.householdId, scope.userId);
+    const validIdSet = new Set(goals.map((g) => g.id));
+    const filtered = ids.filter((id) => validIdSet.has(id));
+
+    update.pinnedGoalIds = filtered;
   }
 
   if (patch.pinnedJournalTemplateIds !== undefined) {

--- a/src/server/routes/dashboardPrefs.ts
+++ b/src/server/routes/dashboardPrefs.ts
@@ -29,9 +29,9 @@ export async function getDashboardPrefsRoute(req: Request, res: Response): Promi
 export async function updateDashboardPrefsRoute(req: Request, res: Response): Promise<void> {
   try {
     const { householdId, userId } = getRequestIdentity(req);
-    const { pinnedRoutineIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks } = req.body || {};
+    const { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks } = req.body || {};
 
-    const prefs = await updateDashboardPrefs(householdId, userId, { pinnedRoutineIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks });
+    const prefs = await updateDashboardPrefs(householdId, userId, { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks });
     res.status(200).json({ dashboardPrefs: prefs });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
Adds a new optional pinnedGoalIds field to the DashboardPrefs schema,
validated against the user's active goals in the repository update path
(mirroring how pinnedRoutineIds is handled). Exposes the field through
the dashboardPrefs PUT route and the persistence client type so the
frontend can hydrate and persist pinned goals per-user, not just in
localStorage.

https://claude.ai/code/session_01EqfGYybYqZW9V6o1bFn4mi