### PR TITLE
fix: swap Target icon for Repeat on habit rows

### DIFF
--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -1,4 +1,4 @@
-import { Check, Target, Hash, Pin, PinOff, ListTodo, Layers, FolderInput, Trophy, Clock, Calendar, Shield, Repeat, Activity, History, Pencil, Trash2 } from 'lucide-react';
+import { Check, CheckCheck, Target, Hash, Pin, PinOff, ListTodo, Layers, FolderInput, Trophy, Clock, Calendar, Shield, Repeat, Activity, History, Pencil, Trash2 } from 'lucide-react';
 import type { Habit, DayLog } from '../../types';
 import { cn } from '../../utils/cn';
 
@@ -115,7 +115,7 @@ export const HabitGridCell = ({
                 </button>
             );
         }
-        if (habit.goal) return <Repeat size={12} className="text-emerald-500" />;
+        if (habit.goal) return <CheckCheck size={12} className="text-emerald-500" />;
         if (habit.timeEstimate) return <span className="text-[10px] text-neutral-500 font-medium">{habit.timeEstimate}m</span>;
         return null;
     };

--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -115,7 +115,7 @@ export const HabitGridCell = ({
                 </button>
             );
         }
-        if (habit.goal) return <Target size={12} className="text-emerald-500" />;
+        if (habit.goal) return <Repeat size={12} className="text-emerald-500" />;
         if (habit.timeEstimate) return <span className="text-[10px] text-neutral-500 font-medium">{habit.timeEstimate}m</span>;
         return null;
     };


### PR DESCRIPTION
The green Target (bullseye) icon rendered next to every simple habit in
HabitGridCell was visually identical to the Goals tab icon in BottomTabBar,
making users think every habit was goal-linked. The actual linked-goal
indicator is already a distinct amber Trophy, so habits linked to a goal
were confusingly showing both icons at once.

Using Repeat (already imported in this file, same semantic used for the
timesPerWeek badge) keeps a visual marker on the row while clearly
differentiating simple habits from Goals-tab navigation and Trophy-tagged
linked habits.

https://claude.ai/code/session_01KV2FFXbNNdSexFFmkSW3dn