### PR TITLE
fix(habits): resolve bundle children against unfiltered habits so cross-category children stay in the drawer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -521,6 +521,7 @@ const HabitTrackerContent: React.FC = () => {
           trackerViewMode === 'all' ? (
             <TrackerGrid
               habits={filteredHabits}
+              allHabits={habits}
               logs={logs}
               onToggle={toggleHabit}
               onUpdateValue={updateLog}

--- a/src/components/AddHabitModal.tsx
+++ b/src/components/AddHabitModal.tsx
@@ -321,9 +321,14 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                     } catch (_e) { /* membership may not exist for pre-migration bundles */ }
                 }
 
-                // Link new existing children — update bundleParentId and create membership
+                // Link new existing children — update bundleParentId, inherit the
+                // bundle's category so children stay grouped with their parent,
+                // and create membership
                 for (const childId of newlyLinkedExistingIds) {
-                    await updateHabit(childId, { bundleParentId: savedHabit.id });
+                    await updateHabit(childId, {
+                        bundleParentId: savedHabit.id,
+                        categoryId: selectedCategoryId,
+                    });
                     try {
                         await createBundleMembership({
                             parentHabitId: savedHabit.id,

--- a/src/components/BundlePickerModal.tsx
+++ b/src/components/BundlePickerModal.tsx
@@ -40,8 +40,12 @@ export const BundlePickerModal = ({
         try {
             const todayDayKey = format(new Date(), 'yyyy-MM-dd');
 
-            // 1. Set child's bundleParentId
-            await updateHabit(habitId, { bundleParentId: bundle.id });
+            // 1. Set child's bundleParentId and inherit the bundle's category
+            //    so every habit inside a bundle shares that bundle's grouping.
+            await updateHabit(habitId, {
+                bundleParentId: bundle.id,
+                categoryId: bundle.categoryId,
+            });
 
             // 2. Update parent's subHabitIds
             const existingIds = bundle.subHabitIds || [];

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -40,6 +40,12 @@ import { CSS } from '@dnd-kit/utilities';
 
 interface TrackerGridProps {
     habits: Habit[];
+    // Full unfiltered habit set, used for resolving bundle children by id.
+    // Children can live in a different category than their parent bundle, so
+    // they must be resolved against the full set (not the category-filtered
+    // `habits`), otherwise cross-category children disappear from the drawer
+    // and `hasChildren` can collapse to false — hiding the expand handle.
+    allHabits?: Habit[];
     logs: Record<string, DayLog>;
     onToggle: (habitId: string, date: string) => Promise<void>;
     onUpdateValue: (habitId: string, date: string, value: number) => Promise<void>;
@@ -775,6 +781,7 @@ const SortableWeeklyHabitRow = ({
 // [REPLACED TRACKER GRID DEFINITION]
 export const TrackerGrid = ({
     habits,
+    allHabits,
     logs,
     onAddHabit,
     onEditHabit,
@@ -784,6 +791,9 @@ export const TrackerGrid = ({
     onViewHistory,
     loading
 }: TrackerGridProps) => {
+    // Fall back to `habits` when no unfiltered set is provided, preserving
+    // prior behavior for callers that don't pass `allHabits`.
+    const childLookupHabits = allHabits ?? habits;
     const {
         deleteHabit,
         reorderHabits,
@@ -1276,7 +1286,7 @@ export const TrackerGrid = ({
                                             <SortableHabitRow
                                                 key={habit.id}
                                                 habit={habit}
-                                                allHabits={habits}
+                                                allHabits={childLookupHabits}
                                                 expandedIds={expandedIds}
                                                 onToggleExpand={toggleExpand}
                                                 logs={logs}


### PR DESCRIPTION
Bundle drawer rendering used the category-filtered habit list to resolve
subHabitIds into child Habit objects. When a child lived in a different
category than the parent bundle, allHabits.find(...) returned undefined
and the child silently dropped from the drawer. If every linked child
happened to live outside the active category, children.length became 0,
hasChildren became false, and the expand handle never rendered — making
the bundle look like a non-expandable row.

This hit choice bundles most visibly (children are typically cross-
category picks like "Bath", "Podcast", etc.), but affected any bundle
whose children crossed categories. Impact example: a Fitness bundle
"Recover Activity" linking six habits tagged Wellness/Mindfulness
showed no drawer at all on the Fitness tab; a mixed-category bundle
showed a truncated drawer.

Fix: TrackerGrid now accepts an optional allHabits prop carrying the
unfiltered habit set. It is used solely for resolving subHabitIds in
SortableHabitRow's children lookup; top-level rendering still uses the
category-filtered habits prop. App.tsx passes the unfiltered habits
from useHabitStore as allHabits while continuing to pass
filteredHabits as habits.