### PR TITLE
Update active goal when reordering goals within a track

### DIFF
--- a/src/server/routes/__tests__/goalTracks.test.ts
+++ b/src/server/routes/__tests__/goalTracks.test.ts
@@ -252,7 +252,7 @@ describe('Goal Tracks Routes', () => {
       expect(res.body.trackStatus).toBe('locked');
     });
 
-    it('should reorder goals in a track', async () => {
+    it('should reorder goals in a track and promote the new first goal to active', async () => {
       const track = await createGoalTrack({ name: 'Reorder Test', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
       const g1 = await createGoal({ title: 'A', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
       const g2 = await createGoal({ title: 'B', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
@@ -260,7 +260,7 @@ describe('Goal Tracks Routes', () => {
       await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g1.id });
       await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g2.id });
 
-      // Reverse order
+      // Reverse order — g2 moves to the front and should become active
       const res = await request(app)
         .patch(`/api/goal-tracks/${track.id}/goals/reorder`)
         .send({ goalIds: [g2.id, g1.id] });
@@ -271,6 +271,93 @@ describe('Goal Tracks Routes', () => {
       const updated2 = await getGoalById(g2.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
       expect(updated2?.trackOrder).toBe(0);
       expect(updated1?.trackOrder).toBe(1);
+
+      // Active goal should follow the new ordering
+      expect(updated2?.trackStatus).toBe('active');
+      expect(updated2?.activeWindowStart).toBeTruthy();
+      expect(updated1?.trackStatus).toBe('locked');
+    });
+
+    it('should promote a previously-locked goal to active when moved ahead of the active goal', async () => {
+      const track = await createGoalTrack({ name: 'Promote Locked', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g1 = await createGoal({ title: 'First', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g2 = await createGoal({ title: 'Second', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g3 = await createGoal({ title: 'Third', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g1.id });
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g2.id });
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g3.id });
+
+      // Complete g1 — g2 becomes active via advancement
+      await request(app).put(`/api/goals/${g1.id}`).send({ completedAt: new Date().toISOString() });
+
+      // Reorder: move g3 (locked) to the front, behind the completed g1
+      const res = await request(app)
+        .patch(`/api/goal-tracks/${track.id}/goals/reorder`)
+        .send({ goalIds: [g1.id, g3.id, g2.id] });
+
+      expect(res.status).toBe(200);
+
+      const u1 = await getGoalById(g1.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const u2 = await getGoalById(g2.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const u3 = await getGoalById(g3.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+
+      expect(u1?.trackStatus).toBe('completed');
+      expect(u3?.trackStatus).toBe('active');
+      expect(u3?.activeWindowStart).toBeTruthy();
+      expect(u2?.trackStatus).toBe('locked');
+    });
+
+    it('should preserve completed status when a completed goal is reordered', async () => {
+      const track = await createGoalTrack({ name: 'Completed Preserve', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g1 = await createGoal({ title: 'Done', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g2 = await createGoal({ title: 'Working', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g1.id });
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g2.id });
+
+      // Complete g1 — g2 becomes active
+      await request(app).put(`/api/goals/${g1.id}`).send({ completedAt: new Date().toISOString() });
+
+      // Move completed g1 after the active g2
+      const res = await request(app)
+        .patch(`/api/goal-tracks/${track.id}/goals/reorder`)
+        .send({ goalIds: [g2.id, g1.id] });
+
+      expect(res.status).toBe(200);
+
+      const u1 = await getGoalById(g1.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const u2 = await getGoalById(g2.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+
+      // Completed goal stays completed; active goal stays active
+      expect(u1?.trackStatus).toBe('completed');
+      expect(u2?.trackStatus).toBe('active');
+    });
+
+    it('should preserve activeWindowStart when a previously-active goal is re-promoted', async () => {
+      const track = await createGoalTrack({ name: 'Preserve Window', categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g1 = await createGoal({ title: 'Originally Active', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      const g2 = await createGoal({ title: 'Other', type: 'onetime', linkedHabitIds: [], categoryId: TEST_CATEGORY_ID }, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g1.id });
+      await request(app).post(`/api/goal-tracks/${track.id}/goals`).send({ goalId: g2.id });
+
+      const originalWindowStart = (await getGoalById(g1.id, TEST_HOUSEHOLD_ID, TEST_USER_ID))?.activeWindowStart;
+      expect(originalWindowStart).toBeTruthy();
+
+      // Demote g1 by moving g2 to the front
+      await request(app)
+        .patch(`/api/goal-tracks/${track.id}/goals/reorder`)
+        .send({ goalIds: [g2.id, g1.id] });
+
+      // Re-promote g1 by moving it back to the front
+      await request(app)
+        .patch(`/api/goal-tracks/${track.id}/goals/reorder`)
+        .send({ goalIds: [g1.id, g2.id] });
+
+      const u1 = await getGoalById(g1.id, TEST_HOUSEHOLD_ID, TEST_USER_ID);
+      expect(u1?.trackStatus).toBe('active');
+      expect(u1?.activeWindowStart).toBe(originalWindowStart);
     });
 
     it('should remove a goal from a track', async () => {

--- a/src/server/routes/goalTracks.ts
+++ b/src/server/routes/goalTracks.ts
@@ -395,7 +395,12 @@ export async function removeGoalFromTrack(req: Request, res: Response): Promise<
  * PATCH /api/goal-tracks/:id/goals/reorder
  * Reorder goals within a track.
  * Body: { goalIds: string[] }
- * Does NOT change trackStatus, activeWindowStart, or activeWindowEnd (preserves history).
+ *
+ * After reordering, recomputes which goal is active so that the invariant
+ * "active goal == first non-completed goal by trackOrder" holds. Completed
+ * goals retain their status. A previously-active goal that gets demoted to
+ * 'locked' keeps its activeWindowStart untouched (history is preserved);
+ * activeWindowEnd is never set here — that field is reserved for completion.
  */
 export async function reorderTrackGoals(req: Request, res: Response): Promise<void> {
   try {
@@ -420,6 +425,35 @@ export async function reorderTrackGoals(req: Request, res: Response): Promise<vo
       await updateGoal(goalIds[i], householdId, userId, {
         trackOrder: i,
       } as Partial<Goal>);
+    }
+
+    // Recompute active goal based on the new order. The active goal must be
+    // the first non-completed goal by trackOrder. Reordering can shift that
+    // position, so promote/demote to keep the invariant.
+    const trackGoalsSorted = await getGoalsByTrack(trackId, householdId, userId);
+    const firstIncomplete = trackGoalsSorted.find(g => g.trackStatus !== 'completed');
+
+    if (firstIncomplete && firstIncomplete.trackStatus !== 'active') {
+      // Promote this goal. Preserve activeWindowStart if it already has one
+      // (e.g. from a prior activation that was demoted); otherwise start a
+      // fresh window today.
+      const promotion: Partial<Goal> = { trackStatus: 'active' };
+      if (!firstIncomplete.activeWindowStart) {
+        promotion.activeWindowStart = todayDayKey();
+      }
+      await updateGoal(firstIncomplete.id, householdId, userId, promotion as Partial<Goal>);
+
+      // Demote any other goal that was previously active (there should be at
+      // most one). Leave activeWindowStart/activeWindowEnd untouched — we
+      // never set activeWindowEnd on demotion because that field's semantics
+      // mean "completed".
+      for (const g of trackGoalsSorted) {
+        if (g.id !== firstIncomplete.id && g.trackStatus === 'active') {
+          await updateGoal(g.id, householdId, userId, {
+            trackStatus: 'locked',
+          } as Partial<Goal>);
+        }
+      }
     }
 
     invalidateUserCaches(userId);


### PR DESCRIPTION
The PATCH /api/goal-tracks/:id/goals/reorder endpoint only updated
trackOrder, leaving trackStatus untouched. If a user moved a locked
goal ahead of the active goal (e.g. dragging a newly-added goal to
the top), the visual indicator didn't follow — the old goal stayed
"active" while the new first goal stayed "locked".

After writing the new trackOrder values, recompute the active goal so
that the invariant "active goal == first non-completed goal by
trackOrder" always holds. A goal promoted from locked gets an
activeWindowStart of today (unless it already has one from a prior
activation, in which case the original date is preserved). A demoted
goal keeps its activeWindowStart — activeWindowEnd is never set here
since that field's semantics mean "completed".

https://claude.ai/code/session_01ASaZTj2fZhqk12vSXjeeXn