### PR TITLE
fix(goals): refetch tracks after reorder so drag-drop persists

### DIFF
--- a/src/pages/goals/GoalsPage.tsx
+++ b/src/pages/goals/GoalsPage.tsx
@@ -258,7 +258,7 @@ export const GoalsPage: React.FC<GoalsPageProps> = ({
     onViewTrack,
 }) => {
     const { data, loading, error, refetch } = useGoalsWithProgress();
-    const { data: tracks } = useGoalTracks();
+    const { data: tracks, refetch: refetchTracks } = useGoalTracks();
     const { categories } = useHabitStore();
     const [editingGoalId, setEditingGoalId] = useState<string | null>(null);
     const [expandedStacks, setExpandedStacks] = useState<Set<string>>(new Set());
@@ -364,12 +364,16 @@ export const GoalsPage: React.FC<GoalsPageProps> = ({
         }
 
         reorderGoalTracks(allTrackIds).then(() => {
+            // Tracks hold their own sortOrder state, so we must refetch the
+            // tracks list — not just goals — for the reordered view to render.
+            refetchTracks();
             refetch();
         }).catch((err) => {
             console.error('Failed to reorder goal tracks:', err);
-            refetch(); // Revert on error
+            refetchTracks(); // Revert on error
+            refetch();
         });
-    }, [goalStacks, refetch]);
+    }, [goalStacks, refetch, refetchTracks]);
 
     if (loading) {
         return (


### PR DESCRIPTION
On the Goals page, dragging a goal track to a new position left the
order unchanged on the UI. The drop would visually snap back and the
new order was never reflected.

`handleTrackDragEnd` called the reorder API correctly, but the only
refetch it triggered afterwards was from `useGoalsWithProgress`. The
track order comes from `useGoalTracks`, whose `refetch` was never
extracted from the hook — so the track list rendered on the page kept
its stale `sortOrder` values and the reorder appeared to do nothing.

- Destructure `refetch: refetchTracks` from `useGoalTracks`.
- Invoke it alongside the goals refetch in both the success and error
  branches of `handleTrackDragEnd`, mirroring the pattern used for
  goals reordering.

https://claude.ai/code/session_01EiZBQRjaHpdVbtSeUCxVz7