### PR TITLE
Refactor health rule backfill to use configurable day windows

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -113,6 +113,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Health Metric Syncing** — Import steps, active calories, sleep hours, workout minutes, weight
 - **Health Rules** — Auto-log habits when health data meets a threshold
 - **Health Suggestions** — Receive suggestions to log habits based on health data
+- **Bounded Backfill** — Create entries from already-synced Apple Health data over a selectable lookback window: 7 / 30 (default) / 90 days, capped server-side at 365 days. Backfill never overwrites existing entries and only creates entries for days where the rule's condition is met.
 - **Auto-Logged Entry Indicators** — Health-sourced entries marked with icon in tracker
 - **Feature Gate** — Available to authorized users only (email allowlist)
 

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -428,6 +428,10 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                     <p className="mt-0.5">Receive suggestions to log habits based on your health data. Accept or dismiss each suggestion.</p>
                   </li>
                   <li className="text-xs text-neutral-400 pl-2">
+                    <span className="font-semibold text-neutral-300">Backfill</span>
+                    <p className="mt-0.5">When creating a health-tracked habit, pick a backfill window of 7, 30, or 90 days (or none). Backfill reads Apple Health data already synced into HabitFlow and creates entries for qualifying days in the window. It never overwrites existing entries and is capped at 365 days.</p>
+                  </li>
+                  <li className="text-xs text-neutral-400 pl-2">
                     <span className="font-semibold text-neutral-300">Auto-Logged Entries</span>
                     <div className="flex items-center gap-1.5 mt-0.5">
                       <Activity size={11} className="text-emerald-500/70 shrink-0" />

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -1559,14 +1559,21 @@ export async function deleteHealthRule(habitId: string): Promise<{ success: bool
 
 /**
  * Trigger backfill for a habit based on its health rule.
+ *
+ * @param habitId - The habit to backfill entries for.
+ * @param options.days - Lookback window in calendar days, [1, 365]. Defaults to server-side 30.
+ *
+ * Always includes the browser's IANA timezone so the server computes "today" against
+ * the user's local midnight rather than falling back to America/New_York.
  */
 export async function triggerBackfill(
   habitId: string,
-  startDayKey?: string
-): Promise<{ created: number; skipped: number; evaluated: number }> {
+  options: { days?: number } = {}
+): Promise<{ created: number; skipped: number; evaluated: number; days: number }> {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return apiRequest(`/habits/${habitId}/health-rule/backfill`, {
     method: 'POST',
-    body: JSON.stringify({ startDayKey }),
+    body: JSON.stringify({ days: options.days, timeZone }),
   });
 }
 

--- a/src/pages/AppleHealthPage.tsx
+++ b/src/pages/AppleHealthPage.tsx
@@ -42,9 +42,12 @@ export function AppleHealthPage({ onBack }: Props) {
   const [operator, setOperator] = useState<HealthRuleOperator>('>=');
   const [threshold, setThreshold] = useState('');
   const [behavior, setBehavior] = useState<HealthRuleBehavior>('auto_log');
-  const [backfillOption, setBackfillOption] = useState<'habit_start' | 'none'>('habit_start');
+  // 0 = no backfill, otherwise the size of the lookback window in days.
+  // Backfill reads Apple Health data that has already been synced into HabitFlow
+  // and creates HabitEntries for qualifying days inside this window.
+  const [backfillDays, setBackfillDays] = useState<0 | 7 | 30 | 90>(30);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitMessage, setSubmitMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [submitMessage, setSubmitMessage] = useState<{ type: 'success' | 'error' | 'info'; text: string } | null>(null);
 
   // Connected habits
   const [connectedHabits, setConnectedHabits] = useState<ConnectedHabit[]>([]);
@@ -87,7 +90,7 @@ export function AppleHealthPage({ onBack }: Props) {
     setThreshold(metric.defaultThreshold);
     setOperator('>=');
     setBehavior('auto_log');
-    setBackfillOption('habit_start');
+    setBackfillDays(30);
     setSubmitMessage(null);
     if (categories.length > 0 && !selectedCategoryId) {
       setSelectedCategoryId(categories[0].id);
@@ -117,12 +120,21 @@ export function AppleHealthPage({ onBack }: Props) {
         behavior,
       });
 
-      // Trigger backfill if requested
-      if (backfillOption === 'habit_start') {
-        await triggerBackfill(newHabit.id);
+      // Trigger backfill if a non-zero window was selected
+      let backfillText = '';
+      if (backfillDays > 0) {
+        const result = await triggerBackfill(newHabit.id, { days: backfillDays });
+        if (result.created > 0) {
+          backfillText = ` Backfilled ${result.created} ${result.created === 1 ? 'entry' : 'entries'} from the last ${backfillDays} days.`;
+        } else if (result.evaluated > 0) {
+          backfillText = ` Backfill ran but found no Apple Health data in the last ${backfillDays} days — sync data into HabitFlow first.`;
+        }
       }
 
-      setSubmitMessage({ type: 'success', text: `Created "${habitName.trim()}" with ${metricKey} tracking` });
+      setSubmitMessage({
+        type: 'success',
+        text: `Created "${habitName.trim()}" with ${metricKey} tracking.${backfillText}`,
+      });
       setExpandedMetric(null);
       await loadConnectedHabits();
     } catch (e) {
@@ -144,10 +156,25 @@ export function AppleHealthPage({ onBack }: Props) {
 
   const handleBackfill = async (habitId: string) => {
     try {
-      const result = await triggerBackfill(habitId);
-      alert(`Backfill complete: ${result.created} entries created, ${result.skipped} skipped.`);
+      const result = await triggerBackfill(habitId, { days: 30 });
+      if (result.created > 0) {
+        setSubmitMessage({
+          type: 'success',
+          text: `Backfill created ${result.created} ${result.created === 1 ? 'entry' : 'entries'} from the last 30 days.`,
+        });
+      } else if (result.evaluated > 0) {
+        setSubmitMessage({
+          type: 'info',
+          text: 'Backfill ran but found no Apple Health data in the last 30 days. Apple Health data needs to be synced into HabitFlow before backfill can populate entries.',
+        });
+      } else {
+        setSubmitMessage({
+          type: 'info',
+          text: 'Backfill completed with no changes.',
+        });
+      }
     } catch {
-      alert('Backfill failed.');
+      setSubmitMessage({ type: 'error', text: 'Backfill failed. Please try again.' });
     }
   };
 
@@ -185,13 +212,15 @@ export function AppleHealthPage({ onBack }: Props) {
         Create habits that automatically track using your Apple Health data. Choose a metric below to get started.
       </p>
 
-      {/* Success/Error Message */}
+      {/* Success/Error/Info Message */}
       {submitMessage && (
         <div className={cn(
           "px-4 py-3 rounded-lg text-sm",
           submitMessage.type === 'success'
             ? "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20"
-            : "bg-red-500/10 text-red-400 border border-red-500/20"
+            : submitMessage.type === 'info'
+              ? "bg-sky-500/10 text-sky-400 border border-sky-500/20"
+              : "bg-red-500/10 text-red-400 border border-red-500/20"
         )}>
           {submitMessage.text}
         </div>
@@ -323,35 +352,36 @@ export function AppleHealthPage({ onBack }: Props) {
                       </div>
                     </div>
 
-                    {/* Backfill */}
+                    {/* Backfill window */}
                     <div className="space-y-1">
                       <label className="text-xs text-neutral-500">Backfill past data</label>
-                      <div className="grid grid-cols-2 gap-1.5">
-                        <button
-                          type="button"
-                          onClick={() => setBackfillOption('habit_start')}
-                          className={cn(
-                            "px-2 py-1.5 rounded-lg text-xs font-medium border transition-colors",
-                            backfillOption === 'habit_start'
-                              ? "bg-amber-500/20 text-amber-400 border-amber-500/50"
-                              : "bg-neutral-800 text-neutral-400 border-white/5"
-                          )}
-                        >
-                          From start
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setBackfillOption('none')}
-                          className={cn(
-                            "px-2 py-1.5 rounded-lg text-xs font-medium border transition-colors",
-                            backfillOption === 'none'
-                              ? "bg-neutral-700/50 text-neutral-300 border-white/10"
-                              : "bg-neutral-800 text-neutral-400 border-white/5"
-                          )}
-                        >
-                          No backfill
-                        </button>
+                      <div className="grid grid-cols-4 gap-1.5">
+                        {([
+                          { value: 7, label: '7 days' },
+                          { value: 30, label: '30 days' },
+                          { value: 90, label: '90 days' },
+                          { value: 0, label: 'None' },
+                        ] as const).map((opt) => (
+                          <button
+                            key={opt.value}
+                            type="button"
+                            onClick={() => setBackfillDays(opt.value)}
+                            className={cn(
+                              "px-2 py-1.5 rounded-lg text-xs font-medium border transition-colors",
+                              backfillDays === opt.value
+                                ? opt.value === 0
+                                  ? "bg-neutral-700/50 text-neutral-300 border-white/10"
+                                  : "bg-amber-500/20 text-amber-400 border-amber-500/50"
+                                : "bg-neutral-800 text-neutral-400 border-white/5"
+                            )}
+                          >
+                            {opt.label}
+                          </button>
+                        ))}
                       </div>
+                      <p className="text-[11px] text-neutral-500 pt-1">
+                        Reads Apple Health data already synced into HabitFlow and creates entries for qualifying days in the window.
+                      </p>
                     </div>
 
                     {/* Submit */}

--- a/src/server/routes/__tests__/habitHealthRules.test.ts
+++ b/src/server/routes/__tests__/habitHealthRules.test.ts
@@ -13,9 +13,17 @@ import { createCategory } from '../../repositories/categoryRepository';
 import { createHabit } from '../../repositories/habitRepository';
 import { upsertHealthMetric } from '../../repositories/healthMetricDailyRepository';
 import { getHabitEntriesForDay } from '../../repositories/habitEntryRepository';
+import { getNowDayKey } from '../../utils/dayKey';
 
 const HID = 'household-rules';
 const UID = 'user-rules';
+
+/** Compute a dayKey that is N days before today in the server's default timezone. */
+function daysAgoDayKey(n: number): string {
+  const today = new Date(getNowDayKey() + 'T00:00:00Z');
+  today.setUTCDate(today.getUTCDate() - n);
+  return today.toISOString().slice(0, 10);
+}
 
 describe('Habit Health Rule Routes', () => {
   let app: Express;
@@ -164,38 +172,136 @@ describe('Habit Health Rule Routes', () => {
   });
 
   describe('POST /api/habits/:habitId/health-rule/backfill', () => {
-    it('backfills qualifying days', async () => {
-      // Create rule
+    beforeEach(async () => {
+      // Create rule shared by all backfill tests
       await request(app)
         .post(`/api/habits/${habitId}/health-rule`)
         .send({ metricType: 'steps', operator: '>=', thresholdValue: 10000, behavior: 'auto_log' })
         .expect(201);
+    });
 
-      // Seed health data
+    it('backfills qualifying days inside the window', async () => {
+      const qualifyingDay = daysAgoDayKey(2);
+      const nonQualifyingDay = daysAgoDayKey(3);
+
       await upsertHealthMetric(
-        { userId: UID, dayKey: '2026-03-01', source: 'apple_health', steps: 12000 },
+        { userId: UID, dayKey: qualifyingDay, source: 'apple_health', steps: 12000 },
         HID, UID
       );
       await upsertHealthMetric(
-        { userId: UID, dayKey: '2026-03-02', source: 'apple_health', steps: 5000 },
+        { userId: UID, dayKey: nonQualifyingDay, source: 'apple_health', steps: 5000 },
         HID, UID
       );
 
       const res = await request(app)
         .post(`/api/habits/${habitId}/health-rule/backfill`)
-        .send({ startDayKey: '2026-03-01' });
+        .send({ days: 7 });
 
       expect(res.status).toBe(200);
-      expect(res.body.created).toBeGreaterThanOrEqual(1);
+      expect(res.body.created).toBe(1);
+      expect(res.body.days).toBe(7);
 
-      // Verify entry created for qualifying day
-      const entries = await getHabitEntriesForDay(habitId, '2026-03-01', HID, UID);
+      const qualifyingEntries = await getHabitEntriesForDay(habitId, qualifyingDay, HID, UID);
+      expect(qualifyingEntries).toHaveLength(1);
+      expect(qualifyingEntries[0].source).toBe('apple_health');
+
+      const nonQualifyingEntries = await getHabitEntriesForDay(habitId, nonQualifyingDay, HID, UID);
+      expect(nonQualifyingEntries).toHaveLength(0);
+    });
+
+    it('defaults to a 30-day window when no body is sent', async () => {
+      const insideDay = daysAgoDayKey(5);
+      await upsertHealthMetric(
+        { userId: UID, dayKey: insideDay, source: 'apple_health', steps: 12000 },
+        HID, UID
+      );
+
+      const res = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.days).toBe(30);
+      expect(res.body.created).toBe(1);
+
+      const entries = await getHabitEntriesForDay(habitId, insideDay, HID, UID);
       expect(entries).toHaveLength(1);
-      expect(entries[0].source).toBe('apple_health');
+    });
 
-      // Verify no entry for non-qualifying day
-      const entries2 = await getHabitEntriesForDay(habitId, '2026-03-02', HID, UID);
-      expect(entries2).toHaveLength(0);
+    it('excludes metrics outside the window', async () => {
+      const insideDay = daysAgoDayKey(3);
+      const outsideDay = daysAgoDayKey(40);
+
+      await upsertHealthMetric(
+        { userId: UID, dayKey: insideDay, source: 'apple_health', steps: 12000 },
+        HID, UID
+      );
+      await upsertHealthMetric(
+        { userId: UID, dayKey: outsideDay, source: 'apple_health', steps: 15000 },
+        HID, UID
+      );
+
+      const res = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 7 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.created).toBe(1);
+
+      expect(await getHabitEntriesForDay(habitId, insideDay, HID, UID)).toHaveLength(1);
+      expect(await getHabitEntriesForDay(habitId, outsideDay, HID, UID)).toHaveLength(0);
+    });
+
+    it('rejects days > 365 with a 400', async () => {
+      const res = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 400 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('rejects days < 1 with a 400', async () => {
+      const zeroRes = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 0 });
+      expect(zeroRes.status).toBe(400);
+
+      const negRes = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: -5 });
+      expect(negRes.status).toBe(400);
+    });
+
+    it('rejects non-integer days with a 400', async () => {
+      const floatRes = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 7.5 });
+      expect(floatRes.status).toBe(400);
+
+      const stringRes = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 'thirty' });
+      expect(stringRes.status).toBe(400);
+    });
+
+    it('accepts a timeZone param without error', async () => {
+      const res = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 7, timeZone: 'America/Los_Angeles' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.days).toBe(7);
+    });
+
+    it('returns 0 created when no health data exists in the window', async () => {
+      const res = await request(app)
+        .post(`/api/habits/${habitId}/health-rule/backfill`)
+        .send({ days: 7 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.created).toBe(0);
+      expect(res.body.evaluated).toBe(7);
     });
   });
 });

--- a/src/server/routes/habitHealthRules.ts
+++ b/src/server/routes/habitHealthRules.ts
@@ -25,6 +25,21 @@ const VALID_METRIC_TYPES: HealthMetricType[] = ['steps', 'sleep_hours', 'workout
 const VALID_OPERATORS: HealthRuleOperator[] = ['>=', '<=', '>', '<', 'exists'];
 const VALID_BEHAVIORS: HealthRuleBehavior[] = ['auto_log', 'suggest'];
 
+// Backfill window bounds (in days). Guards against accidentally importing years of data.
+const MIN_BACKFILL_DAYS = 1;
+const MAX_BACKFILL_DAYS = 365;
+const DEFAULT_BACKFILL_DAYS = 30;
+
+/**
+ * Subtract N calendar days from a dayKey (YYYY-MM-DD). Calendar arithmetic only —
+ * dayKey is a label, not a timestamp, so UTC math is safe here.
+ */
+function subtractDaysFromDayKey(dayKey: string, days: number): string {
+  const d = new Date(dayKey + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
 /**
  * POST /api/habits/:habitId/health-rule
  * Create a health rule for a habit.
@@ -196,12 +211,38 @@ router.delete('/', async (req: Request, res: Response) => {
 /**
  * POST /api/habits/:habitId/health-rule/backfill
  * Trigger backfill for a habit based on its health rule.
+ *
+ * Body: { days?: number, timeZone?: string }
+ * - days: size of the lookback window in calendar days. Range [1, 365]. Default 30.
+ *   The window is [today - (days-1), today] inclusive in the user's timezone.
+ * - timeZone: IANA timezone for computing "today". Defaults to America/New_York if omitted/invalid.
  */
 router.post('/backfill', async (req: Request, res: Response) => {
   try {
     const { householdId, userId } = getRequestIdentity(req);
     const { habitId } = req.params;
-    const { startDayKey: customStartDayKey, timeZone } = req.body;
+    const { days: rawDays, timeZone } = req.body;
+
+    // Validate window size up front so we never pass through to the service with a bad range.
+    let days: number;
+    if (rawDays === undefined || rawDays === null) {
+      days = DEFAULT_BACKFILL_DAYS;
+    } else if (
+      typeof rawDays !== 'number' ||
+      !Number.isInteger(rawDays) ||
+      rawDays < MIN_BACKFILL_DAYS ||
+      rawDays > MAX_BACKFILL_DAYS
+    ) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `days must be an integer between ${MIN_BACKFILL_DAYS} and ${MAX_BACKFILL_DAYS}.`,
+        },
+      });
+      return;
+    } else {
+      days = rawDays;
+    }
 
     // Resolve user timezone for accurate dayKey boundaries
     const userTimeZone = resolveTimeZone(typeof timeZone === 'string' ? timeZone : undefined);
@@ -220,13 +261,13 @@ router.post('/backfill', async (req: Request, res: Response) => {
       return;
     }
 
-    // Determine start date: custom, or habit creation date
-    const startDayKey = customStartDayKey || habit.createdAt.slice(0, 10);
+    // Bounded range: [today - (days-1), today] inclusive in the user's timezone.
     const endDayKey = getNowDayKey(userTimeZone);
+    const startDayKey = subtractDaysFromDayKey(endDayKey, days - 1);
 
     const result = await runBackfill(habit, rule, startDayKey, endDayKey, householdId, userId);
 
-    res.status(200).json(result);
+    res.status(200).json({ ...result, days });
   } catch (error) {
     console.error('[Health Backfill] Error:', error);
     const message = error instanceof Error ? error.message : 'Internal server error';


### PR DESCRIPTION
## Summary
Refactors the health rule backfill feature to use a configurable lookback window (in days) instead of a fixed start date. This allows users to choose how far back to backfill Apple Health data (7, 30, 90 days, or none) when creating health-tracked habits, with better feedback on backfill results.

## Key Changes

**Backend (habitHealthRules.ts)**
- Replaced `startDayKey` parameter with `days` parameter (range: 1-365 days, default: 30)
- Added validation for the `days` parameter with proper error responses for invalid inputs
- Implemented `subtractDaysFromDayKey()` helper to compute bounded date ranges
- Backfill window now computed as `[today - (days-1), today]` inclusive in user's timezone
- Response now includes the `days` value for client confirmation

**Frontend (AppleHealthPage.tsx)**
- Changed backfill UI from binary "From start" / "No backfill" toggle to 4-option buttons: 7 days, 30 days, 90 days, None
- Updated `triggerBackfill()` calls to pass `{ days }` option instead of `startDayKey`
- Enhanced user feedback with detailed success/info messages showing number of entries created or data availability status
- Added info message type to distinguish between success, error, and informational messages
- Improved backfill messaging in both habit creation flow and standalone backfill action

**Client API (persistenceClient.ts)**
- Updated `triggerBackfill()` signature to accept `options: { days?: number }`
- Now automatically includes browser's IANA timezone so server computes "today" against user's local midnight
- Response type updated to include `days` field

**Tests (habitHealthRules.test.ts)**
- Added `daysAgoDayKey()` helper for relative date computation in tests
- Refactored single test into comprehensive test suite covering:
  - Backfill within window boundaries
  - Default 30-day window behavior
  - Exclusion of metrics outside the window
  - Validation of day bounds (1-365)
  - Rejection of non-integer values
  - Timezone parameter acceptance
  - Handling of empty results

## Notable Implementation Details
- Calendar arithmetic uses UTC to safely manipulate dayKey strings (YYYY-MM-DD format)
- Backfill window is inclusive on both ends: `[today - (days-1), today]`
- Server validates `days` parameter before any database operations to prevent invalid ranges
- User timezone is passed from browser to ensure "today" is computed against local midnight, not server timezone
- Backfill results now distinguish between "created" (entries added), "evaluated" (days checked), and "skipped" (metrics that didn't qualify)

https://claude.ai/code/session_019RNr6mMHzKUL4QMSNDG6zg