### PR TITLE
Document BUG-4: weekly field duplication causes Today view miscount

### DIFF
--- a/docs/system-model/HABITFLOW_BUG_ANALYSIS.md
+++ b/docs/system-model/HABITFLOW_BUG_ANALYSIS.md
@@ -112,6 +112,70 @@ A legitimate entry with `value: 0` (e.g., user logs "0 glasses of water") gets `
 
 ---
 
+### BUG-4: Day view ignores `requiredDaysPerWeek`, misreports weekly progress
+
+**Severity:** High (user-visible, silently wrong)
+
+**Files:**
+- `src/server/services/dayViewService.ts` lines 366, 138
+- `src/server/routes/progress.ts` lines 158-159 (correct comparison for reference)
+- `src/components/AddHabitModal.tsx` lines 246, 253 (where both fields are written)
+
+**Reported symptom:** "I've gone to the gym 2 days and have a 3 days per week goal, and the Today view only shows I've made 1 contribution."
+
+**Root cause:** `Habit` has two fields that both express "weekly target count":
+- `timesPerWeek` — top-level weekly target
+- `requiredDaysPerWeek` — required days per week, written alongside `assignedDays`
+
+`AddHabitModal` writes these from two independent UI controls. A user who uses the scheduling section ("3 days per week") but leaves the separate `timesPerWeek` input blank ends up with `requiredDaysPerWeek=3, timesPerWeek=undefined`.
+
+Different readers then disagree on whether this habit is "weekly":
+
+**`src/server/routes/progress.ts:158-159` (correct — considers both):**
+```typescript
+const isWeeklyStreak = (habit.timesPerWeek != null && habit.timesPerWeek > 0) ||
+  (habit.assignedDays?.length && habit.requiredDaysPerWeek);
+```
+
+**`src/server/services/dayViewService.ts:366` (wrong — only checks `timesPerWeek`):**
+```typescript
+} else if (habit.timesPerWeek != null && habit.timesPerWeek > 0) {
+  // Weekly habit: derive week progress
+  const weekProgress = deriveWeeklyProgress(...)
+```
+
+A habit with only `requiredDaysPerWeek` set falls through to the daily branches below. For a quantity habit (`goal.type === 'number'`), it hits line 386–400 which filters entries to **today's dayKey only**, sums them, and renders `currentValue/goal.target`.
+
+Additionally, inside `deriveWeeklyProgress` at line 138:
+```typescript
+const target = habit.timesPerWeek ?? habit.goal.target ?? 1;
+```
+This also ignores `requiredDaysPerWeek`, so even if the outer branch were fixed, the target would still be wrong when only `requiredDaysPerWeek` is set.
+
+**Impact:**
+
+| Scenario | What Today view shows | What user expects | What other views show |
+|---|---|---|---|
+| Gym habit with `requiredDaysPerWeek=3, timesPerWeek=undefined`, 2 days logged Mon+Wed, viewing Wed | 1 of `goal.target` (today's single entry) | 2 of 3 | Progress/streak view uses weekly logic (`progress.ts` correctly detects it as weekly), `scheduleEngine` has yet another code path → three views disagree |
+
+The three views disagreeing is the real red flag — `dayViewService`, `progress.ts`, and `scheduleEngine` each implement their own "is this habit weekly?" check, and they do not match.
+
+**Fix (recommended, two parts):**
+
+1. **Immediate fix** — `dayViewService.ts:366` should use the same check as `progress.ts:158`:
+   ```typescript
+   const isWeekly =
+     (habit.timesPerWeek != null && habit.timesPerWeek > 0) ||
+     (habit.requiredDaysPerWeek != null && habit.requiredDaysPerWeek > 0);
+   ```
+   And `deriveWeeklyProgress` line 138 should fall back: `habit.timesPerWeek ?? habit.requiredDaysPerWeek ?? habit.goal.target ?? 1`.
+
+2. **Root-cause fix** — migrate `requiredDaysPerWeek` into `timesPerWeek` (collapse the duplicated field). Migration 002 already normalized legacy `frequency: 'weekly'` → `timesPerWeek`; a similar migration should fold `requiredDaysPerWeek` → `timesPerWeek` and delete the duplicated control in `AddHabitModal`. Having two fields with the same meaning is what created this bug and will create more.
+
+**Status:** Unresolved as of 2026-04-11. Confirmed via code read — not yet reproduced in a running environment.
+
+---
+
 ## Inconsistencies
 
 ### INCONSISTENCY-1: Dual Habit-Goal link sync

--- a/docs/system-model/HABITFLOW_ENTITY_MODEL.md
+++ b/docs/system-model/HABITFLOW_ENTITY_MODEL.md
@@ -93,8 +93,8 @@
 | `nonNegotiableDays` | number[] | No | Specific non-negotiable days |
 | `deadline` | string | No | Deadline time (HH:mm) |
 | `freezeCount` | number | No | Freeze inventory (max 3) |
-| `timesPerWeek` | number | No | Weekly target count |
-| `requiredDaysPerWeek` | number | No | Required completions per week |
+| `timesPerWeek` | number | No | Weekly target count. **See note below — duplicative with `requiredDaysPerWeek`.** |
+| `requiredDaysPerWeek` | number | No | Required completions per week. **Duplicative with `timesPerWeek` — see note below.** |
 | `bundleType` | `'checklist'\|'choice'` | No | Bundle mode |
 | `bundleOptions` | Array | No | **DEPRECATED** Choice options (use subHabitIds) |
 | `checklistSuccessRule` | object | No | Checklist success criteria |
@@ -125,6 +125,17 @@
 **Deleted:** Soft delete via `archived: true`
 **UI:** Tracker Grid, Day View, Schedule View, Goal Detail, Analytics
 **Related to:** Category, HabitEntry, Goal, Routine, BundleMembership
+
+> **⚠ Duplicative fields: `timesPerWeek` vs `requiredDaysPerWeek`**
+>
+> Both fields express "weekly target count" but are written from separate UI controls in `AddHabitModal` (`timesPerWeek` from a standalone input, `requiredDaysPerWeek` from the scheduling section). A habit can have either one set, both, or neither.
+>
+> Readers disagree on how to detect "is this habit weekly?":
+> - `src/server/routes/progress.ts:158` checks **both** fields.
+> - `src/server/services/dayViewService.ts:366` checks **only** `timesPerWeek` → causes BUG-4.
+> - `src/server/services/scheduleEngine.ts` has its own third path.
+>
+> These should be collapsed into one canonical field (follow the pattern of migration `002_migrate_weekly_frequency`). See `HABITFLOW_BUG_ANALYSIS.md` BUG-4 and `HABITFLOW_SYSTEM_RULES.md` "Weekly target canonical field".
 
 ---
 

--- a/docs/system-model/HABITFLOW_SYSTEM_RULES.md
+++ b/docs/system-model/HABITFLOW_SYSTEM_RULES.md
@@ -65,11 +65,29 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 ### R8: Weekly Habit Completion
 
 - Week window: Monday to Sunday (`weekStartsOn: 1`).
+- **"Is this habit weekly?" MUST be computed as:**
+  ```
+  isWeekly = (timesPerWeek != null && timesPerWeek > 0)
+          || (requiredDaysPerWeek != null && requiredDaysPerWeek > 0)
+  ```
+  See **R8a** below for why both fields must be checked.
 - Three sub-types determined by `deriveWeeklyProgress()`:
-  - **Quantity weekly** (`habit.goal.type === 'number'`): sum of entry values in week >= `timesPerWeek` / `goal.target`.
+  - **Quantity weekly** (`habit.goal.type === 'number'`): sum of entry values in week >= weekly target.
   - **Frequency weekly** (`!isQuantity && target > 1`): count of distinct `dayKeys` with entries in week >= target.
   - **Binary weekly** (single entry suffices): any non-deleted entry in week = complete.
+- The weekly target value MUST be resolved as `timesPerWeek ?? requiredDaysPerWeek ?? goal.target ?? 1`.
 - **Source:** `dayViewService.ts:deriveWeeklyProgress()`
+
+### R8a: Weekly target canonical field
+
+- `Habit` currently has two duplicative fields: `timesPerWeek` and `requiredDaysPerWeek`. Both express "weekly target count" and are written from separate controls in `AddHabitModal`.
+- Until a migration collapses them, **every reader must check both** (see R8 formula above).
+- Known violators:
+  - `src/server/services/dayViewService.ts:366` — checks only `timesPerWeek`. This causes **BUG-4**: a quantity habit with `requiredDaysPerWeek=3, timesPerWeek=undefined` is misclassified as daily, and the Today view shows today-only progress instead of weekly progress.
+  - `src/server/services/dayViewService.ts:138` (`deriveWeeklyProgress` target resolution) — same issue.
+- Known correct readers:
+  - `src/server/routes/progress.ts:158-159`.
+- **Long-term fix (root cause):** add a migration following `002_migrate_weekly_frequency.ts` that folds `requiredDaysPerWeek` → `timesPerWeek`, delete the duplicated UI control in `AddHabitModal`, and remove `requiredDaysPerWeek` from the type. Having two fields for the same concept is the defect; the short-term "check both" fix is a patch, not a cure.
 
 ### R9: Checklist Bundle Completion
 


### PR DESCRIPTION
## Summary
- Added **BUG-4** to `HABITFLOW_BUG_ANALYSIS.md`: `dayViewService.ts:366` only checks `timesPerWeek` to classify weekly habits, ignoring `requiredDaysPerWeek`. Habits created via the scheduling section (which sets `requiredDaysPerWeek`) are misclassified as daily, so the Today view shows today-only progress instead of weekly aggregation.
- Flagged the duplicative fields (`timesPerWeek` vs `requiredDaysPerWeek`) in `HABITFLOW_ENTITY_MODEL.md` with a callout block.
- Added rule **R8a** (weekly target canonical field) to `HABITFLOW_SYSTEM_RULES.md` with the canonical formula and migration path.

## Context
User reported: gym habit with 3 days/week goal, completed on 2 days, Today view shows 1 contribution instead of 2. Root cause is that `dayViewService`, `progress.ts`, and `scheduleEngine` each have their own is-this-habit-weekly check and they disagree.

## Test plan
- [ ] Review doc changes for accuracy against current code
- [ ] Docs only — no code changes, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)