### PR TITLE
fix(goals): allow clicking non-active goals in a track

### DIFF
--- a/src/components/goals/GoalTrackSection.tsx
+++ b/src/components/goals/GoalTrackSection.tsx
@@ -84,11 +84,10 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
                     return (
                         <button
                             key={goal.id}
-                            onClick={() => !isLocked && onViewGoal?.(goal.id)}
-                            disabled={isLocked}
+                            onClick={() => onViewGoal?.(goal.id)}
                             className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-left transition-colors ${
                                 isLocked
-                                    ? 'opacity-40 cursor-default'
+                                    ? 'opacity-60 hover:bg-neutral-800/50 hover:opacity-100'
                                     : isActive
                                     ? 'bg-emerald-500/5 border border-emerald-500/20 hover:bg-emerald-500/10'
                                     : isCompleted

--- a/src/pages/goals/GoalTrackDetailPage.tsx
+++ b/src/pages/goals/GoalTrackDetailPage.tsx
@@ -71,7 +71,7 @@ const SortableTrackGoal: React.FC<{
                 isDragging ? 'bg-neutral-700/50 shadow-lg' :
                 isActive ? 'bg-emerald-500/5 border border-emerald-500/20' :
                 'bg-neutral-800/30 border border-white/5'
-            } ${isLocked ? 'opacity-40' : ''}`}
+            } ${isLocked ? 'opacity-60' : ''}`}
         >
             {/* Drag handle */}
             <div {...listeners} className="cursor-grab active:cursor-grabbing flex-shrink-0 touch-none">
@@ -93,9 +93,8 @@ const SortableTrackGoal: React.FC<{
 
             {/* Goal info */}
             <button
-                onClick={() => !isLocked && onViewGoal?.(goal.id)}
-                disabled={isLocked}
-                className={`flex-1 min-w-0 text-left ${isLocked ? 'cursor-default' : ''}`}
+                onClick={() => onViewGoal?.(goal.id)}
+                className="flex-1 min-w-0 text-left"
             >
                 <div className={`text-sm ${
                     isCompleted ? 'text-neutral-500 line-through' :


### PR DESCRIPTION
Locked (non-active) goals in a track were rendered with `disabled`
buttons, so users couldn't open the goal detail page for them — which
meant the "Remove from track" action on `GoalDetailPage` was
unreachable. Enable the click on locked goals in both the inline
`GoalTrackSection` (on the Goals page) and `GoalTrackDetailPage`, and
soften the opacity from 40% → 60% with a hover cue so they still read
as "not yet started" but invite interaction.