### PR TITLE
feat(theme): production-ready light mode + semantic theme system

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,22 @@ Key areas:
 
 Routing is query-string based (`?view=...`) plus path-based routes for dedicated pages.
 
+### Theming
+
+Semantic-token design system in `src/theme/`:
+
+- `palette.ts` — Single source of truth for light/dark color palettes (hex). Both themes share the same token keys.
+- `cssVars.ts` — Emits CSS variables (as space-separated RGB triplets) from the palette at runtime. The Tailwind config consumes these via `rgb(var(--token) / <alpha-value>)` aliases (`bg-surface-1`, `text-content-muted`, `border-line-subtle`, `bg-accent`, etc.), so opacity modifiers keep working (`bg-surface-1/80`).
+- `ThemeContext.tsx` — Provides `mode` (`'light' | 'dark' | 'system'`), `resolvedMode` (`'light' | 'dark'`), and `setMode`. Listens to `prefers-color-scheme` when `mode === 'system'`, applies `class="dark"` / `class="light"` to `<html>`, and updates `color-scheme`.
+- `useThemeColors.ts` — Hook returning the active palette as hex; used by chart/SVG consumers (recharts, gradients) that need hex rather than Tailwind classes.
+- `heatmap.ts` — Theme-aware `getHeatmapColor(intensity, mode)` replaces the old dark-only class-returning form.
+
+A pre-hydration script in `index.html` applies the correct theme class to `<html>` before React boots, reading `localStorage['hf_theme_mode']` and falling back to `prefers-color-scheme` if the stored value is `'system'` (or to dark on any failure). The user's choice also persists on the server in `DashboardPrefs.themeMode` so it syncs across devices.
+
+`scripts/check-theme-tokens.sh` is a lint guard that fails if raw `bg-neutral-600/700/800/900`, `bg-white/*`, or `border-white/*` classes appear in an allowlisted set of migrated directories. Expand the allowlist as more surfaces migrate.
+
+Category colors (`bg-emerald-500`, `bg-blue-500`, ...) in `src/utils/categoryColors.ts` are data-encoding colors, NOT theme tokens — they stay visually distinct across modes.
+
 ## Backend
 
 - **Entry point:** `src/server/index.ts` (uses `createApp()` from `src/server/app.ts`).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -136,6 +136,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 
 ## Settings & Account
 
+- **Appearance (Theme)** — Light / Dark / System. User-menu quick toggle + labeled Settings section. Preference syncs across devices via `DashboardPrefs.themeMode`; `system` mode tracks `prefers-color-scheme` at runtime. Default is Dark.
 - **Gemini API Key** — Add, view, or remove AI integration key
 - **Apple Health Link** — Connect health integration (beta users)
 - **Setup Guide Reopen** — Re-trigger onboarding walkthrough

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -140,7 +140,7 @@ HabitFlow App
 | Delete Goal Confirm | Modal | Goal context menu "Delete" | Deletion confirmation dialog | Goals |
 | Delete Habit Confirm | Modal | Trash button on a habit that is linked to one or more goals (shown after the click-twice confirm so the user sees which goals are affected) | Lists the affected goals and explains historical progress on them is preserved before allowing deletion | Habits, Goals |
 | Completed Habits | Modal | Routine runner completion | Summary of habits logged during routine | Habits, Entries |
-| Settings | Modal | Header settings icon | Preferences, API keys, data management | User config |
+| Settings | Modal | Header settings icon | Appearance (Light / Dark / System), preferences, API keys, data management | User config |
 | Info / Tutorial | Modal | Header info icon | App tutorial and feature explanations | — |
 | Habit Creation Inline | Modal | Quick-add in certain contexts | Lightweight inline habit creation | Habits |
 
@@ -464,7 +464,8 @@ graph TB
 - **Drag-to-reorder:** Supported for categories (long-press), goals within categories, pinned goals on dashboard
 - **Soft delete:** All deletions use confirmation modals; data is soft-deleted (`deletedAt`)
 - **Mobile-first:** Bottom tab bar, safe-area insets, touch-friendly tap targets (44px+)
-- **Color theming:** Categories have associated colors; habits inherit category color
+- **Category colors:** Categories have associated user-chosen colors; habits inherit category color. These are data-encoding colors (stay visually distinct across themes), not theme tokens.
+- **Theme system:** Light / Dark / System modes. User-menu quick toggle + Settings → Appearance section. All core surfaces consume semantic tokens (`bg-surface-0/1/2`, `text-content-primary/secondary/muted`, `bg-accent`, `bg-accent-soft`, `border-line-subtle/strong`) defined in `src/theme/palette.ts`. Charts and heatmaps use `useThemeColors()` and `getHeatmapColor(intensity, mode)` for hex consumers. A pre-hydration script in `index.html` applies the active theme class before React boots. Choice persists in `DashboardPrefs.themeMode` for cross-device sync.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,33 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>habit-flow-ai</title>
+    <!--
+      Theme pre-hydration: apply the user's saved theme class to <html>
+      before React boots so the first paint is never mismatched.
+      Must stay in sync with src/theme/ThemeContext.tsx (THEME_STORAGE_KEY
+      and the default-to-dark rule).
+    -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('hf_theme_mode');
+          var mode = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'dark';
+          var resolved = mode;
+          if (mode === 'system') {
+            resolved = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          var root = document.documentElement;
+          if (resolved === 'dark') {
+            root.classList.add('dark');
+          } else {
+            root.classList.add('light');
+          }
+          root.style.colorScheme = resolved;
+        } catch (e) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/check-theme-tokens.sh
+++ b/scripts/check-theme-tokens.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Theme-token drift guard.
+#
+# Scans a specific allowlist of "migrated" directories/files for raw
+# dark-mode-only Tailwind classes that should have been converted to
+# semantic theme tokens. Fails (exit 1) if any remain.
+#
+# Files OUTSIDE this allowlist are NOT checked — they're grandfathered
+# and can continue to use raw neutral-/white- classes until they're
+# migrated in a future PR.
+#
+# When migrating a new surface:
+#   1. Fully convert it to semantic tokens.
+#   2. Add its path to MIGRATED_GLOBS below.
+#   3. Run `./scripts/check-theme-tokens.sh` locally.
+#
+# This script is intentionally grep-based so it runs anywhere without
+# installing a custom ESLint plugin. If we add eslint-plugin-tailwindcss
+# later, this becomes a delete.
+
+set -euo pipefail
+
+# Paths that MUST speak semantic tokens — no raw bg-neutral-*, text-neutral-*,
+# bg-white/*, or border-white/* allowed.
+MIGRATED_GLOBS=(
+  "src/components/Layout.tsx"
+  "src/components/BottomTabBar.tsx"
+  "src/components/EmptyState.tsx"
+  "src/components/Toast.tsx"
+  "src/components/SettingsModal.tsx"
+  "src/components/CategoryTabs.tsx"
+  "src/components/TrackerGrid.tsx"
+  "src/components/ProgressRings.tsx"
+  "src/components/MomentumHeader.tsx"
+  "src/components/CategoryMomentumBanner.tsx"
+  "src/components/CategoryCompletionRow.tsx"
+  "src/components/ProgressDashboard.tsx"
+  "src/components/HeatmapLegend.tsx"
+  "src/components/YearHeatmapGrid.tsx"
+  "src/components/RecentHeatmapGrid.tsx"
+  "src/components/dashboard"
+  "src/components/day-view"
+  "src/components/goals/GoalCard.tsx"
+  "src/components/goals/GoalGridCard.tsx"
+  "src/components/goals/GoalPulseCard.tsx"
+  "src/components/goals/GoalTrendChart.tsx"
+  "src/components/goals/GoalCumulativeChart.tsx"
+  "src/components/goals/GoalSparkline.tsx"
+  "src/components/goals/MiniHeatmap.tsx"
+  "src/components/goals/GoalSharedComponents.tsx"
+)
+
+# Raw classes that are forbidden inside MIGRATED files. Extend cautiously.
+# bg-neutral-500 is treated as a user-chosen data-encoding color (category
+# palette), not a theme token — allowed. 600/700/800/900 are dark-only surfaces.
+FORBIDDEN='\bbg-neutral-(600|700|800|900)\b|\btext-neutral-(600|700|800|900)\b|\bborder-neutral-(600|700|800|900)\b|\bbg-white\/[0-9]+\b|\bborder-white\/[0-9]+\b'
+
+status=0
+for glob in "${MIGRATED_GLOBS[@]}"; do
+  if [[ -d "$glob" ]]; then
+    files=$(find "$glob" -type f \( -name '*.tsx' -o -name '*.ts' \) ! -path '*__tests__*')
+  elif [[ -f "$glob" ]]; then
+    files="$glob"
+  else
+    echo "skip (missing): $glob" >&2
+    continue
+  fi
+
+  for f in $files; do
+    # Ignore commented-out lines (//, /* */, docstring examples)
+    if grep -En "$FORBIDDEN" "$f" \
+        | grep -Ev '^\s*[0-9]+:\s*(\*|//|/\*)' \
+        | grep -Ev 'bg-to-text' \
+        | head -5; then
+      echo "  ^^^ raw theme-fragile classes found in $f (see above)"
+      status=1
+    fi
+  done
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "theme-token check: OK"
+fi
+exit $status

--- a/scripts/migrate-theme-tokens-accent.sh
+++ b/scripts/migrate-theme-tokens-accent.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Second-pass migration specifically for primary-accent button patterns.
+# Run AFTER migrate-theme-tokens.sh. Targets the common pairings that
+# appear after the initial pass: bg-emerald-500 + text-neutral-900/black,
+# hover:bg-emerald-600 etc. Still leaves category-color emerald uses alone
+# by requiring the specific textual pairing.
+
+set -euo pipefail
+
+for f in "$@"; do
+  [[ -f "$f" ]] || { echo "skip (not a file): $f" >&2; continue; }
+
+  sed -i '' \
+    -e 's/bg-emerald-500 text-neutral-900/bg-accent text-content-on-accent/g' \
+    -e 's/bg-emerald-500 text-black/bg-accent text-content-on-accent/g' \
+    -e 's/text-neutral-900 bg-emerald-500/text-content-on-accent bg-accent/g' \
+    -e 's/bg-emerald-500 border-emerald-500/bg-accent border-accent/g' \
+    -e 's/bg-emerald-500 hover:bg-accent-strong/bg-accent hover:bg-accent-strong/g' \
+    -e 's/bg-emerald-500 shadow/bg-accent shadow/g' \
+    -e 's/hover:bg-emerald-600/hover:bg-accent-strong/g' \
+    -e 's/hover:bg-emerald-400/hover:bg-accent-strong/g' \
+    -e 's/border-emerald-500\/50/border-accent\/50/g' \
+    -e 's/border-emerald-500\/40/border-accent\/40/g' \
+    -e 's/border-emerald-500\/20/border-accent\/20/g' \
+    -e 's/border-emerald-500\b/border-accent/g' \
+    -e 's/focus:border-emerald-500/focus:border-focus/g' \
+    -e 's/ring-emerald-500/ring-focus/g' \
+    "$f"
+
+  echo "accent-migrated: $f"
+done

--- a/scripts/migrate-theme-tokens.sh
+++ b/scripts/migrate-theme-tokens.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/migrate-theme-tokens.sh <file1> <file2> ...
+# Applies the mechanical Tailwind-class → semantic-token migration in place.
+# INTENDED ONLY FOR THIS PR. Not a long-running script.
+#
+# After running on a file, ALWAYS review the diff — category color classes
+# (bg-emerald-500 on a category chip), and context-sensitive patterns
+# (text-neutral-900 NOT on an accent bg) will need hand correction.
+
+set -euo pipefail
+
+for f in "$@"; do
+  if [[ ! -f "$f" ]]; then
+    echo "skip (not a file): $f" >&2
+    continue
+  fi
+
+  # Use a marker-based approach so chained replacements don't double-apply
+  # (e.g. bg-neutral-900 -> bg-surface-0, but bg-surface-0 should NOT
+  # match a later rule for bg-neutral). sed -i '' for BSD sed on macOS.
+  sed -i '' \
+    -e 's/bg-neutral-900/bg-surface-0/g' \
+    -e 's/bg-neutral-800\/50/bg-surface-1\/50/g' \
+    -e 's/bg-neutral-800\/80/bg-surface-1\/80/g' \
+    -e 's/bg-neutral-800/bg-surface-1/g' \
+    -e 's/bg-neutral-700/bg-surface-2/g' \
+    -e 's/bg-neutral-600/bg-surface-2/g' \
+    -e 's/hover:bg-neutral-800/hover:bg-surface-2/g' \
+    -e 's/hover:bg-neutral-700/hover:bg-surface-2/g' \
+    -e 's/hover:bg-white\/10/hover:bg-surface-2/g' \
+    -e 's/hover:bg-white\/5/hover:bg-surface-2/g' \
+    -e 's/text-white/text-content-primary/g' \
+    -e 's/text-neutral-100/text-content-primary/g' \
+    -e 's/text-neutral-200/text-content-primary/g' \
+    -e 's/text-neutral-300/text-content-secondary/g' \
+    -e 's/text-neutral-400/text-content-secondary/g' \
+    -e 's/text-neutral-500/text-content-muted/g' \
+    -e 's/text-neutral-600/text-content-muted/g' \
+    -e 's/hover:text-white/hover:text-content-primary/g' \
+    -e 's/hover:text-neutral-200/hover:text-content-primary/g' \
+    -e 's/hover:text-neutral-300/hover:text-content-secondary/g' \
+    -e 's/hover:text-neutral-400/hover:text-content-secondary/g' \
+    -e 's/border-white\/5/border-line-subtle/g' \
+    -e 's/border-white\/10/border-line-subtle/g' \
+    -e 's/border-white\/20/border-line-strong/g' \
+    -e 's/border-neutral-700/border-line-strong/g' \
+    -e 's/border-neutral-800/border-line-subtle/g' \
+    -e 's/border-neutral-600/border-line-strong/g' \
+    -e 's/ring-emerald-500\/50/ring-focus\/50/g' \
+    -e 's/ring-emerald-500\/30/ring-focus\/30/g' \
+    -e 's/hover:bg-emerald-400/hover:bg-accent-strong/g' \
+    -e 's/hover:bg-emerald-500/hover:bg-accent-strong/g' \
+    -e 's/bg-emerald-500\/10/bg-accent-soft/g' \
+    -e 's/bg-emerald-500\/15/bg-accent-soft/g' \
+    -e 's/bg-emerald-500\/20/bg-accent-soft/g' \
+    -e 's/border-emerald-500\/30/border-accent\/30/g' \
+    -e 's/border-emerald-500\/20/border-accent\/20/g' \
+    -e 's/text-emerald-300/text-accent-contrast/g' \
+    -e 's/text-emerald-400/text-accent-contrast/g' \
+    -e 's/hover:text-emerald-400/hover:text-accent-contrast/g' \
+    "$f"
+
+  echo "migrated: $f"
+done

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { DayView } from './components/day-view/DayView';
 import { ScheduleView } from './components/day-view/ScheduleView';
 import { DevIdentityPanel } from './components/DevIdentityPanel';
 import { DashboardPrefsProvider } from './store/DashboardPrefsContext';
+import { ThemeProvider } from './theme/ThemeContext';
 
 // Retry wrapper for lazy imports — handles stale chunk failures after deployments
 function lazyRetry<T extends React.ComponentType<any>>(
@@ -700,24 +701,26 @@ const HabitTrackerContent: React.FC = () => {
 function App() {
   return (
     <ErrorBoundary>
-      <AuthProvider>
-        <AuthGate>
-          <ToastProvider>
-            <HabitProvider>
-              <RoutineProvider>
-                <TaskProvider>
-                  <DashboardPrefsProvider>
-                    <Layout>
-                      <HabitTrackerContent />
-                    </Layout>
-                    {import.meta.env.DEV && <DevIdentityPanel />}
-                  </DashboardPrefsProvider>
-                </TaskProvider>
-              </RoutineProvider>
-            </HabitProvider>
-          </ToastProvider>
-        </AuthGate>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <AuthGate>
+            <ToastProvider>
+              <HabitProvider>
+                <RoutineProvider>
+                  <TaskProvider>
+                    <DashboardPrefsProvider>
+                      <Layout>
+                        <HabitTrackerContent />
+                      </Layout>
+                      {import.meta.env.DEV && <DevIdentityPanel />}
+                    </DashboardPrefsProvider>
+                  </TaskProvider>
+                </RoutineProvider>
+              </HabitProvider>
+            </ToastProvider>
+          </AuthGate>
+        </AuthProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,11 +290,11 @@ const HabitTrackerContent: React.FC = () => {
     <div className="flex flex-col h-full gap-6">
       {/* Error Banner */}
       {lastPersistenceError && (
-        <div className="p-3 mb-2 text-sm text-red-100 bg-red-600/90 border border-red-500/50 rounded-lg flex items-center justify-between shadow-lg backdrop-blur-sm">
+        <div className="p-3 mb-2 text-sm text-danger-contrast bg-danger-soft border border-danger/40 rounded-lg flex items-center justify-between shadow-lg backdrop-blur-sm">
           <span>{lastPersistenceError}</span>
           <button
             type="button"
-            className="ml-4 px-3 py-1 text-red-100 hover:text-white hover:bg-red-700/50 rounded transition-colors font-medium"
+            className="ml-4 px-3 py-1 text-danger-contrast hover:bg-surface-2 rounded transition-colors font-medium"
             onClick={clearPersistenceError}
           >
             Dismiss
@@ -306,7 +306,7 @@ const HabitTrackerContent: React.FC = () => {
         {/* Title Section */}
         <div className={`flex flex-col gap-2 ${view === 'journal' || view === 'analytics' ? 'hidden' : ''}`}>
           <div className="flex items-center justify-between">
-            <h2 className="text-2xl font-bold text-white">
+            <h2 className="text-2xl font-bold text-content-primary">
               {view === 'tracker' ? 'Habits' : view === 'dashboard' ? 'Dashboard' : view === 'routines' ? 'Routines' : view === 'tasks' ? 'Tasks' : 'Goals'}
             </h2>
 
@@ -314,7 +314,7 @@ const HabitTrackerContent: React.FC = () => {
               {view === 'tracker' && (
                 <button
                   onClick={() => { setEditingHabit(null); setIsModalOpen(true); }}
-                  className="p-2 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-neutral-900 transition-colors"
+                  className="p-2 rounded-lg bg-accent hover:bg-accent-strong text-content-on-accent transition-colors"
                   title="Add Habit"
                 >
                   <Plus size={20} />
@@ -324,7 +324,7 @@ const HabitTrackerContent: React.FC = () => {
                 <>
                   <button
                     onClick={() => setShowCreateTrack(true)}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-emerald-400 bg-neutral-800/50 hover:bg-neutral-800 border border-white/5 rounded-lg transition-colors"
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-content-secondary hover:text-accent-contrast bg-surface-1 hover:bg-surface-2 border border-line-subtle rounded-lg transition-colors"
                     title="New Track"
                   >
                     <Route size={13} />
@@ -332,7 +332,7 @@ const HabitTrackerContent: React.FC = () => {
                   </button>
                   <button
                     onClick={() => setShowCreateGoal(true)}
-                    className="p-2 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-neutral-900 transition-colors"
+                    className="p-2 rounded-lg bg-accent hover:bg-accent-strong text-content-on-accent transition-colors"
                     title="Create Goal"
                   >
                     <Plus size={20} />
@@ -342,7 +342,7 @@ const HabitTrackerContent: React.FC = () => {
               {view === 'routines' && (
                 <button
                   onClick={() => setRoutineEditorState({ isOpen: true, mode: 'create', routine: undefined })}
-                  className="p-2 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-neutral-900 transition-colors"
+                  className="p-2 rounded-lg bg-accent hover:bg-accent-strong text-content-on-accent transition-colors"
                   title="New Routine"
                 >
                   <Plus size={20} />
@@ -353,7 +353,7 @@ const HabitTrackerContent: React.FC = () => {
 
           {/* Goals View Toggle — centered below title */}
           {view === 'goals' && !selectedGoalId && !completedGoalId && (
-            <div className="flex gap-4 border-b border-white/5">
+            <div className="flex gap-4 border-b border-line-subtle">
               {([
                 { id: 'all' as const, label: 'All', icon: List },
                 { id: 'schedule' as const, label: 'Schedule', icon: CalendarClock },
@@ -362,14 +362,14 @@ const HabitTrackerContent: React.FC = () => {
                 <button
                   key={id}
                   onClick={() => setGoalsViewMode(id)}
-                  className={`pb-3 px-3 text-sm font-medium transition-colors relative ${goalsViewMode === id ? 'text-emerald-400' : 'text-white/40 hover:text-white/60'}`}
+                  className={`pb-3 px-3 text-sm font-medium transition-colors relative ${goalsViewMode === id ? 'text-accent-contrast' : 'text-content-muted hover:text-content-secondary'}`}
                 >
                   <div className="flex items-center gap-2">
                     <Icon size={16} />
                     {label}
                   </div>
                   {goalsViewMode === id && (
-                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent rounded-t-full" />
                   )}
                 </button>
               ))}
@@ -378,7 +378,7 @@ const HabitTrackerContent: React.FC = () => {
 
           {/* Tracker View Toggle — centered below title */}
           {view === 'tracker' && (
-            <div className="flex gap-4 border-b border-white/5">
+            <div className="flex gap-4 border-b border-line-subtle">
               {([
                 { id: 'all' as const, label: 'All', icon: List },
                 { id: 'day' as const, label: 'Today', icon: CalendarDays },
@@ -387,14 +387,14 @@ const HabitTrackerContent: React.FC = () => {
                 <button
                   key={id}
                   onClick={() => setTrackerViewMode(id)}
-                  className={`pb-3 px-3 text-sm font-medium transition-colors relative ${trackerViewMode === id ? 'text-emerald-400' : 'text-white/40 hover:text-white/60'}`}
+                  className={`pb-3 px-3 text-sm font-medium transition-colors relative ${trackerViewMode === id ? 'text-accent-contrast' : 'text-content-muted hover:text-content-secondary'}`}
                 >
                   <div className="flex items-center gap-2">
                     <Icon size={16} />
                     {label}
                   </div>
                   {trackerViewMode === id && (
-                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent rounded-t-full" />
                   )}
                 </button>
               ))}
@@ -427,7 +427,7 @@ const HabitTrackerContent: React.FC = () => {
         )
       }
 
-      <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" /></div>}>
+      <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent" /></div>}>
       {
         completedGoalId ? (
           <GoalCompletedPage

--- a/src/components/AddHabitModal.tsx
+++ b/src/components/AddHabitModal.tsx
@@ -527,23 +527,23 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl max-h-[90dvh] overflow-y-auto modal-scroll">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl max-h-[90dvh] overflow-y-auto modal-scroll">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">
+                    <h3 className="text-xl font-bold text-content-primary">
                         {isEditMode
                             ? (initialData?.type !== 'bundle' && habitType === 'bundle')
                                 ? 'Convert to Bundle'
                                 : 'Edit Habit'
                             : 'Add New Habit'}
                     </h3>
-                    <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white -mr-2" aria-label="Close">
+                    <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary -mr-2" aria-label="Close">
                         <X size={20} />
                     </button>
                 </div>
 
                 <form onSubmit={handleSubmit} className="space-y-5">
                     {/* 1. Type Selection (Step 1) */}
-                    <div className="bg-neutral-800/50 p-1 rounded-lg flex space-x-1">
+                    <div className="bg-surface-1/50 p-1 rounded-lg flex space-x-1">
                         <button
                             type="button"
                             onClick={() => {
@@ -551,8 +551,8 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 setBundleMode(null);
                             }}
                             className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${habitType === 'regular'
-                                ? 'bg-emerald-500 text-neutral-900 shadow-lg'
-                                : 'text-neutral-400 hover:text-white hover:bg-white/5'
+                                ? 'bg-accent text-content-on-accent shadow-lg'
+                                : 'text-content-secondary hover:text-content-primary hover:bg-surface-2'
                                 }`}
                         >
                             <CheckSquare size={16} />
@@ -564,8 +564,8 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 setHabitType('bundle');
                             }}
                             className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${habitType === 'bundle'
-                                ? 'bg-indigo-500 text-white shadow-lg'
-                                : 'text-neutral-400 hover:text-white hover:bg-white/5'
+                                ? 'bg-indigo-500 text-content-primary shadow-lg'
+                                : 'text-content-secondary hover:text-content-primary hover:bg-surface-2'
                                 }`}
                         >
                             <Layers size={16} />
@@ -581,16 +581,16 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 onClick={() => setBundleMode('checklist')}
                                 className={`relative p-3 rounded-xl border text-left transition-all ${bundleMode === 'checklist'
                                     ? 'bg-indigo-500/20 border-indigo-500 ring-1 ring-indigo-500/50'
-                                    : 'bg-neutral-800 border-white/5 hover:bg-neutral-700/50'
+                                    : 'bg-surface-1 border-line-subtle hover:bg-surface-2/50'
                                     }`}
                             >
                                 <div className="flex items-center gap-2 mb-2">
-                                    <div className={`p-1.5 rounded-lg ${bundleMode === 'checklist' ? 'bg-indigo-500 text-white' : 'bg-neutral-700 text-neutral-400'}`}>
+                                    <div className={`p-1.5 rounded-lg ${bundleMode === 'checklist' ? 'bg-indigo-500 text-content-primary' : 'bg-surface-2 text-content-secondary'}`}>
                                         <CheckSquare size={16} />
                                     </div>
-                                    <span className={`text-sm font-semibold ${bundleMode === 'checklist' ? 'text-white' : 'text-neutral-300'}`}>Checklist</span>
+                                    <span className={`text-sm font-semibold ${bundleMode === 'checklist' ? 'text-content-primary' : 'text-content-secondary'}`}>Checklist</span>
                                 </div>
-                                <p className="text-xs text-neutral-500 leading-relaxed">
+                                <p className="text-xs text-content-muted leading-relaxed">
                                     "I want to do multiple items."
                                     <br />
                                     <span className="opacity-75 italic block mt-1">Example: Morning Routine (Bed, Teeth, Water)</span>
@@ -607,16 +607,16 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 onClick={() => setBundleMode('choice')}
                                 className={`relative p-3 rounded-xl border text-left transition-all ${bundleMode === 'choice'
                                     ? 'bg-amber-500/20 border-amber-500 ring-1 ring-amber-500/50'
-                                    : 'bg-neutral-800 border-white/5 hover:bg-neutral-700/50'
+                                    : 'bg-surface-1 border-line-subtle hover:bg-surface-2/50'
                                     }`}
                             >
                                 <div className="flex items-center gap-2 mb-2">
-                                    <div className={`p-1.5 rounded-lg ${bundleMode === 'choice' ? 'bg-amber-500 text-neutral-900' : 'bg-neutral-700 text-neutral-400'}`}>
+                                    <div className={`p-1.5 rounded-lg ${bundleMode === 'choice' ? 'bg-amber-500 text-neutral-900' : 'bg-surface-2 text-content-secondary'}`}>
                                         <ChevronRight size={16} />
                                     </div>
-                                    <span className={`text-sm font-semibold ${bundleMode === 'choice' ? 'text-white' : 'text-neutral-300'}`}>Choice</span>
+                                    <span className={`text-sm font-semibold ${bundleMode === 'choice' ? 'text-content-primary' : 'text-content-secondary'}`}>Choice</span>
                                 </div>
-                                <p className="text-xs text-neutral-500 leading-relaxed">
+                                <p className="text-xs text-content-muted leading-relaxed">
                                     "Any one option satisfies the habit."
                                     <br />
                                     <span className="opacity-75 italic block mt-1">Example: Read OR Podcast OR YouTube</span>
@@ -633,19 +633,19 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                     {/* 1. Basic Info */}
                     <div className="space-y-4">
                         <div>
-                            <label className="block text-sm font-medium text-neutral-400 mb-1">Habit Name</label>
+                            <label className="block text-sm font-medium text-content-secondary mb-1">Habit Name</label>
                             <input
                                 type="text"
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                 placeholder="e.g., Morning Jog"
                                 required
                             />
                         </div>
 
                         <div>
-                                <label className="block text-sm font-medium text-neutral-400 mb-1">Category</label>
+                                <label className="block text-sm font-medium text-content-secondary mb-1">Category</label>
                                 {categories.length > 0 && !isCreatingCategory && (
                                     <select
                                         value={selectedCategoryId}
@@ -656,7 +656,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                 setSelectedCategoryId(e.target.value);
                                             }
                                         }}
-                                        className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500 appearance-none"
+                                        className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus appearance-none"
                                     >
                                         <option value="__new__">+ New Category</option>
                                         {categories.map(cat => (
@@ -690,7 +690,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                     }
                                                 }
                                             }}
-                                            className="flex-1 bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                            className="flex-1 bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                             placeholder="Category name"
                                             autoFocus
                                             disabled={isSubmittingCategory}
@@ -712,7 +712,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                     setIsSubmittingCategory(false);
                                                 }
                                             }}
-                                            className="px-3 py-2 bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                                            className="px-3 py-2 bg-accent hover:bg-accent-strong disabled:opacity-50 text-content-primary text-sm font-medium rounded-lg transition-colors"
                                         >
                                             {isSubmittingCategory ? '...' : 'Save'}
                                         </button>
@@ -720,20 +720,20 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                             <button
                                                 type="button"
                                                 onClick={() => { setIsCreatingCategory(false); setNewCategoryName(''); }}
-                                                className="px-3 py-2 bg-neutral-700 hover:bg-neutral-600 text-white text-sm rounded-lg transition-colors"
+                                                className="px-3 py-2 bg-surface-2 hover:bg-surface-2 text-content-primary text-sm rounded-lg transition-colors"
                                             >
                                                 Cancel
                                             </button>
                                         )}
                                     </div>
                                 ) : categories.length === 0 ? (
-                                    <p className="text-sm text-neutral-500 mb-2">No categories yet. Create one to get started.</p>
+                                    <p className="text-sm text-content-muted mb-2">No categories yet. Create one to get started.</p>
                                 ) : null}
                                 {!isCreatingCategory && categories.length === 0 && (
                                     <button
                                         type="button"
                                         onClick={() => setIsCreatingCategory(true)}
-                                        className="text-sm text-emerald-400 hover:text-emerald-300 transition-colors mt-1"
+                                        className="text-sm text-accent-contrast hover:text-accent-contrast transition-colors mt-1"
                                     >
                                         + New Category
                                     </button>
@@ -744,7 +744,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                     {/* 2. Tracking Style (Only for Regular) */}
                     {habitType === 'regular' && (
                         <div className="space-y-3">
-                            <label className="block text-sm font-medium text-neutral-400">Tracking Style</label>
+                            <label className="block text-sm font-medium text-content-secondary">Tracking Style</label>
 
                             {/* Goal Type Toggle */}
                             <div className="grid grid-cols-2 gap-2">
@@ -753,7 +753,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                     onClick={() => setGoalType('boolean')}
                                     className={`flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors border ${goalType === 'boolean'
                                         ? 'bg-blue-500/20 text-blue-400 border-blue-500/50'
-                                        : 'bg-neutral-800 text-neutral-400 border-white/5 hover:bg-neutral-700'
+                                        : 'bg-surface-1 text-content-secondary border-line-subtle hover:bg-surface-2'
                                         }`}
                                 >
                                     <CheckCircle2 size={16} />
@@ -764,7 +764,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                     onClick={() => setGoalType('number')}
                                     className={`flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors border ${goalType === 'number'
                                         ? 'bg-amber-500/20 text-amber-400 border-amber-500/50'
-                                        : 'bg-neutral-800 text-neutral-400 border-white/5 hover:bg-neutral-700'
+                                        : 'bg-surface-1 text-content-secondary border-line-subtle hover:bg-surface-2'
                                         }`}
                                 >
                                     <Calculator size={16} />
@@ -788,7 +788,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                         setLinkedGoalId(e.target.value || null);
                                     }
                                 }}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg pl-10 pr-4 py-2 text-white focus:outline-none focus:border-emerald-500 appearance-none"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg pl-10 pr-4 py-2 text-content-primary focus:outline-none focus:border-focus appearance-none"
                             >
                                 <option value="">Connect to a Goal (Optional)</option>
                                 <option value="__new__">+ Create New Goal</option>
@@ -797,19 +797,19 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                     <option key={g.id} value={g.id}>{g.title}</option>
                                 ))}
                             </select>
-                            <ChevronDown size={16} className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none" />
+                            <ChevronDown size={16} className="absolute right-3 top-1/2 -translate-y-1/2 text-content-muted pointer-events-none" />
                         </div>
                     </div>
 
 
                     {/* Bundle Configuration - UNIFIED (Checklist + Choice) */}
                     {habitType === 'bundle' && (bundleMode === 'checklist' || bundleMode === 'choice') && (
-                        <div className="space-y-4 border-t border-white/5 pt-4 animate-in fade-in slide-in-from-top-2">
+                        <div className="space-y-4 border-t border-line-subtle pt-4 animate-in fade-in slide-in-from-top-2">
                             <div className="flex items-center justify-between">
-                                <label className="text-sm font-bold text-white">
+                                <label className="text-sm font-bold text-content-primary">
                                     {bundleMode === 'checklist' ? 'Checklist Items' : 'Choices'}
                                 </label>
-                                <span className="text-xs text-neutral-500">
+                                <span className="text-xs text-content-muted">
                                     {bundleMode === 'checklist' ? 'Checking parent completes all children.' : 'Select one valid option.'}
                                 </span>
                             </div>
@@ -819,11 +819,11 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 <button
                                     type="button"
                                     onClick={() => setShowSubHabitSelect(!showSubHabitSelect)}
-                                    className="flex items-center justify-between w-full text-left bg-neutral-800/50 p-3 rounded-lg border border-white/5 hover:bg-neutral-800 transition-colors"
+                                    className="flex items-center justify-between w-full text-left bg-surface-1/50 p-3 rounded-lg border border-line-subtle hover:bg-surface-1 transition-colors"
                                 >
                                     <div className="flex items-center gap-2">
-                                        {showSubHabitSelect ? <ChevronDown size={18} className="text-neutral-400" /> : <Search size={18} className="text-neutral-400" />}
-                                        <span className="text-sm font-medium text-neutral-300">
+                                        {showSubHabitSelect ? <ChevronDown size={18} className="text-content-secondary" /> : <Search size={18} className="text-content-secondary" />}
+                                        <span className="text-sm font-medium text-content-secondary">
                                             Add Existing Habits
                                         </span>
                                     </div>
@@ -833,15 +833,15 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 </button>
 
                                 {showSubHabitSelect && (
-                                    <div className="space-y-3 p-3 bg-neutral-900 rounded-lg border border-white/10 animate-in fade-in zoom-in-95 duration-200">
+                                    <div className="space-y-3 p-3 bg-surface-0 rounded-lg border border-line-subtle animate-in fade-in zoom-in-95 duration-200">
                                         <div className="relative">
-                                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500" />
+                                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-content-muted" />
                                             <input
                                                 type="text"
                                                 value={searchTerm}
                                                 onChange={(e) => setSearchTerm(e.target.value)}
                                                 placeholder="Search habits..."
-                                                className="w-full bg-neutral-800 border border-white/10 rounded-lg pl-9 pr-4 py-2 text-xs text-white focus:outline-none focus:border-indigo-500"
+                                                className="w-full bg-surface-1 border border-line-subtle rounded-lg pl-9 pr-4 py-2 text-xs text-content-primary focus:outline-none focus:border-indigo-500"
                                             />
                                         </div>
                                         <div className="max-h-40 overflow-y-auto space-y-1 custom-scrollbar">
@@ -849,13 +849,13 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                 <div
                                                     key={h.id}
                                                     onClick={() => toggleSubHabit(h.id)}
-                                                    className={`flex items-center justify-between p-2 rounded cursor-pointer transition-colors ${subHabitIds.includes(h.id) ? 'bg-indigo-500/20 text-indigo-300' : 'hover:bg-neutral-800 text-neutral-400'}`}
+                                                    className={`flex items-center justify-between p-2 rounded cursor-pointer transition-colors ${subHabitIds.includes(h.id) ? 'bg-indigo-500/20 text-indigo-300' : 'hover:bg-surface-1 text-content-secondary'}`}
                                                 >
                                                     <span className="text-xs">{h.name}</span>
                                                     {subHabitIds.includes(h.id) && <CheckCircle2 size={12} />}
                                                 </div>
                                             )) : (
-                                                <p className="text-center text-xs text-neutral-500 py-2">No matching habits.</p>
+                                                <p className="text-center text-xs text-content-muted py-2">No matching habits.</p>
                                             )}
                                         </div>
                                     </div>
@@ -864,14 +864,14 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
 
                             {/* Create New Item */}
                             <div className="space-y-2">
-                                <label className="text-xs font-semibold text-neutral-500 uppercase tracking-wider">New Child Habit</label>
+                                <label className="text-xs font-semibold text-content-muted uppercase tracking-wider">New Child Habit</label>
                                 <div className="flex flex-col gap-2">
                                     <div className="flex gap-2">
                                         <input
                                             type="text"
                                             value={newHabitName}
                                             onChange={(e) => setNewHabitName(e.target.value)}
-                                            className="flex-1 bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500"
+                                            className="flex-1 bg-surface-1 border border-line-subtle rounded-lg px-3 py-2 text-sm text-content-primary focus:outline-none focus:border-indigo-500"
                                             placeholder="Item name (e.g. Floss)..."
                                         />
                                         <button
@@ -890,13 +890,13 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                     {/* Choice Mode: Optional Metric Config for New Items */}
                                     {bundleMode === 'choice' && newHabitName.trim() && (
                                         <div className="flex items-center gap-2 pl-1 animate-in fade-in pt-1">
-                                            <div className="flex bg-neutral-800 rounded-lg p-1 border border-white/5">
+                                            <div className="flex bg-surface-1 rounded-lg p-1 border border-line-subtle">
                                                 <button
                                                     type="button"
                                                     onClick={() => setNewHabitGoalType('boolean')}
                                                     className={`text-xs px-3 py-1.5 rounded-md transition-all ${newHabitGoalType === 'boolean'
-                                                        ? 'bg-neutral-700 text-white shadow-sm'
-                                                        : 'text-neutral-500 hover:text-neutral-300'
+                                                        ? 'bg-surface-2 text-content-primary shadow-sm'
+                                                        : 'text-content-muted hover:text-content-secondary'
                                                         }`}
                                                 >
                                                     Simple (Done/Not)
@@ -905,8 +905,8 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                     type="button"
                                                     onClick={() => setNewHabitGoalType('number')}
                                                     className={`text-xs px-3 py-1.5 rounded-md transition-all ${newHabitGoalType === 'number'
-                                                        ? 'bg-neutral-700 text-white shadow-sm'
-                                                        : 'text-neutral-500 hover:text-neutral-300'
+                                                        ? 'bg-surface-2 text-content-primary shadow-sm'
+                                                        : 'text-content-muted hover:text-content-secondary'
                                                         }`}
                                                 >
                                                     Tracked Amount
@@ -919,7 +919,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                     value={newHabitUnit}
                                                     onChange={(e) => setNewHabitUnit(e.target.value)}
                                                     placeholder="Unit (e.g. miles)"
-                                                    className="bg-neutral-900 border border-white/10 rounded px-2 py-1.5 text-xs text-white w-24 animate-in fade-in slide-in-from-left-2"
+                                                    className="bg-surface-0 border border-line-subtle rounded px-2 py-1.5 text-xs text-content-primary w-24 animate-in fade-in slide-in-from-left-2"
                                                 />
                                             )}
                                         </div>
@@ -929,7 +929,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
 
                             {/* List of Items (Linked + Pending) */}
                             {(subHabitIds.length > 0 || pendingSubHabits.length > 0) && (
-                                <div className="bg-neutral-800/20 rounded-lg border border-white/5 overflow-hidden">
+                                <div className="bg-surface-1/20 rounded-lg border border-line-subtle overflow-hidden">
                                     {/* We can't easily show linked habits names without finding them, so just show pending + count logic? 
                                         Actually, let's just list them simply.
                                      */}
@@ -938,15 +938,15 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                         {pendingSubHabits.map((p, idx) => (
                                             <div key={p.tempId} className={`flex justify-between items-center p-2 rounded border transition-colors ${editingPendingId === p.tempId
                                                 ? 'bg-amber-500/10 border-amber-500/30'
-                                                : 'bg-neutral-800 border-white/5'
+                                                : 'bg-surface-1 border-line-subtle'
                                                 }`}>
                                                 <div
                                                     className="flex items-center gap-2 flex-1 cursor-pointer"
                                                     onClick={() => handleEditPendingSubHabit(p.tempId)}
                                                 >
-                                                    <span className={`text-sm ${editingPendingId === p.tempId ? 'text-amber-200' : 'text-white'}`}>{p.name}</span>
+                                                    <span className={`text-sm ${editingPendingId === p.tempId ? 'text-amber-200' : 'text-content-primary'}`}>{p.name}</span>
                                                     {p.goalType === 'number' && (
-                                                        <span className="text-xs text-emerald-400 bg-emerald-500/10 px-1 rounded">
+                                                        <span className="text-xs text-accent-contrast bg-accent-soft px-1 rounded">
                                                             {p.unit || 'units'}
                                                         </span>
                                                     )}
@@ -965,7 +965,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                         }}
                                                         disabled={idx === 0}
                                                         aria-label="Move up"
-                                                        className="text-neutral-500 hover:text-white p-1 disabled:opacity-30 disabled:hover:text-neutral-500"
+                                                        className="text-content-muted hover:text-content-primary p-1 disabled:opacity-30 disabled:hover:text-content-muted"
                                                     >
                                                         <ChevronUp size={14} />
                                                     </button>
@@ -977,7 +977,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                         }}
                                                         disabled={idx === pendingSubHabits.length - 1}
                                                         aria-label="Move down"
-                                                        className="text-neutral-500 hover:text-white p-1 disabled:opacity-30 disabled:hover:text-neutral-500"
+                                                        className="text-content-muted hover:text-content-primary p-1 disabled:opacity-30 disabled:hover:text-content-muted"
                                                     >
                                                         <ChevronDown size={14} />
                                                     </button>
@@ -988,7 +988,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                                             removePendingSubHabit(p.tempId);
                                                         }}
                                                         aria-label="Remove"
-                                                        className="text-neutral-500 hover:text-red-400 p-1"
+                                                        className="text-content-muted hover:text-red-400 p-1"
                                                     >
                                                         <X size={14} />
                                                     </button>
@@ -1093,27 +1093,27 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                     {/* 4. Numeric Target Configuration */}
                     {
                         habitType === 'regular' && goalType === 'number' && (
-                            <div className="grid grid-cols-2 gap-4 pt-2 border-t border-white/5">
+                            <div className="grid grid-cols-2 gap-4 pt-2 border-t border-line-subtle">
                                 <div>
-                                    <label className="block text-sm font-medium text-neutral-400 mb-1">
+                                    <label className="block text-sm font-medium text-content-secondary mb-1">
                                         Target Amount <span className="text-xs opacity-50 font-normal">(Optional)</span>
                                     </label>
                                     <input
                                         type="number"
                                         value={target}
                                         onChange={(e) => setTarget(e.target.value)}
-                                        className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                        className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                         placeholder="e.g. 10"
                                     />
                                 </div>
                                 {goalType === 'number' && (
                                     <div>
-                                        <label className="block text-sm font-medium text-neutral-400 mb-1">Unit</label>
+                                        <label className="block text-sm font-medium text-content-secondary mb-1">Unit</label>
                                         <input
                                             type="text"
                                             value={unit}
                                             onChange={(e) => setUnit(e.target.value)}
-                                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                             placeholder="e.g. pages"
                                         />
                                     </div>
@@ -1123,9 +1123,9 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                     }
 
                     {/* 5. Schedule & Streak */}
-                    <div className="space-y-4 pt-2 border-t border-white/5">
+                    <div className="space-y-4 pt-2 border-t border-line-subtle">
                         <div className="space-y-2">
-                            <label className="text-xs font-medium text-neutral-400 uppercase flex items-center gap-1">
+                            <label className="text-xs font-medium text-content-secondary uppercase flex items-center gap-1">
                                 <Calendar size={12} /> Scheduled Days
                             </label>
                             <DayChipSelector
@@ -1136,7 +1136,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                         </div>
 
                         <div className="space-y-2">
-                            <label className="text-xs font-medium text-neutral-400 uppercase flex items-center gap-1">
+                            <label className="text-xs font-medium text-content-secondary uppercase flex items-center gap-1">
                                 <Shield size={12} /> Days Per Week Required
                             </label>
                             <NumberChipSelector
@@ -1151,7 +1151,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 </p>
                             )}
                             {requiredDaysPerWeek < scheduledDays.length && (
-                                <p className="text-xs text-emerald-400 mt-1">
+                                <p className="text-xs text-accent-contrast mt-1">
                                     {scheduledDays.length - requiredDaysPerWeek} grace day{scheduledDays.length - requiredDaysPerWeek !== 1 ? 's' : ''} per week
                                 </p>
                             )}
@@ -1160,11 +1160,11 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
 
                     {/* Add to Bundle action — for regular habits not already in a bundle */}
                     {isEditMode && initialData && habitType === 'regular' && !initialData.bundleParentId && initialData.type !== 'bundle' && (
-                        <div className="border-t border-white/5 pt-3">
+                        <div className="border-t border-line-subtle pt-3">
                             <button
                                 type="button"
                                 onClick={() => setShowBundlePicker(true)}
-                                className="flex items-center gap-2 w-full px-3 py-2.5 rounded-lg text-left transition-colors hover:bg-white/5 active:bg-white/10 text-neutral-400 hover:text-neutral-200"
+                                className="flex items-center gap-2 w-full px-3 py-2.5 rounded-lg text-left transition-colors hover:bg-surface-2 active:bg-white/10 text-content-secondary hover:text-content-primary"
                             >
                                 <Layers size={16} className="text-indigo-400" />
                                 <span className="text-sm font-medium">Add to Bundle...</span>
@@ -1173,11 +1173,11 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                     )}
 
                     {/* Actions */}
-                    <div className="sticky bottom-0 pt-2 pb-1 bg-neutral-900 flex justify-end gap-3">
+                    <div className="sticky bottom-0 pt-2 pb-1 bg-surface-0 flex justify-end gap-3">
                         <button
                             type="button"
                             onClick={onClose}
-                            className="px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                            className="px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                         >
                             Cancel
                         </button>
@@ -1189,7 +1189,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 (habitType === 'bundle' && bundleMode === 'checklist' && subHabitIds.length === 0 && pendingSubHabits.length === 0) ||
                                 (habitType === 'bundle' && bundleMode === 'choice' && (subHabitIds.length + pendingSubHabits.length) < 1)
                             }
-                            className="w-full bg-emerald-500 hover:bg-emerald-600 text-white font-bold py-3 rounded-lg transition-colors flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="w-full bg-emerald-500 hover:bg-accent-strong text-content-primary font-bold py-3 rounded-lg transition-colors flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             {isEditMode ? 'Save Changes' : 'Create Habit'}
                         </button>

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -17,7 +17,7 @@ const tabs: { route: TabRoute; label: string; icon: React.FC<{ size?: number; cl
 
 export const BottomTabBar: React.FC<BottomTabBarProps> = ({ activeView, onNavigate }) => {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-neutral-900 border-t border-white/10 pb-[env(safe-area-inset-bottom,0px)]">
+    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-surface-1 border-t border-line-subtle pb-[env(safe-area-inset-bottom,0px)]">
       <div className="flex items-center justify-around max-w-lg mx-auto h-14">
         {tabs.map(({ route, label, icon: Icon }) => {
           const isActive = activeView === route;
@@ -27,14 +27,14 @@ export const BottomTabBar: React.FC<BottomTabBarProps> = ({ activeView, onNaviga
               onClick={() => onNavigate(route)}
               className={`flex flex-col items-center justify-center gap-0.5 min-w-[3rem] py-1 px-1 transition-colors ${
                 isActive
-                  ? 'text-emerald-400'
-                  : 'text-neutral-500 active:text-neutral-300'
+                  ? 'text-accent-contrast'
+                  : 'text-content-muted active:text-content-secondary'
               }`}
               aria-label={label}
               aria-current={isActive ? 'page' : undefined}
             >
-              <Icon size={20} className={isActive ? 'text-emerald-400' : ''} />
-              <span className={`text-[10px] font-medium leading-tight ${isActive ? 'text-emerald-400' : ''}`}>
+              <Icon size={20} className={isActive ? 'text-accent-contrast' : ''} />
+              <span className={`text-[10px] font-medium leading-tight ${isActive ? 'text-accent-contrast' : ''}`}>
                 {label}
               </span>
             </button>

--- a/src/components/BundleComponents.tsx
+++ b/src/components/BundleComponents.tsx
@@ -40,21 +40,21 @@ export const DailyBundleRow: React.FC<BundleRowProps> = ({
     const isChoice = habit.bundleType === 'choice';
 
     return (
-        <div className="flex flex-col border-b border-white/5 bg-neutral-900/30">
+        <div className="flex flex-col border-b border-line-subtle bg-surface-0/30">
             {/* Parent Row */}
             <div className="flex">
                 <div
-                    className="w-64 flex-shrink-0 p-4 border-r border-white/5 flex items-center justify-between cursor-pointer hover:bg-white/[0.02] group relative"
+                    className="w-64 flex-shrink-0 p-4 border-r border-line-subtle flex items-center justify-between cursor-pointer hover:bg-white/[0.02] group relative"
                     onClick={isChoice ? undefined : onToggleExpand} // Disable expand for choice
                 >
                     <div className="flex items-center gap-3">
                         <div className="flex flex-col">
-                            <span className="font-medium text-neutral-200 flex items-center gap-2">
+                            <span className="font-medium text-content-primary flex items-center gap-2">
                                 {habit.name}
                                 {isChoice ? <Layers size={14} className="text-amber-400" /> : <ListTodo size={14} className="text-indigo-400" />}
                                 {habit.linkedGoalId && <Trophy size={12} className="text-amber-500" />}
                             </span>
-                            <span className="text-xs text-neutral-500">
+                            <span className="text-xs text-content-muted">
                                 {isChoice ? (habit.bundleOptions?.length || 0) + ' Options' : (subHabits.length || 0) + ' items'}
                             </span>
                         </div>
@@ -65,8 +65,8 @@ export const DailyBundleRow: React.FC<BundleRowProps> = ({
                     )}
 
                     {/* Actions Context Menu */}
-                    <div className="absolute right-2 opacity-0 group-hover:opacity-100 flex gap-2 bg-neutral-900/80 p-1 rounded">
-                        <button onClick={(e) => { e.stopPropagation(); onEditHabit(habit); }} className="text-xs text-neutral-500 hover:text-white">Edit</button>
+                    <div className="absolute right-2 opacity-0 group-hover:opacity-100 flex gap-2 bg-surface-0/80 p-1 rounded">
+                        <button onClick={(e) => { e.stopPropagation(); onEditHabit(habit); }} className="text-xs text-content-muted hover:text-content-primary">Edit</button>
                     </div>
                 </div>
 
@@ -104,9 +104,9 @@ export const DailyBundleRow: React.FC<BundleRowProps> = ({
                         else if (ruleType === 'percent') meetsSuccess = totalChildren > 0 && (completedChildren / totalChildren) * 100 >= (rule?.percent ?? 100);
 
                         return (
-                            <div key={dateStr} className="w-16 flex-shrink-0 border-r border-white/5 flex items-center justify-center p-2">
+                            <div key={dateStr} className="w-16 flex-shrink-0 border-r border-line-subtle flex items-center justify-center p-2">
                                 <div
-                                    className="relative w-full h-full flex flex-col items-center justify-center cursor-pointer hover:bg-white/5 transition-colors p-1"
+                                    className="relative w-full h-full flex flex-col items-center justify-center cursor-pointer hover:bg-surface-2 transition-colors p-1"
                                     onClick={() => {
                                         const targetState = !isFullyComplete;
                                         subHabits.forEach(sub => {
@@ -119,12 +119,12 @@ export const DailyBundleRow: React.FC<BundleRowProps> = ({
                                 >
                                     <div className={cn(
                                         "text-[10px] font-medium mb-1",
-                                        isFullyComplete ? "text-emerald-400" : meetsSuccess ? "text-indigo-400" : "text-neutral-400"
+                                        isFullyComplete ? "text-accent-contrast" : meetsSuccess ? "text-indigo-400" : "text-content-secondary"
                                     )}>
                                         {completedChildren}/{totalChildren}
                                         {meetsSuccess && !isFullyComplete && <span className="ml-0.5 text-[8px]">&#10003;</span>}
                                     </div>
-                                    <div className="w-full h-1 bg-neutral-800 rounded-full overflow-hidden">
+                                    <div className="w-full h-1 bg-surface-1 rounded-full overflow-hidden">
                                         <div
                                             className={cn(
                                                 "h-full transition-all duration-300",
@@ -144,21 +144,21 @@ export const DailyBundleRow: React.FC<BundleRowProps> = ({
             {isExpanded && !isChoice && (
                 <div className="flex flex-col">
                     {subHabits.map((child: Habit) => (
-                        <div key={child.id} className="flex border-b border-white/5 last:border-0 bg-neutral-900/50">
+                        <div key={child.id} className="flex border-b border-line-subtle last:border-0 bg-surface-0/50">
                             {/* Child Name Cell */}
                             <div
-                                className="w-64 flex-shrink-0 p-4 pl-12 border-r border-white/5 flex items-center justify-between cursor-pointer hover:bg-white/[0.02] group relative"
+                                className="w-64 flex-shrink-0 p-4 pl-12 border-r border-line-subtle flex items-center justify-between cursor-pointer hover:bg-white/[0.02] group relative"
                                 onClick={(e) => {
                                     handleCellClick(e, child, format(new Date(), 'yyyy-MM-dd'));
                                 }}
                             >
-                                <span className="text-sm text-neutral-400 truncate flex items-center gap-1.5">
+                                <span className="text-sm text-content-secondary truncate flex items-center gap-1.5">
                                     {child.name}
                                     {child.linkedGoalId && <Trophy size={10} className="flex-shrink-0 text-amber-500" />}
                                 </span>
                                 {/* Child Actions */}
-                                <div className="absolute right-2 opacity-0 group-hover:opacity-100 flex gap-2 bg-neutral-900/80 p-1 rounded">
-                                    <button onClick={(e) => { e.stopPropagation(); onEditHabit(child); }} className="text-[10px] text-neutral-500 hover:text-white uppercase tracking-wider font-semibold">Edit</button>
+                                <div className="absolute right-2 opacity-0 group-hover:opacity-100 flex gap-2 bg-surface-0/80 p-1 rounded">
+                                    <button onClick={(e) => { e.stopPropagation(); onEditHabit(child); }} className="text-[10px] text-content-muted hover:text-content-primary uppercase tracking-wider font-semibold">Edit</button>
                                     <button onClick={(e) => { e.stopPropagation(); if (deleteConfirmId === child.id) deleteHabit(child.id); else setDeleteConfirmId(child.id); }} className="text-[10px] text-red-500 hover:text-red-400 uppercase tracking-wider font-semibold">
                                         {deleteConfirmId === child.id ? 'Sure?' : 'Del'}
                                     </button>
@@ -171,10 +171,10 @@ export const DailyBundleRow: React.FC<BundleRowProps> = ({
                                     const log = logs[`${child.id}-${dateStr}`];
                                     const isDone = log?.completed;
                                     return (
-                                        <div key={dateStr} className="w-16 flex-shrink-0 border-r border-white/5 flex items-center justify-center p-2">
+                                        <div key={dateStr} className="w-16 flex-shrink-0 border-r border-line-subtle flex items-center justify-center p-2">
                                             <button
                                                 onClick={(e) => { e.stopPropagation(); onToggle(child.id, dateStr); }}
-                                                className={cn("w-6 h-6 rounded flex items-center justify-center transition-colors", isDone ? "bg-indigo-500/20 text-indigo-400" : "bg-neutral-800 text-neutral-700 hover:bg-neutral-700")}
+                                                className={cn("w-6 h-6 rounded flex items-center justify-center transition-colors", isDone ? "bg-indigo-500/20 text-indigo-400" : "bg-surface-1 text-neutral-700 hover:bg-surface-2")}
                                             >
                                                 <Check size={14} className={isDone ? 'opacity-100' : 'opacity-0'} />
                                             </button>
@@ -241,15 +241,15 @@ const ChoiceCell: React.FC<{
     }, [showMenu]);
 
     return (
-        <div className="w-16 flex-shrink-0 border-r border-white/5 relative flex items-center justify-center p-2">
+        <div className="w-16 flex-shrink-0 border-r border-line-subtle relative flex items-center justify-center p-2">
             <button
                 ref={triggerRef}
                 onClick={handleGenericToggle}
                 className={cn(
                     "w-10 h-10 rounded-lg flex items-center justify-center transition-all relative group/btn",
                     isCompleted
-                        ? (currentOption ? "bg-amber-500 text-neutral-900" : "bg-emerald-500 text-neutral-900")
-                        : "bg-neutral-800 text-neutral-600 hover:bg-neutral-700"
+                        ? (currentOption ? "bg-amber-500 text-neutral-900" : "bg-accent text-content-on-accent")
+                        : "bg-surface-1 text-content-muted hover:bg-surface-2"
                 )}
             >
                 {isCompleted && (
@@ -263,7 +263,7 @@ const ChoiceCell: React.FC<{
                 )}
                 {/* Hover Hint if Completed */}
                 {isCompleted && !showMenu && (
-                    <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-black/90 text-white text-[10px] px-2 py-1 rounded opacity-0 group-hover/btn:opacity-100 pointer-events-none whitespace-nowrap z-20">
+                    <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-black/90 text-content-primary text-[10px] px-2 py-1 rounded opacity-0 group-hover/btn:opacity-100 pointer-events-none whitespace-nowrap z-20">
                         {currentOption ? currentOption.label : 'Generic Complete'}
                     </div>
                 )}
@@ -272,7 +272,7 @@ const ChoiceCell: React.FC<{
             {/* Portal Menu */}
             {showMenu && createPortal(
                 <div
-                    className="fixed w-32 bg-neutral-800 border border-white/10 rounded-lg shadow-xl z-[9999] overflow-hidden flex flex-col p-1"
+                    className="fixed w-32 bg-surface-1 border border-line-subtle rounded-lg shadow-xl z-[9999] overflow-hidden flex flex-col p-1"
                     style={{
                         top: menuPos.top,
                         left: menuPos.left,
@@ -280,7 +280,7 @@ const ChoiceCell: React.FC<{
                     }}
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <div className="text-[10px] uppercase text-neutral-500 px-2 py-1 font-semibold">Select Option</div>
+                    <div className="text-[10px] uppercase text-content-muted px-2 py-1 font-semibold">Select Option</div>
                     {habit.bundleOptions?.map(opt => (
                         <button
                             key={opt.key}
@@ -289,8 +289,8 @@ const ChoiceCell: React.FC<{
                                 setShowMenu(false);
                             }}
                             className={cn(
-                                "text-left px-2 py-1.5 text-xs rounded hover:bg-white/10 transition-colors flex items-center gap-2",
-                                currentOptionKey === opt.key ? "text-amber-400" : "text-neutral-300"
+                                "text-left px-2 py-1.5 text-xs rounded hover:bg-surface-2 transition-colors flex items-center gap-2",
+                                currentOptionKey === opt.key ? "text-amber-400" : "text-content-secondary"
                             )}
                         >
                             {currentOptionKey === opt.key && <div className="w-1 h-1 rounded-full bg-amber-400" />}

--- a/src/components/BundlePickerModal.tsx
+++ b/src/components/BundlePickerModal.tsx
@@ -76,21 +76,21 @@ export const BundlePickerModal = ({
         <div className="modal-overlay fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
             <div
                 className={cn(
-                    "bg-neutral-900 border border-white/10 rounded-t-2xl sm:rounded-2xl w-full sm:max-w-sm shadow-2xl",
+                    "bg-surface-0 border border-line-subtle rounded-t-2xl sm:rounded-2xl w-full sm:max-w-sm shadow-2xl",
                     "animate-in slide-in-from-bottom-4 fade-in duration-200",
                     "max-h-[80vh] flex flex-col"
                 )}
                 onClick={e => e.stopPropagation()}
             >
                 {/* Header */}
-                <div className="flex items-center justify-between p-4 border-b border-white/5">
+                <div className="flex items-center justify-between p-4 border-b border-line-subtle">
                     <div className="flex items-center gap-2">
                         <Layers size={18} className="text-indigo-400" />
-                        <h3 className="text-base font-semibold text-white">Add to Bundle</h3>
+                        <h3 className="text-base font-semibold text-content-primary">Add to Bundle</h3>
                     </div>
                     <button
                         onClick={onClose}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg hover:bg-white/10 text-neutral-400 hover:text-white transition-colors -m-1"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg hover:bg-surface-2 text-content-secondary hover:text-content-primary transition-colors -m-1"
                         aria-label="Close"
                     >
                         <X size={18} />
@@ -99,8 +99,8 @@ export const BundlePickerModal = ({
 
                 {/* Current habit */}
                 <div className="px-4 pt-3 pb-2">
-                    <p className="text-xs text-neutral-500">
-                        Adding <span className="text-neutral-300 font-medium">{habitName}</span> to a bundle
+                    <p className="text-xs text-content-muted">
+                        Adding <span className="text-content-secondary font-medium">{habitName}</span> to a bundle
                     </p>
                 </div>
 
@@ -108,13 +108,13 @@ export const BundlePickerModal = ({
                 {bundles.length >= 4 && (
                     <div className="px-4 pb-2">
                         <div className="relative">
-                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500" />
+                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-content-muted" />
                             <input
                                 type="text"
                                 placeholder="Search bundles..."
                                 value={search}
                                 onChange={e => setSearch(e.target.value)}
-                                className="w-full pl-9 pr-3 py-2 bg-neutral-800 border border-white/5 rounded-lg text-sm text-white placeholder-neutral-500 focus:outline-none focus:border-indigo-500/50"
+                                className="w-full pl-9 pr-3 py-2 bg-surface-1 border border-line-subtle rounded-lg text-sm text-content-primary placeholder-neutral-500 focus:outline-none focus:border-indigo-500/50"
                                 autoFocus
                             />
                         </div>
@@ -124,7 +124,7 @@ export const BundlePickerModal = ({
                 {/* Bundle list */}
                 <div className="flex-1 overflow-y-auto modal-scroll px-2 pb-4">
                     {bundles.length === 0 ? (
-                        <p className="text-center text-sm text-neutral-500 py-6">
+                        <p className="text-center text-sm text-content-muted py-6">
                             {search ? 'No matching bundles' : 'No bundles available'}
                         </p>
                     ) : (
@@ -134,7 +134,7 @@ export const BundlePickerModal = ({
                                     key={bundle.id}
                                     onClick={() => handleSelect(bundle)}
                                     disabled={isMoving}
-                                    className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left transition-colors hover:bg-white/5 text-neutral-200 active:bg-white/10 disabled:opacity-50"
+                                    className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left transition-colors hover:bg-surface-2 text-content-primary active:bg-white/10 disabled:opacity-50"
                                 >
                                     <div className={cn(
                                         "p-1.5 rounded-lg flex-shrink-0",
@@ -149,7 +149,7 @@ export const BundlePickerModal = ({
                                     </div>
                                     <div className="flex-1 min-w-0">
                                         <span className="text-sm font-medium truncate block">{bundle.name}</span>
-                                        <span className="text-xs text-neutral-500">
+                                        <span className="text-xs text-content-muted">
                                             {bundle.bundleType === 'checklist' ? 'Checklist' : 'Choice'}
                                             {bundle.subHabitIds && bundle.subHabitIds.length > 0 && (
                                                 <> &middot; {bundle.subHabitIds.length} item{bundle.subHabitIds.length !== 1 ? 's' : ''}</>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -42,7 +42,7 @@ const DroppableSlot = ({ dayIndex, time, children }: { dayIndex: number, time: s
     return (
         <div
             ref={setNodeRef}
-            className={`h-[40px] border-b border-white/5 w-full relative group transition-colors ${isOver ? 'bg-emerald-500/10' : ''}`}
+            className={`h-[40px] border-b border-line-subtle w-full relative group transition-colors ${isOver ? 'bg-accent-soft' : ''}`}
         >
             {children}
         </div>
@@ -164,8 +164,8 @@ export const CalendarView: React.FC = () => {
                 className={cn(
                     "rounded px-2 py-1 transition-colors cursor-move group overflow-hidden z-20 hover:shadow-lg hover:scale-[1.02] active:scale-95 duration-100 h-full w-full border",
                     isNonNegotiable
-                        ? "bg-emerald-500/20 border-yellow-500 shadow-[0_0_8px_rgba(234,179,8,0.4)]"
-                        : "bg-emerald-500/20 border-emerald-500/50 hover:bg-emerald-500/30"
+                        ? "bg-accent-soft border-yellow-500 shadow-[0_0_8px_rgba(234,179,8,0.4)]"
+                        : "bg-accent-soft border-accent/50 hover:bg-accent-strong/30"
                 )}
                 style={style}
                 title={`${habit.name} (${habit.scheduledTime})${isNonNegotiable ? ' - Non-Negotiable' : ''}`}
@@ -173,7 +173,7 @@ export const CalendarView: React.FC = () => {
                 <div className={cn("text-xs font-medium truncate", isNonNegotiable ? "text-yellow-100" : "text-emerald-100")}>
                     {habit.name}
                 </div>
-                <div className="text-[10px] text-emerald-300/80 truncate">
+                <div className="text-[10px] text-accent-contrast/80 truncate">
                     {habit.scheduledTime} ({habit.durationMinutes}m)
                 </div>
             </div>
@@ -191,33 +191,33 @@ export const CalendarView: React.FC = () => {
                 />
 
                 {/* Header */}
-                <div className="flex items-center justify-between bg-neutral-900/50 p-4 rounded-xl border border-white/5 backdrop-blur-sm">
-                    <h2 className="text-xl font-bold text-white flex items-center gap-2">
-                        <CalendarIcon className="text-emerald-400" />
+                <div className="flex items-center justify-between bg-surface-0/50 p-4 rounded-xl border border-line-subtle backdrop-blur-sm">
+                    <h2 className="text-xl font-bold text-content-primary flex items-center gap-2">
+                        <CalendarIcon className="text-accent-contrast" />
                         Weekly Calendar
                     </h2>
                     <div className="flex items-center gap-4">
-                        <button onClick={handlePrevWeek} className="p-2 hover:bg-white/5 rounded-lg text-neutral-400 hover:text-white">
+                        <button onClick={handlePrevWeek} className="p-2 hover:bg-surface-2 rounded-lg text-content-secondary hover:text-content-primary">
                             <ChevronLeft size={20} />
                         </button>
-                        <span className="font-medium text-neutral-200">
+                        <span className="font-medium text-content-primary">
                             {format(currentWeekStart, 'MMM d')} - {format(addDays(currentWeekStart, 6), 'MMM d, yyyy')}
                         </span>
-                        <button onClick={handleNextWeek} className="p-2 hover:bg-white/5 rounded-lg text-neutral-400 hover:text-white">
+                        <button onClick={handleNextWeek} className="p-2 hover:bg-surface-2 rounded-lg text-content-secondary hover:text-content-primary">
                             <ChevronRight size={20} />
                         </button>
                     </div>
                 </div>
 
                 {/* Calendar Grid Container */}
-                <div className="flex-1 bg-neutral-900/50 rounded-xl border border-white/5 backdrop-blur-sm overflow-hidden flex flex-col relative min-h-[400px]">
+                <div className="flex-1 bg-surface-0/50 rounded-xl border border-line-subtle backdrop-blur-sm overflow-hidden flex flex-col relative min-h-[400px]">
                     {/* Header Row (Days) */}
-                    <div className="flex border-b border-white/5 bg-neutral-900 sticky top-0 z-20 pr-4">
-                        <div className="w-16 flex-shrink-0 border-r border-white/5" />
+                    <div className="flex border-b border-line-subtle bg-surface-0 sticky top-0 z-20 pr-4">
+                        <div className="w-16 flex-shrink-0 border-r border-line-subtle" />
                         {weekDays.map(day => (
-                            <div key={day.toISOString()} className="flex-1 p-2 text-center border-r border-white/5 last:border-0 border-b border-transparent">
-                                <div className="text-xs font-medium text-neutral-500 uppercase">{format(day, 'EEE')}</div>
-                                <div className={`text-lg font-bold ${isSameDay(day, new Date()) ? 'text-emerald-400' : 'text-neutral-300'}`}>
+                            <div key={day.toISOString()} className="flex-1 p-2 text-center border-r border-line-subtle last:border-0 border-b border-transparent">
+                                <div className="text-xs font-medium text-content-muted uppercase">{format(day, 'EEE')}</div>
+                                <div className={`text-lg font-bold ${isSameDay(day, new Date()) ? 'text-accent-contrast' : 'text-content-secondary'}`}>
                                     {format(day, 'd')}
                                 </div>
                             </div>
@@ -228,9 +228,9 @@ export const CalendarView: React.FC = () => {
                     <div className="flex-1 overflow-y-auto relative scrollbar-thin scrollbar-thumb-neutral-700">
                         <div className="flex relative min-h-[1000px]">
                             {/* Time Labels Column */}
-                            <div className="w-16 flex-shrink-0 border-r border-white/5 bg-neutral-900/50 z-10">
+                            <div className="w-16 flex-shrink-0 border-r border-line-subtle bg-surface-0/50 z-10">
                                 {timeSlots.map((slot, i) => (
-                                    <div key={i} className="h-[40px] text-[10px] text-neutral-500 text-right pr-2 pt-1 border-b border-white/5 last:border-0">
+                                    <div key={i} className="h-[40px] text-[10px] text-content-muted text-right pr-2 pt-1 border-b border-line-subtle last:border-0">
                                         {slot.minute === 0 ? slot.timeStr : ''}
                                     </div>
                                 ))}
@@ -244,7 +244,7 @@ export const CalendarView: React.FC = () => {
                                         const jsDayIndex = day.getDay();
 
                                         return (
-                                            <div key={day.toISOString()} className="flex-1 border-r border-white/5 last:border-0 h-full relative group">
+                                            <div key={day.toISOString()} className="flex-1 border-r border-line-subtle last:border-0 h-full relative group">
                                                 {/* Droppable Background Slots */}
                                                 <div className="absolute inset-0 flex flex-col z-0">
                                                     {timeSlots.map((slot, i) => (
@@ -286,17 +286,17 @@ export const CalendarView: React.FC = () => {
 
                 {/* Unassigned Habits Table */}
                 {unassignedHabits.length > 0 && (
-                    <div className="bg-neutral-900/50 rounded-xl border border-white/5 backdrop-blur-sm p-6 overflow-hidden flex flex-col max-h-[40%] shrink-0">
-                        <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2 shrink-0">
+                    <div className="bg-surface-0/50 rounded-xl border border-line-subtle backdrop-blur-sm p-6 overflow-hidden flex flex-col max-h-[40%] shrink-0">
+                        <h3 className="text-lg font-bold text-content-primary mb-4 flex items-center gap-2 shrink-0">
                             <Clock className="text-yellow-500" size={18} />
                             Unassigned Habits
-                            <span className="text-xs font-normal text-neutral-500 ml-2">
+                            <span className="text-xs font-normal text-content-muted ml-2">
                                 (Set a time to move these to the calendar)
                             </span>
                         </h3>
                         <div className="overflow-auto min-h-0">
-                            <table className="w-full text-left text-sm text-neutral-400">
-                                <thead className="text-xs uppercase text-neutral-300 sticky top-0 bg-neutral-900 z-10">
+                            <table className="w-full text-left text-sm text-content-secondary">
+                                <thead className="text-xs uppercase text-content-secondary sticky top-0 bg-surface-0 z-10">
                                     <tr>
                                         <th className="px-4 py-3">Habit Name</th>
                                         <th className="px-4 py-3">Assigned Days</th>
@@ -353,7 +353,7 @@ const UnassignedHabitRow = ({ habit, onUpdate }: { habit: Habit, onUpdate: any }
 
     return (
         <tr className="hover:bg-white/[0.02] transition-colors">
-            <td className="px-4 py-3 font-medium text-white">{habit.name}</td>
+            <td className="px-4 py-3 font-medium text-content-primary">{habit.name}</td>
             <td className="px-4 py-3">
                 <div className="flex gap-1">
                     {days.map((d, i) => (
@@ -362,7 +362,7 @@ const UnassignedHabitRow = ({ habit, onUpdate }: { habit: Habit, onUpdate: any }
                             onClick={() => setAssignedDays(prev =>
                                 prev.includes(i) ? prev.filter(x => x !== i) : [...prev, i]
                             )}
-                            className={`w-6 h-6 text-[10px] rounded flex items-center justify-center transition-colors ${assignedDays.includes(i) ? 'bg-emerald-500 text-neutral-900 font-bold' : 'bg-neutral-800 hover:bg-neutral-700'
+                            className={`w-6 h-6 text-[10px] rounded flex items-center justify-center transition-colors ${assignedDays.includes(i) ? 'bg-accent text-content-on-accent font-bold' : 'bg-surface-1 hover:bg-surface-2'
                                 }`}
                         >
                             {d}
@@ -375,7 +375,7 @@ const UnassignedHabitRow = ({ habit, onUpdate }: { habit: Habit, onUpdate: any }
                     type="time"
                     value={time}
                     onChange={e => setTime(e.target.value)}
-                    className="bg-neutral-800 border-white/10 rounded px-2 py-1 text-white focus:border-emerald-500 focus:outline-none"
+                    className="bg-surface-1 border-line-subtle rounded px-2 py-1 text-content-primary focus:border-focus focus:outline-none"
                 />
             </td>
             <td className="px-4 py-3">
@@ -383,7 +383,7 @@ const UnassignedHabitRow = ({ habit, onUpdate }: { habit: Habit, onUpdate: any }
                     type="number"
                     value={duration}
                     onChange={e => setDuration(e.target.value)}
-                    className="bg-neutral-800 border-white/10 rounded px-2 py-1 text-white w-20 focus:border-emerald-500 focus:outline-none"
+                    className="bg-surface-1 border-line-subtle rounded px-2 py-1 text-content-primary w-20 focus:border-focus focus:outline-none"
                     min="5" step="5"
                 />
             </td>
@@ -392,8 +392,8 @@ const UnassignedHabitRow = ({ habit, onUpdate }: { habit: Habit, onUpdate: any }
                     onClick={handleSave}
                     disabled={!isDirty || !time}
                     className={`p-1.5 rounded-lg transition-colors ${isDirty && time
-                        ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500 hover:text-white cursor-pointer'
-                        : 'bg-white/5 text-neutral-600 cursor-not-allowed'
+                        ? 'bg-accent-soft text-accent-contrast hover:bg-accent-strong hover:text-content-primary cursor-pointer'
+                        : 'bg-white/5 text-content-muted cursor-not-allowed'
                         }`}
                     title={!time ? "Time required" : !isDirty ? "No changes" : "Save Changes"}
                 >

--- a/src/components/CategoryCompletionRow.tsx
+++ b/src/components/CategoryCompletionRow.tsx
@@ -66,15 +66,15 @@ export const CategoryCompletionRow: React.FC<CategoryCompletionRowProps> = React
     return (
         <button
             onClick={onClick}
-            className="w-full group flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 rounded-xl bg-neutral-900/30 border border-white/5 hover:bg-neutral-800/50 hover:border-emerald-500/30 transition-all duration-200"
+            className="w-full group flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 rounded-xl bg-surface-0/30 border border-line-subtle hover:bg-surface-1/50 hover:border-accent/30 transition-all duration-200"
         >
             <div className="flex items-center gap-3">
                 <div className={`w-1 h-8 rounded-full ${category.color} opacity-80`} />
                 <div className="text-left">
-                    <h4 className={`font-bold text-sm ${textColorClass} group-hover:text-white transition-colors`}>
+                    <h4 className={`font-bold text-sm ${textColorClass} group-hover:text-content-primary transition-colors`}>
                         {category.name}
                     </h4>
-                    <div className="item-center flex gap-2 text-xs text-neutral-500">
+                    <div className="item-center flex gap-2 text-xs text-content-muted">
                         <span>{habits.length} habits</span>
                         <span>•</span>
                         <span>{totalCompletions} completions</span>
@@ -94,10 +94,10 @@ export const CategoryCompletionRow: React.FC<CategoryCompletionRowProps> = React
                         />
                     ))}
                 </div>
-                <ChevronRight size={16} className="text-neutral-600 group-hover:text-white transition-colors hidden sm:block" />
+                <ChevronRight size={16} className="text-content-muted group-hover:text-content-primary transition-colors hidden sm:block" />
             </div>
 
-            <Tooltip id={`cat-tooltip-${category.id}`} className="z-50 !bg-neutral-800 !text-white !opacity-100 !rounded-lg !px-3 !py-1 !text-xs" />
+            <Tooltip id={`cat-tooltip-${category.id}`} className="z-50 !bg-surface-1 !text-content-primary !opacity-100 !rounded-lg !px-3 !py-1 !text-xs" />
         </button>
     );
 });

--- a/src/components/CategoryMomentumBanner.tsx
+++ b/src/components/CategoryMomentumBanner.tsx
@@ -31,7 +31,7 @@ export const CategoryMomentumBanner: React.FC<CategoryMomentumBannerProps> = ({ 
             <div className={`text-xs font-bold uppercase tracking-wider ${colorClass}`}>
                 Momentum: {state}
             </div>
-            <div className="hidden sm:block w-px h-3 bg-white/10" />
+            <div className="hidden sm:block w-px h-3 bg-surface-2" />
             <div className="text-sm text-content-secondary italic font-medium">
                 "{phrase}"
             </div>

--- a/src/components/CategoryMomentumBanner.tsx
+++ b/src/components/CategoryMomentumBanner.tsx
@@ -18,13 +18,13 @@ export const CategoryMomentumBanner: React.FC<CategoryMomentumBannerProps> = ({ 
 
     // Determine color based on state for visual flair, or keep simple text
     const stateColors: Record<string, string> = {
-        'Strong': 'text-emerald-400',
+        'Strong': 'text-accent-contrast',
         'Steady': 'text-blue-400',
         'Building': 'text-orange-400',
-        'Paused': 'text-neutral-400'
+        'Paused': 'text-content-secondary'
     };
 
-    const colorClass = stateColors[state] || 'text-neutral-400';
+    const colorClass = stateColors[state] || 'text-content-secondary';
 
     return (
         <div className="flex items-center gap-3 px-1 animate-in slide-in-from-top-1 duration-300">
@@ -32,7 +32,7 @@ export const CategoryMomentumBanner: React.FC<CategoryMomentumBannerProps> = ({ 
                 Momentum: {state}
             </div>
             <div className="hidden sm:block w-px h-3 bg-white/10" />
-            <div className="text-sm text-neutral-400 italic font-medium">
+            <div className="text-sm text-content-secondary italic font-medium">
                 "{phrase}"
             </div>
         </div>

--- a/src/components/CategoryPickerModal.tsx
+++ b/src/components/CategoryPickerModal.tsx
@@ -56,21 +56,21 @@ export const CategoryPickerModal = ({
         <div className="modal-overlay fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
             <div
                 className={cn(
-                    "bg-neutral-900 border border-white/10 rounded-t-2xl sm:rounded-2xl w-full sm:max-w-sm shadow-2xl",
+                    "bg-surface-0 border border-line-subtle rounded-t-2xl sm:rounded-2xl w-full sm:max-w-sm shadow-2xl",
                     "animate-in slide-in-from-bottom-4 fade-in duration-200",
                     "max-h-[80vh] flex flex-col"
                 )}
                 onClick={e => e.stopPropagation()}
             >
                 {/* Header */}
-                <div className="flex items-center justify-between p-4 border-b border-white/5">
+                <div className="flex items-center justify-between p-4 border-b border-line-subtle">
                     <div className="flex items-center gap-2">
-                        <FolderInput size={18} className="text-emerald-400" />
-                        <h3 className="text-base font-semibold text-white">Move to Category</h3>
+                        <FolderInput size={18} className="text-accent-contrast" />
+                        <h3 className="text-base font-semibold text-content-primary">Move to Category</h3>
                     </div>
                     <button
                         onClick={onClose}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg hover:bg-white/10 text-neutral-400 hover:text-white transition-colors -m-1"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg hover:bg-surface-2 text-content-secondary hover:text-content-primary transition-colors -m-1"
                         aria-label="Close"
                     >
                         <X size={18} />
@@ -79,10 +79,10 @@ export const CategoryPickerModal = ({
 
                 {/* Current location */}
                 <div className="px-4 pt-3 pb-2">
-                    <p className="text-xs text-neutral-500">
-                        Moving <span className="text-neutral-300 font-medium">{habit.name}</span>
+                    <p className="text-xs text-content-muted">
+                        Moving <span className="text-content-secondary font-medium">{habit.name}</span>
                         {currentCategory && (
-                            <> from <span className="text-neutral-300 font-medium">{currentCategory.name}</span></>
+                            <> from <span className="text-content-secondary font-medium">{currentCategory.name}</span></>
                         )}
                     </p>
                 </div>
@@ -91,13 +91,13 @@ export const CategoryPickerModal = ({
                 {categories.length >= 6 && (
                     <div className="px-4 pb-2">
                         <div className="relative">
-                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500" />
+                            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-content-muted" />
                             <input
                                 type="text"
                                 placeholder="Search categories..."
                                 value={search}
                                 onChange={e => setSearch(e.target.value)}
-                                className="w-full pl-9 pr-3 py-2 bg-neutral-800 border border-white/5 rounded-lg text-sm text-white placeholder-neutral-500 focus:outline-none focus:border-emerald-500/50"
+                                className="w-full pl-9 pr-3 py-2 bg-surface-1 border border-line-subtle rounded-lg text-sm text-content-primary placeholder-neutral-500 focus:outline-none focus:border-emerald-500/50"
                                 autoFocus
                             />
                         </div>
@@ -107,7 +107,7 @@ export const CategoryPickerModal = ({
                 {/* Category list */}
                 <div className="flex-1 overflow-y-auto modal-scroll px-2 pb-4">
                     {filtered.length === 0 ? (
-                        <p className="text-center text-sm text-neutral-500 py-6">No categories found</p>
+                        <p className="text-center text-sm text-content-muted py-6">No categories found</p>
                     ) : (
                         <div className="flex flex-col gap-0.5">
                             {filtered.map(category => {
@@ -128,8 +128,8 @@ export const CategoryPickerModal = ({
                                         className={cn(
                                             "flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left transition-colors",
                                             isCurrent
-                                                ? "bg-white/5 text-neutral-500 cursor-default"
-                                                : "hover:bg-white/5 text-neutral-200 active:bg-white/10"
+                                                ? "bg-white/5 text-content-muted cursor-default"
+                                                : "hover:bg-surface-2 text-content-primary active:bg-white/10"
                                         )}
                                     >
                                         <div
@@ -140,7 +140,7 @@ export const CategoryPickerModal = ({
                                             {category.name}
                                         </span>
                                         {isCurrent && (
-                                            <span className="flex items-center gap-1 text-xs text-neutral-500">
+                                            <span className="flex items-center gap-1 text-xs text-content-muted">
                                                 <Check size={12} /> Current
                                             </span>
                                         )}

--- a/src/components/CategoryTabs.tsx
+++ b/src/components/CategoryTabs.tsx
@@ -316,8 +316,8 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
                     onClick={() => onSelectCategory(uncategorized.id)}
                     className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap flex-shrink-0 transition-all ${
                         activeCategoryId === uncategorized.id
-                            ? 'bg-amber-500 text-neutral-900 shadow-lg shadow-amber-500/20'
-                            : 'bg-surface-1 text-amber-400 hover:bg-surface-2 border border-amber-500/30'
+                            ? 'bg-warning text-content-on-accent shadow-lg shadow-warning/20'
+                            : 'bg-surface-1 text-warning-contrast hover:bg-surface-2 border border-warning/30'
                     }`}
                 >
                     Uncategorized
@@ -327,7 +327,7 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
             {reorderMode ? (
                 <button
                     onClick={() => setReorderMode(false)}
-                    className="px-3 py-2 rounded-full bg-emerald-500 text-neutral-900 text-sm font-medium hover:bg-accent-strong transition-colors flex items-center gap-1 whitespace-nowrap flex-shrink-0"
+                    className="px-3 py-2 rounded-full bg-accent text-content-on-accent text-sm font-medium hover:bg-accent-strong transition-colors flex items-center gap-1 whitespace-nowrap flex-shrink-0"
                 >
                     <Check size={14} strokeWidth={3} /> Done
                 </button>
@@ -345,7 +345,7 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
                             aria-invalid={!!addCategoryError}
                             aria-describedby={addCategoryError ? 'add-category-error' : undefined}
                         />
-                        <button type="submit" className="p-2 rounded-full bg-emerald-500 text-content-primary hover:bg-emerald-600">
+                        <button type="submit" className="p-2 rounded-full bg-accent text-content-on-accent hover:bg-accent-strong">
                             <Plus size={14} />
                         </button>
                     </div>

--- a/src/components/CategoryTabs.tsx
+++ b/src/components/CategoryTabs.tsx
@@ -133,7 +133,7 @@ const SortableCategoryPill: React.FC<SortableCategoryPillProps> = ({
                             e.stopPropagation();
                         }}
                         onPointerDown={(e) => e.stopPropagation()}
-                        className="px-4 py-2 rounded-full bg-neutral-800 text-white text-sm font-medium border border-emerald-500 outline-none w-auto min-w-[100px]"
+                        className="px-4 py-2 rounded-full bg-surface-1 text-content-primary text-sm font-medium border border-emerald-500 outline-none w-auto min-w-[100px]"
                     />
                 </form>
             </div>
@@ -164,8 +164,8 @@ const SortableCategoryPill: React.FC<SortableCategoryPillProps> = ({
                 className={`
           px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-all select-none
           ${isActive
-                        ? `${category.color} text-white shadow-lg shadow-white/10 pr-8`
-                        : 'bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-white'
+                        ? `${category.color} text-content-primary shadow-lg shadow-white/10 pr-8`
+                        : 'bg-surface-1 text-content-secondary hover:bg-surface-2 hover:text-content-primary'
                     }
           ${reorderMode ? 'ring-1 ring-emerald-500/40 cursor-grab' : ''}
         `}
@@ -177,8 +177,8 @@ const SortableCategoryPill: React.FC<SortableCategoryPillProps> = ({
                 <button
                     onClick={onDelete}
                     className={`absolute right-1 top-1/2 -translate-y-1/2 p-1.5 rounded-full transition-colors z-10 ${deleteConfirmId === category.id
-                        ? 'bg-red-500 text-white hover:bg-red-600 shadow-sm'
-                        : 'hover:bg-black/20 text-white/70 hover:text-white'
+                        ? 'bg-red-500 text-content-primary hover:bg-red-600 shadow-sm'
+                        : 'hover:bg-black/20 text-content-primary/70 hover:text-content-primary'
                         }`}
                     title={deleteConfirmId === category.id ? "Click again to confirm delete" : "Delete Category"}
                     onPointerDown={(e) => e.stopPropagation()}
@@ -317,7 +317,7 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
                     className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap flex-shrink-0 transition-all ${
                         activeCategoryId === uncategorized.id
                             ? 'bg-amber-500 text-neutral-900 shadow-lg shadow-amber-500/20'
-                            : 'bg-neutral-800 text-amber-400 hover:bg-neutral-700 border border-amber-500/30'
+                            : 'bg-surface-1 text-amber-400 hover:bg-surface-2 border border-amber-500/30'
                     }`}
                 >
                     Uncategorized
@@ -327,7 +327,7 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
             {reorderMode ? (
                 <button
                     onClick={() => setReorderMode(false)}
-                    className="px-3 py-2 rounded-full bg-emerald-500 text-neutral-900 text-sm font-medium hover:bg-emerald-400 transition-colors flex items-center gap-1 whitespace-nowrap flex-shrink-0"
+                    className="px-3 py-2 rounded-full bg-emerald-500 text-neutral-900 text-sm font-medium hover:bg-accent-strong transition-colors flex items-center gap-1 whitespace-nowrap flex-shrink-0"
                 >
                     <Check size={14} strokeWidth={3} /> Done
                 </button>
@@ -340,12 +340,12 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
                             value={newCategoryName}
                             onChange={(e) => { setNewCategoryName(e.target.value); setAddCategoryError(null); }}
                             placeholder="Category name..."
-                            className="px-3 py-2 rounded-full bg-neutral-800 text-white text-sm border border-neutral-700 focus:border-emerald-500 outline-none w-32"
+                            className="px-3 py-2 rounded-full bg-surface-1 text-content-primary text-sm border border-line-strong focus:border-emerald-500 outline-none w-32"
                             onBlur={() => !newCategoryName && !addCategoryError && setIsAdding(false)}
                             aria-invalid={!!addCategoryError}
                             aria-describedby={addCategoryError ? 'add-category-error' : undefined}
                         />
-                        <button type="submit" className="p-2 rounded-full bg-emerald-500 text-white hover:bg-emerald-600">
+                        <button type="submit" className="p-2 rounded-full bg-emerald-500 text-content-primary hover:bg-emerald-600">
                             <Plus size={14} />
                         </button>
                     </div>
@@ -358,7 +358,7 @@ export const CategoryTabs: React.FC<CategoryTabsProps> = ({
             ) : (
                 <button
                     onClick={() => setIsAdding(true)}
-                    className="px-3 py-2 rounded-full bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-white transition-colors"
+                    className="px-3 py-2 rounded-full bg-surface-1 text-content-secondary hover:bg-surface-2 hover:text-content-primary transition-colors"
                     title="Add Category"
                 >
                     <Plus size={18} />

--- a/src/components/CompletedHabitsModal.tsx
+++ b/src/components/CompletedHabitsModal.tsx
@@ -78,31 +78,31 @@ export const CompletedHabitsModal: React.FC<CompletedHabitsModalProps> = ({
 
     return (
         <div className="modal-overlay fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4" role="dialog" aria-modal="true" aria-labelledby="completed-habits-title">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[85dvh] animate-fade-in-up">
-                <div className="flex items-center justify-between p-4 border-b border-white/10">
-                    <h2 id="completed-habits-title" className="text-lg font-semibold text-white">Completed Habits</h2>
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl shadow-2xl flex flex-col max-h-[85dvh] animate-fade-in-up">
+                <div className="flex items-center justify-between p-4 border-b border-line-subtle">
+                    <h2 id="completed-habits-title" className="text-lg font-semibold text-content-primary">Completed Habits</h2>
                     <button
                         type="button"
                         onClick={onClose}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-neutral-400 hover:text-white hover:bg-neutral-800 transition-colors touch-manipulation -m-1"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-content-secondary hover:text-content-primary hover:bg-surface-1 transition-colors touch-manipulation -m-1"
                         aria-label="Close"
                     >
                         <X size={22} />
                     </button>
                 </div>
 
-                <div className="flex flex-wrap gap-2 p-4 border-b border-white/5">
+                <div className="flex flex-wrap gap-2 p-4 border-b border-line-subtle">
                     <button
                         type="button"
                         onClick={handleCheckAll}
-                        className="px-3 py-1.5 rounded-lg bg-neutral-700/80 text-neutral-200 text-sm font-medium hover:bg-neutral-600 transition-colors touch-manipulation"
+                        className="px-3 py-1.5 rounded-lg bg-surface-2/80 text-content-primary text-sm font-medium hover:bg-surface-2 transition-colors touch-manipulation"
                     >
                         Check all
                     </button>
                     <button
                         type="button"
                         onClick={handleUncheckAll}
-                        className="px-3 py-1.5 rounded-lg bg-neutral-700/80 text-neutral-200 text-sm font-medium hover:bg-neutral-600 transition-colors touch-manipulation"
+                        className="px-3 py-1.5 rounded-lg bg-surface-2/80 text-content-primary text-sm font-medium hover:bg-surface-2 transition-colors touch-manipulation"
                     >
                         Uncheck all
                     </button>
@@ -110,14 +110,14 @@ export const CompletedHabitsModal: React.FC<CompletedHabitsModalProps> = ({
 
                 <div className="flex-1 overflow-y-auto modal-scroll p-4">
                     {habitSteps.length === 0 ? (
-                        <p className="text-neutral-500 text-sm">No habit-linked steps in this routine.</p>
+                        <p className="text-content-muted text-sm">No habit-linked steps in this routine.</p>
                     ) : (
                         <ul className="space-y-2" role="list">
                             {habitSteps.map((step) => {
                                 const checked = checkedStepIds.has(step.id);
                                 const label = getHabitName(step.linkedHabitId) || step.title || 'Habit';
                                 return (
-                                    <li key={step.id} className="flex items-center gap-3 py-2.5 px-3 rounded-xl bg-neutral-800/50 border border-white/5">
+                                    <li key={step.id} className="flex items-center gap-3 py-2.5 px-3 rounded-xl bg-surface-1/50 border border-line-subtle">
                                         <button
                                             type="button"
                                             role="checkbox"
@@ -126,10 +126,10 @@ export const CompletedHabitsModal: React.FC<CompletedHabitsModalProps> = ({
                                             onClick={() => toggleStep(step.id)}
                                             className="flex items-center gap-3 w-full text-left touch-manipulation min-h-[44px]"
                                         >
-                                            <span className="flex-shrink-0 text-neutral-400">
-                                                {checked ? <CheckSquare size={22} className="text-emerald-400" /> : <Square size={22} />}
+                                            <span className="flex-shrink-0 text-content-secondary">
+                                                {checked ? <CheckSquare size={22} className="text-accent-contrast" /> : <Square size={22} />}
                                             </span>
-                                            <span className="text-white font-medium">{label}</span>
+                                            <span className="text-content-primary font-medium">{label}</span>
                                         </button>
                                     </li>
                                 );
@@ -138,11 +138,11 @@ export const CompletedHabitsModal: React.FC<CompletedHabitsModalProps> = ({
                     )}
                 </div>
 
-                <div className="flex flex-wrap gap-3 p-4 border-t border-white/10 bg-neutral-900/80">
+                <div className="flex flex-wrap gap-3 p-4 border-t border-line-subtle bg-surface-0/80">
                     <button
                         type="button"
                         onClick={onClose}
-                        className="flex-1 min-w-[120px] px-4 py-3 rounded-lg bg-neutral-700 text-white font-semibold hover:bg-neutral-600 transition-colors touch-manipulation"
+                        className="flex-1 min-w-[120px] px-4 py-3 rounded-lg bg-surface-2 text-content-primary font-semibold hover:bg-surface-2 transition-colors touch-manipulation"
                     >
                         Cancel
                     </button>
@@ -150,7 +150,7 @@ export const CompletedHabitsModal: React.FC<CompletedHabitsModalProps> = ({
                         type="button"
                         onClick={handleLogSelected}
                         disabled={submitting}
-                        className="flex-1 min-w-[120px] px-4 py-3 rounded-lg bg-emerald-500 text-neutral-900 font-semibold hover:bg-emerald-400 transition-colors touch-manipulation disabled:opacity-60 disabled:pointer-events-none"
+                        className="flex-1 min-w-[120px] px-4 py-3 rounded-lg bg-accent text-content-on-accent font-semibold hover:bg-accent-strong transition-colors touch-manipulation disabled:opacity-60 disabled:pointer-events-none"
                     >
                         {submitting ? 'Saving...' : 'Log selected habits'}
                     </button>

--- a/src/components/ConvertBundleConfirmModal.tsx
+++ b/src/components/ConvertBundleConfirmModal.tsx
@@ -39,13 +39,13 @@ export const ConvertBundleConfirmModal: React.FC<ConvertBundleConfirmModalProps>
 
     return (
         <div className="modal-overlay fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Convert to Bundle</h3>
+                    <h3 className="text-xl font-bold text-content-primary">Convert to Bundle</h3>
                     <button
                         onClick={onClose}
                         disabled={isConverting}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors disabled:opacity-50 -mr-2"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50 -mr-2"
                         aria-label="Close"
                     >
                         <X size={20} />
@@ -58,13 +58,13 @@ export const ConvertBundleConfirmModal: React.FC<ConvertBundleConfirmModalProps>
                         <Info className="text-indigo-400 flex-shrink-0 mt-0.5" size={20} />
                         <div className="flex-1">
                             <div className="text-indigo-400 font-medium mb-1">Confirm Conversion</div>
-                            <div className="text-white text-sm space-y-1.5">
+                            <div className="text-content-primary text-sm space-y-1.5">
                                 <p>
                                     Convert <span className="font-medium">&ldquo;{habitName}&rdquo;</span> into
                                     a <span className="font-medium">{bundleType}</span> bundle
                                     with {childCount} child habit{childCount !== 1 ? 's' : ''}.
                                 </p>
-                                <p className="text-neutral-400 text-xs">
+                                <p className="text-content-secondary text-xs">
                                     Your historical entries will be preserved and accessible in habit history.
                                     This action is difficult to undo.
                                 </p>
@@ -74,7 +74,7 @@ export const ConvertBundleConfirmModal: React.FC<ConvertBundleConfirmModalProps>
 
                     {/* Error Display */}
                     {error && (
-                        <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg text-red-400 text-sm">
+                        <div className="p-3 bg-danger-soft border border-danger/50 rounded-lg text-danger-contrast text-sm">
                             {error}
                         </div>
                     )}
@@ -85,7 +85,7 @@ export const ConvertBundleConfirmModal: React.FC<ConvertBundleConfirmModalProps>
                             type="button"
                             onClick={onClose}
                             disabled={isConverting}
-                            className="flex-1 px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="flex-1 px-4 py-2 bg-surface-2 hover:bg-surface-2 text-content-primary rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             Cancel
                         </button>
@@ -93,7 +93,7 @@ export const ConvertBundleConfirmModal: React.FC<ConvertBundleConfirmModalProps>
                             type="button"
                             onClick={handleConfirm}
                             disabled={isConverting}
-                            className="flex-1 px-4 py-2 bg-indigo-500 hover:bg-indigo-400 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                            className="flex-1 px-4 py-2 bg-indigo-500 hover:bg-indigo-400 text-content-primary font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                         >
                             {isConverting ? (
                                 <>

--- a/src/components/CreateGoalModal.tsx
+++ b/src/components/CreateGoalModal.tsx
@@ -172,12 +172,12 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-            <div className="w-full max-w-lg max-h-[90dvh] bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl flex flex-col overflow-hidden">
+            <div className="w-full max-w-lg max-h-[90dvh] bg-surface-0 border border-line-subtle rounded-2xl shadow-2xl flex flex-col overflow-hidden">
 
                 {/* Header */}
-                <div className="flex items-center justify-between p-6 border-b border-white/10 bg-neutral-900 z-10">
+                <div className="flex items-center justify-between p-6 border-b border-line-subtle bg-surface-0 z-10">
                     <div>
-                        <h2 className="text-xl font-bold text-white">
+                        <h2 className="text-xl font-bold text-content-primary">
                             {step === 1 ? 'Create Goal' : 'Link Habits'}
                         </h2>
                         <div className="flex items-center gap-2 mt-2">
@@ -187,7 +187,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                     </div>
                     <button
                         onClick={onClose}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white -mr-2"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary -mr-2"
                         aria-label="Close"
                     >
                         <X size={24} />
@@ -201,42 +201,42 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                         <>
                             {/* Goal Title */}
                             <div className="space-y-2">
-                                <label className="block text-sm font-medium text-neutral-400">Title</label>
+                                <label className="block text-sm font-medium text-content-secondary">Title</label>
                                 <input
                                     type="text"
                                     value={title}
                                     onChange={(e) => setTitle(e.target.value)}
-                                    className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white text-lg placeholder:text-neutral-600 focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
+                                    className="w-full bg-surface-0/50 border border-line-subtle rounded-xl px-4 py-3 text-content-primary text-lg placeholder:text-content-muted focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-focus/50 transition-all"
                                     placeholder="e.g., Run a Marathon"
                                 />
                             </div>
 
                             {/* Goal Type */}
                             <div className="space-y-2">
-                                <label className="block text-sm font-medium text-neutral-400">Goal Type</label>
+                                <label className="block text-sm font-medium text-content-secondary">Goal Type</label>
                                 <div className="flex gap-2">
                                     <button
                                         type="button"
                                         onClick={() => setType('cumulative')}
                                         className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border transition-all ${type === 'cumulative'
-                                            ? 'bg-emerald-500/10 border-emerald-500/50 ring-1 ring-emerald-500/20'
-                                            : 'bg-neutral-900/50 border-white/5 hover:border-white/10 hover:bg-neutral-800/50'
+                                            ? 'bg-accent-soft border-accent/50 ring-1 ring-focus/20'
+                                            : 'bg-surface-0/50 border-line-subtle hover:border-line-subtle hover:bg-surface-1/50'
                                             }`}
                                     >
-                                        <Target size={18} className={type === 'cumulative' ? 'text-emerald-400' : 'text-neutral-400'} />
-                                        <span className="text-white font-medium">Cumulative</span>
+                                        <Target size={18} className={type === 'cumulative' ? 'text-accent-contrast' : 'text-content-secondary'} />
+                                        <span className="text-content-primary font-medium">Cumulative</span>
                                     </button>
 
                                     <button
                                         type="button"
                                         onClick={() => setType('onetime')}
                                         className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border transition-all ${type === 'onetime'
-                                            ? 'bg-emerald-500/10 border-emerald-500/50 ring-1 ring-emerald-500/20'
-                                            : 'bg-neutral-900/50 border-white/5 hover:border-white/10 hover:bg-neutral-800/50'
+                                            ? 'bg-accent-soft border-accent/50 ring-1 ring-focus/20'
+                                            : 'bg-surface-0/50 border-line-subtle hover:border-line-subtle hover:bg-surface-1/50'
                                             }`}
                                     >
-                                        <CalendarCheck size={18} className={type === 'onetime' ? 'text-emerald-400' : 'text-neutral-400'} />
-                                        <span className="text-white font-medium">One-Time</span>
+                                        <CalendarCheck size={18} className={type === 'onetime' ? 'text-accent-contrast' : 'text-content-secondary'} />
+                                        <span className="text-content-primary font-medium">One-Time</span>
                                     </button>
                                 </div>
                             </div>
@@ -245,26 +245,26 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                             {type !== 'onetime' ? (
                                 <div className="flex items-end gap-3">
                                     <div className="flex-1 space-y-2">
-                                        <label className="block text-sm font-medium text-neutral-400">Target Value</label>
+                                        <label className="block text-sm font-medium text-content-secondary">Target Value</label>
                                         <input
                                             type="number"
                                             value={targetValue}
                                             onChange={(e) => setTargetValue(e.target.value)}
-                                            className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
+                                            className="w-full bg-surface-0/50 border border-line-subtle rounded-xl px-4 py-3 text-content-primary focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-focus/50 transition-all"
                                             placeholder="e.g., 100"
                                             min="0.01"
                                             step="0.01"
                                         />
                                     </div>
                                     <div className="flex-1 space-y-2">
-                                        <label className="block text-sm font-medium text-neutral-400">
-                                            Unit <span className="text-neutral-500 font-normal">(Optional)</span>
+                                        <label className="block text-sm font-medium text-content-secondary">
+                                            Unit <span className="text-content-muted font-normal">(Optional)</span>
                                         </label>
                                         <input
                                             type="text"
                                             value={unit}
                                             onChange={(e) => setUnit(e.target.value)}
-                                            className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
+                                            className="w-full bg-surface-0/50 border border-line-subtle rounded-xl px-4 py-3 text-content-primary focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-focus/50 transition-all"
                                             placeholder="e.g., miles, sessions"
                                         />
                                     </div>
@@ -274,8 +274,8 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                             onClick={() => deadlineInputRef.current?.showPicker()}
                                             className={`min-h-[48px] min-w-[48px] flex items-center justify-center rounded-xl border transition-all ${
                                                 deadline
-                                                    ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
-                                                    : 'bg-neutral-900/50 border-white/10 text-neutral-400 hover:border-white/20 hover:text-white'
+                                                    ? 'bg-accent-soft border-accent/50 text-accent-contrast'
+                                                    : 'bg-surface-0/50 border-line-subtle text-content-secondary hover:border-line-strong hover:text-content-primary'
                                             }`}
                                             aria-label={deadline ? `Deadline: ${deadline}` : 'Set deadline'}
                                             title={deadline ? `Deadline: ${deadline}` : 'Set deadline'}
@@ -295,15 +295,15 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                 </div>
                             ) : (
                                 <div className="flex items-center gap-3">
-                                    <span className="text-sm text-neutral-400">Event Date</span>
+                                    <span className="text-sm text-content-secondary">Event Date</span>
                                     <div className="relative">
                                         <button
                                             type="button"
                                             onClick={() => deadlineInputRef.current?.showPicker()}
                                             className={`min-h-[44px] min-w-[44px] flex items-center justify-center rounded-xl border transition-all ${
                                                 deadline
-                                                    ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
-                                                    : 'bg-neutral-900/50 border-white/10 text-neutral-400 hover:border-white/20 hover:text-white'
+                                                    ? 'bg-accent-soft border-accent/50 text-accent-contrast'
+                                                    : 'bg-surface-0/50 border-line-subtle text-content-secondary hover:border-line-strong hover:text-content-primary'
                                             }`}
                                             aria-label={deadline ? `Event date: ${deadline}` : 'Set event date'}
                                             title={deadline ? `Event date: ${deadline}` : 'Set event date'}
@@ -321,15 +321,15 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                         />
                                     </div>
                                     {deadline && (
-                                        <span className="text-sm text-emerald-400">{deadline}</span>
+                                        <span className="text-sm text-accent-contrast">{deadline}</span>
                                     )}
                                 </div>
                             )}
 
                             {/* Category (Optional) */}
                             <div className="space-y-2">
-                                <label className="block text-sm font-medium text-neutral-400">
-                                    Category <span className="text-neutral-500 font-normal">(Optional)</span>
+                                <label className="block text-sm font-medium text-content-secondary">
+                                    Category <span className="text-content-muted font-normal">(Optional)</span>
                                 </label>
 
                                 {isCreatingCategory ? (
@@ -339,7 +339,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                             value={newCategoryName}
                                             onChange={(e) => setNewCategoryName(e.target.value)}
                                             placeholder="New category name..."
-                                            className="flex-1 bg-neutral-900 border border-emerald-500/50 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-1 focus:ring-emerald-500/50"
+                                            className="flex-1 bg-surface-0 border border-accent/50 rounded-xl px-4 py-3 text-content-primary focus:outline-none focus:ring-1 focus:ring-focus/50"
                                             autoFocus
                                             onKeyDown={(e) => {
                                                 if (e.key === 'Enter') {
@@ -352,7 +352,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                             type="button"
                                             onClick={handleCreateCategory}
                                             disabled={!newCategoryName.trim() || isSubmittingCategory}
-                                            className="bg-emerald-500 hover:bg-emerald-400 text-neutral-900 px-4 rounded-xl font-medium transition-colors disabled:opacity-50"
+                                            className="bg-accent hover:bg-accent-strong text-content-on-accent px-4 rounded-xl font-medium transition-colors disabled:opacity-50"
                                         >
                                             {isSubmittingCategory ? '...' : 'Save'}
                                         </button>
@@ -362,7 +362,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                                 setIsCreatingCategory(false);
                                                 setNewCategoryName('');
                                             }}
-                                            className="bg-neutral-800 hover:bg-neutral-700 text-neutral-400 px-3 rounded-xl transition-colors"
+                                            className="bg-surface-1 hover:bg-surface-2 text-content-secondary px-3 rounded-xl transition-colors"
                                         >
                                             <X size={20} />
                                         </button>
@@ -377,7 +377,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                                 setCategoryId(e.target.value);
                                             }
                                         }}
-                                        className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white appearance-none focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
+                                        className="w-full bg-surface-0/50 border border-line-subtle rounded-xl px-4 py-3 text-content-primary appearance-none focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-focus/50 transition-all"
                                     >
                                         <option value="">-- No Category --</option>
                                         <option value="new">+ Create New Category</option>
@@ -394,19 +394,19 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                             {/* Step 2: Link Habits */}
                             <div className="space-y-4">
                                 <div>
-                                    <p className="text-sm text-neutral-400">
+                                    <p className="text-sm text-content-secondary">
                                         {type === 'onetime'
                                             ? 'Select preparation habits for this event'
                                             : 'Select habits that contribute to this goal'}
                                     </p>
                                     {categoryId && (
-                                        <p className="text-xs text-neutral-500 mt-1">
-                                            Showing habits in <span className="text-emerald-400">{categoryMap.get(categoryId)}</span>
+                                        <p className="text-xs text-content-muted mt-1">
+                                            Showing habits in <span className="text-accent-contrast">{categoryMap.get(categoryId)}</span>
                                             {' \u00B7 '}
                                             <button
                                                 type="button"
                                                 onClick={() => setCategoryId('')}
-                                                className="text-emerald-400 hover:text-emerald-300 underline"
+                                                className="text-accent-contrast hover:text-accent-contrast underline"
                                             >
                                                 Show all
                                             </button>
@@ -417,19 +417,19 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                 {/* Search + New Habit */}
                                 <div className="flex gap-3">
                                     <div className="relative flex-1">
-                                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" size={18} />
+                                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-content-secondary" size={18} />
                                         <input
                                             type="text"
                                             value={searchQuery}
                                             onChange={(e) => setSearchQuery(e.target.value)}
-                                            className="w-full bg-neutral-800 border border-white/10 rounded-lg pl-10 pr-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                            className="w-full bg-surface-1 border border-line-subtle rounded-lg pl-10 pr-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                             placeholder="Search habits..."
                                         />
                                     </div>
                                     <button
                                         type="button"
                                         onClick={() => setIsCreateHabitOpen(true)}
-                                        className="flex items-center gap-2 px-4 py-2 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-medium rounded-lg transition-colors"
+                                        className="flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-content-on-accent font-medium rounded-lg transition-colors"
                                     >
                                         <Plus size={18} />
                                         New Habit
@@ -439,7 +439,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                 {/* Habit List */}
                                 <div>
                                     {availableHabits.length === 0 ? (
-                                        <div className="text-center py-12 text-neutral-500">
+                                        <div className="text-center py-12 text-content-muted">
                                             {searchQuery ? 'No habits found matching your search.' : 'No habits available.'}
                                         </div>
                                     ) : (
@@ -452,21 +452,21 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                                 return (
                                                     <label
                                                         key={habit.id}
-                                                        className="flex items-center gap-3 p-4 bg-neutral-800/50 border border-white/5 rounded-lg hover:bg-neutral-800/70 transition-colors cursor-pointer"
+                                                        className="flex items-center gap-3 p-4 bg-surface-1/50 border border-line-subtle rounded-lg hover:bg-surface-1/70 transition-colors cursor-pointer"
                                                     >
                                                         <input
                                                             type="checkbox"
                                                             checked={selectedHabitIds.has(habit.id)}
                                                             onChange={() => toggleHabit(habit.id)}
-                                                            className="w-5 h-5 rounded border-neutral-700 bg-neutral-800 text-emerald-500 focus:ring-emerald-500 cursor-pointer"
+                                                            className="w-5 h-5 rounded border-line-strong bg-surface-1 text-emerald-500 focus:ring-focus cursor-pointer"
                                                         />
                                                         <div className="flex-1 min-w-0">
-                                                            <div className="text-white font-medium mb-1">{habit.name}</div>
-                                                            <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-400">
-                                                                <span className="px-2 py-0.5 bg-neutral-700/50 rounded">{categoryName}</span>
-                                                                <span className="px-2 py-0.5 bg-neutral-700/50 rounded">{habitType}</span>
+                                                            <div className="text-content-primary font-medium mb-1">{habit.name}</div>
+                                                            <div className="flex flex-wrap items-center gap-2 text-xs text-content-secondary">
+                                                                <span className="px-2 py-0.5 bg-surface-2/50 rounded">{categoryName}</span>
+                                                                <span className="px-2 py-0.5 bg-surface-2/50 rounded">{habitType}</span>
                                                                 {habitUnit && (
-                                                                    <span className="px-2 py-0.5 bg-neutral-700/50 rounded">{habitUnit}</span>
+                                                                    <span className="px-2 py-0.5 bg-surface-2/50 rounded">{habitUnit}</span>
                                                                 )}
                                                             </div>
                                                         </div>
@@ -482,20 +482,20 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                 </div>
 
                 {/* Footer */}
-                <div className="p-6 border-t border-white/10 bg-neutral-900 flex justify-between items-center">
+                <div className="p-6 border-t border-line-subtle bg-surface-0 flex justify-between items-center">
                     <div>
                         {step === 2 && (
                             error ? (
-                                <span className="text-red-400 text-sm flex items-center gap-2">
+                                <span className="text-danger-contrast text-sm flex items-center gap-2">
                                     <AlertCircle size={16} />
                                     {error}
                                 </span>
                             ) : selectedHabitIds.size > 0 ? (
-                                <span className="text-sm text-neutral-400">
+                                <span className="text-sm text-content-secondary">
                                     {selectedHabitIds.size} {selectedHabitIds.size === 1 ? 'habit' : 'habits'} selected
                                 </span>
                             ) : (
-                                <span className="text-sm text-neutral-500">Select at least one habit</span>
+                                <span className="text-sm text-content-muted">Select at least one habit</span>
                             )
                         )}
                     </div>
@@ -504,7 +504,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                             <>
                                 <button
                                     onClick={onClose}
-                                    className="px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                                    className="px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                                 >
                                     Cancel
                                 </button>
@@ -513,8 +513,8 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                     disabled={!isStep1Valid}
                                     className={`px-6 py-2 rounded-lg font-bold transition-colors ${
                                         isStep1Valid
-                                            ? 'bg-emerald-500 text-neutral-900 hover:bg-emerald-400 shadow-lg shadow-emerald-500/20'
-                                            : 'bg-neutral-800 text-neutral-500 cursor-not-allowed'
+                                            ? 'bg-accent text-content-on-accent hover:bg-accent-strong shadow-lg shadow-emerald-500/20'
+                                            : 'bg-surface-1 text-content-muted cursor-not-allowed'
                                     }`}
                                 >
                                     Next
@@ -524,7 +524,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                             <>
                                 <button
                                     onClick={() => setStep(1)}
-                                    className="flex items-center gap-1 px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                                    className="flex items-center gap-1 px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                                 >
                                     <ChevronLeft size={16} />
                                     Back
@@ -534,8 +534,8 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                                     disabled={!isFormValid || isSubmitting}
                                     className={`px-6 py-2 rounded-lg font-bold transition-colors shadow-lg shadow-emerald-500/20 ${
                                         isFormValid && !isSubmitting
-                                            ? 'bg-emerald-500 text-neutral-900 hover:bg-emerald-400'
-                                            : 'bg-neutral-800 text-neutral-500 cursor-not-allowed shadow-none'
+                                            ? 'bg-accent text-content-on-accent hover:bg-accent-strong'
+                                            : 'bg-surface-1 text-content-muted cursor-not-allowed shadow-none'
                                     }`}
                                 >
                                     {isSubmitting ? (

--- a/src/components/DailyCheckInModal.tsx
+++ b/src/components/DailyCheckInModal.tsx
@@ -47,20 +47,20 @@ type MetricUiConfig = {
 const METRIC_UI: Record<WellbeingMetricKey, MetricUiConfig> = {
     depression: { key: 'depression', label: 'Depression (legacy)', icon: <Brain size={16} className="text-blue-400" />, colorClass: 'text-blue-400', min: 1, max: 5, step: 1, kind: 'number' },
     anxiety: { key: 'anxiety', label: 'Anxiety', icon: <Activity size={16} className="text-purple-400" />, colorClass: 'text-purple-400', min: 1, max: 5, step: 1, kind: 'number' },
-    energy: { key: 'energy', label: 'Energy', icon: <Battery size={16} className="text-emerald-400" />, colorClass: 'text-emerald-400', min: 1, max: 5, step: 1, kind: 'number' },
+    energy: { key: 'energy', label: 'Energy', icon: <Battery size={16} className="text-accent-contrast" />, colorClass: 'text-accent-contrast', min: 1, max: 5, step: 1, kind: 'number' },
     sleepScore: { key: 'sleepScore', label: 'Sleep score', icon: <Moon size={16} className="text-indigo-400" />, colorClass: 'text-indigo-400', min: 0, max: 100, step: 1, tab: 'morning', kind: 'number' },
     sleepQuality: { key: 'sleepQuality', label: 'Sleep quality (subjective)', icon: <Heart size={16} className="text-fuchsia-300" />, colorClass: 'text-fuchsia-300', min: 0, max: 4, step: 1, tab: 'morning', kind: 'number' },
     lowMood: { key: 'lowMood', label: 'Low Mood', icon: <Brain size={16} className="text-blue-400" />, colorClass: 'text-blue-400', min: 0, max: 4, step: 1, kind: 'number' },
-    calm: { key: 'calm', label: 'Calm', icon: <Wind size={16} className="text-emerald-400" />, colorClass: 'text-emerald-400', min: 0, max: 4, step: 1, kind: 'number' },
+    calm: { key: 'calm', label: 'Calm', icon: <Wind size={16} className="text-accent-contrast" />, colorClass: 'text-accent-contrast', min: 0, max: 4, step: 1, kind: 'number' },
     stress: { key: 'stress', label: 'Stress', icon: <Target size={16} className="text-orange-400" />, colorClass: 'text-orange-400', min: 0, max: 4, step: 1, kind: 'number' },
     focus: { key: 'focus', label: 'Focus', icon: <FocusIcon size={16} className="text-amber-300" />, colorClass: 'text-amber-300', min: 0, max: 4, step: 1, kind: 'number' },
     satisfaction: { key: 'satisfaction', label: 'Satisfaction', icon: <SmilePlus size={16} className="text-lime-400" />, colorClass: 'text-lime-400', min: 0, max: 4, step: 1, kind: 'number' },
-    notes: { key: 'notes', label: 'Notes (Optional)', icon: null, colorClass: 'text-neutral-300', min: 0, max: 0, step: 1, kind: 'text' },
-    readiness: { key: 'readiness', label: 'Readiness', icon: null, colorClass: 'text-neutral-400', min: 0, max: 4, step: 1, kind: 'number' },
-    soreness: { key: 'soreness', label: 'Soreness', icon: null, colorClass: 'text-neutral-400', min: 0, max: 4, step: 1, kind: 'number' },
-    hydration: { key: 'hydration', label: 'Hydration', icon: null, colorClass: 'text-neutral-400', min: 0, max: 4, step: 1, kind: 'number' },
-    fueling: { key: 'fueling', label: 'Fueling', icon: null, colorClass: 'text-neutral-400', min: 0, max: 4, step: 1, kind: 'number' },
-    recovery: { key: 'recovery', label: 'Recovery', icon: null, colorClass: 'text-neutral-400', min: 0, max: 4, step: 1, kind: 'number' },
+    notes: { key: 'notes', label: 'Notes (Optional)', icon: null, colorClass: 'text-content-secondary', min: 0, max: 0, step: 1, kind: 'text' },
+    readiness: { key: 'readiness', label: 'Readiness', icon: null, colorClass: 'text-content-secondary', min: 0, max: 4, step: 1, kind: 'number' },
+    soreness: { key: 'soreness', label: 'Soreness', icon: null, colorClass: 'text-content-secondary', min: 0, max: 4, step: 1, kind: 'number' },
+    hydration: { key: 'hydration', label: 'Hydration', icon: null, colorClass: 'text-content-secondary', min: 0, max: 4, step: 1, kind: 'number' },
+    fueling: { key: 'fueling', label: 'Fueling', icon: null, colorClass: 'text-content-secondary', min: 0, max: 4, step: 1, kind: 'number' },
+    recovery: { key: 'recovery', label: 'Recovery', icon: null, colorClass: 'text-content-secondary', min: 0, max: 4, step: 1, kind: 'number' },
 };
 
 export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, onClose, onNavigateHistory }) => {
@@ -218,16 +218,16 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-            <div className="bg-neutral-900 border border-white/10 rounded-2xl w-full max-w-md max-h-[90dvh] shadow-2xl overflow-hidden flex flex-col animate-in fade-in zoom-in duration-200">
+            <div className="bg-surface-0 border border-line-subtle rounded-2xl w-full max-w-md max-h-[90dvh] shadow-2xl overflow-hidden flex flex-col animate-in fade-in zoom-in duration-200">
                 {/* Header with Tabs */}
-                <div className="border-b border-white/5 bg-neutral-800/50">
+                <div className="border-b border-line-subtle bg-surface-1/50">
                     <div className="flex items-center justify-between p-4 pb-0">
-                        <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+                        <h2 className="text-lg font-semibold text-content-primary flex items-center gap-2">
                             Daily Check-in
                         </h2>
                         <button
                             onClick={onClose}
-                            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full hover:bg-white/10 text-neutral-400 hover:text-white transition-colors -mr-1"
+                            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full hover:bg-surface-2 text-content-secondary hover:text-content-primary transition-colors -mr-1"
                             aria-label="Close"
                         >
                             <X size={20} />
@@ -238,8 +238,8 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                         <button
                             onClick={() => setActiveTab('morning')}
                             className={`flex items-center gap-2 pb-3 text-sm font-medium border-b-2 transition-colors ${activeTab === 'morning'
-                                ? 'border-amber-400 text-white'
-                                : 'border-transparent text-neutral-400 hover:text-white'
+                                ? 'border-amber-400 text-content-primary'
+                                : 'border-transparent text-content-secondary hover:text-content-primary'
                                 }`}
                         >
                             <Sun size={16} className={activeTab === 'morning' ? 'text-amber-400' : ''} />
@@ -248,8 +248,8 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                         <button
                             onClick={() => setActiveTab('evening')}
                             className={`flex items-center gap-2 pb-3 text-sm font-medium border-b-2 transition-colors ${activeTab === 'evening'
-                                ? 'border-indigo-400 text-white'
-                                : 'border-transparent text-neutral-400 hover:text-white'
+                                ? 'border-indigo-400 text-content-primary'
+                                : 'border-transparent text-content-secondary hover:text-content-primary'
                                 }`}
                         >
                             <Moon size={16} className={activeTab === 'evening' ? 'text-indigo-400' : ''} />
@@ -258,7 +258,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                         {onNavigateHistory && (
                             <button
                                 onClick={onNavigateHistory}
-                                className="flex items-center gap-2 pb-3 text-sm font-medium border-b-2 border-transparent text-neutral-400 hover:text-white transition-colors ml-auto"
+                                className="flex items-center gap-2 pb-3 text-sm font-medium border-b-2 border-transparent text-content-secondary hover:text-content-primary transition-colors ml-auto"
                             >
                                 <History size={16} />
                                 History
@@ -284,7 +284,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                             return (
                                 <div key={k} className="space-y-3">
                         <div className="flex justify-between text-sm">
-                            <label className="text-neutral-300 font-medium flex items-center gap-2">
+                            <label className="text-content-secondary font-medium flex items-center gap-2">
                                             {cfg.icon}
                                             {cfg.label}
                             </label>
@@ -299,10 +299,10 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                                         step={cfg.step}
                                         value={value}
                                         onChange={(e) => updateCurrentSession(k as any, Number(e.target.value))}
-                                        className="w-full h-2 bg-neutral-800 rounded-lg appearance-none cursor-pointer accent-emerald-500"
+                                        className="w-full h-2 bg-surface-1 rounded-lg appearance-none cursor-pointer accent-emerald-500"
                         />
                                     {(cfg.max <= 5) && (
-                        <div className="flex justify-between text-xs text-neutral-500 px-1">
+                        <div className="flex justify-between text-xs text-content-muted px-1">
                             <span>Low</span>
                             <span>High</span>
                         </div>
@@ -330,10 +330,10 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                             return (
                                 <div key={`extra-${k}`} className="space-y-3">
                                     <div className="flex justify-between items-center text-sm">
-                            <label className="text-neutral-300 font-medium flex items-center gap-2">
+                            <label className="text-content-secondary font-medium flex items-center gap-2">
                                             {cfg.icon}
                                             {cfg.label}
-                                            <span className="text-[10px] text-neutral-500 font-semibold">(added)</span>
+                                            <span className="text-[10px] text-content-muted font-semibold">(added)</span>
                             </label>
                                         <div className="flex items-center gap-3">
                                             <span className={`${cfg.colorClass} font-bold`}>
@@ -341,7 +341,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                                             </span>
                                             <button
                                                 onClick={() => handleRemoveExtraMetric(k)}
-                                                className="text-xs text-neutral-500 hover:text-white"
+                                                className="text-xs text-content-muted hover:text-content-primary"
                                                 title="Remove metric"
                                             >
                                                 Remove
@@ -355,10 +355,10 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                                         step={cfg.step}
                                         value={value}
                                         onChange={(e) => updateCurrentSession(k as any, Number(e.target.value))}
-                                        className="w-full h-2 bg-neutral-800 rounded-lg appearance-none cursor-pointer accent-emerald-500"
+                                        className="w-full h-2 bg-surface-1 rounded-lg appearance-none cursor-pointer accent-emerald-500"
                         />
                                     {(cfg.max <= 5) && (
-                        <div className="flex justify-between text-xs text-neutral-500 px-1">
+                        <div className="flex justify-between text-xs text-content-muted px-1">
                             <span>Low</span>
                             <span>High</span>
                         </div>
@@ -370,7 +370,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                     {/* Add another metric */}
                     {addableMetrics.length > 0 && (
                         <div className="pt-2">
-                            <div className="text-xs font-semibold text-neutral-400 mb-2">Add another metric</div>
+                            <div className="text-xs font-semibold text-content-secondary mb-2">Add another metric</div>
                             <select
                                 value=""
                                 onChange={(e) => {
@@ -378,7 +378,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                                     if (!key) return;
                                     handleAddMetric(key);
                                 }}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-emerald-500 outline-none"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg px-3 py-2 text-sm text-content-primary focus:border-focus outline-none"
                             >
                                 <option value="" disabled>
                                     Select a metric…
@@ -389,7 +389,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                                     </option>
                                 ))}
                             </select>
-                            <div className="text-[11px] text-neutral-500 mt-2">
+                            <div className="text-[11px] text-content-muted mt-2">
                                 Added metrics will appear in future check-ins too.
                             </div>
                         </div>
@@ -400,20 +400,20 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                         {!notesOpen ? (
                             <button
                                 onClick={() => setNotesOpen(true)}
-                                className="text-sm text-neutral-300 hover:text-white transition-colors"
+                                className="text-sm text-content-secondary hover:text-content-primary transition-colors"
                             >
                                 + Add a note
                             </button>
                         ) : (
                             <div className="space-y-2">
                                 <div className="flex items-center justify-between">
-                                    <label className="text-sm text-neutral-300 font-medium">Note</label>
+                                    <label className="text-sm text-content-secondary font-medium">Note</label>
                                     <button
                                         onClick={() => {
                                             setNotesOpen(false);
                                             updateCurrentSession('notes', '');
                                         }}
-                                        className="text-xs text-neutral-500 hover:text-white"
+                                        className="text-xs text-content-muted hover:text-content-primary"
                                     >
                                         Hide
                                     </button>
@@ -422,7 +422,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                                     value={currentData.notes || ''}
                             onChange={(e) => updateCurrentSession('notes', e.target.value)}
                             placeholder={`How are you feeling this ${activeTab}?`}
-                            className="w-full bg-neutral-800 border border-white/10 rounded-lg p-3 text-sm text-white focus:border-emerald-500 outline-none resize-none h-20"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-lg p-3 text-sm text-content-primary focus:border-focus outline-none resize-none h-20"
                         />
                             </div>
                         )}
@@ -430,7 +430,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                 </div>
 
                 {/* Footer */}
-                <div className="p-4 border-t border-white/5 bg-neutral-800/50 flex justify-end">
+                <div className="p-4 border-t border-line-subtle bg-surface-1/50 flex justify-end">
                     <button
                         onClick={(e) => {
                             console.log('[DailyCheckInModal] BUTTON CLICKED');
@@ -438,7 +438,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                             handleSave();
                         }}
                         type="button"
-                        className="flex items-center gap-2 px-6 py-2 bg-emerald-500 hover:bg-emerald-600 text-white rounded-lg font-medium transition-colors"
+                        className="flex items-center gap-2 px-6 py-2 bg-emerald-500 hover:bg-accent-strong text-content-primary rounded-lg font-medium transition-colors"
                     >
                         <Save size={18} />
                         Save {activeTab.charAt(0).toUpperCase() + activeTab.slice(1)} Check-in

--- a/src/components/DayChipSelector.tsx
+++ b/src/components/DayChipSelector.tsx
@@ -36,8 +36,8 @@ export const DayChipSelector: React.FC<DayChipSelectorProps> = ({
                     className={`
                         w-9 h-9 rounded-lg text-xs font-bold transition-all
                         ${selectedDays.includes(i)
-                            ? 'bg-emerald-500 text-neutral-900 shadow-[0_0_10px_rgba(16,185,129,0.3)]'
-                            : 'bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-white'}
+                            ? 'bg-accent text-content-on-accent shadow-[0_0_10px_rgba(16,185,129,0.3)]'
+                            : 'bg-surface-1 text-content-secondary hover:bg-surface-2 hover:text-content-primary'}
                         ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
                     `}
                 >

--- a/src/components/DeleteHabitConfirmModal.tsx
+++ b/src/components/DeleteHabitConfirmModal.tsx
@@ -58,13 +58,13 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Delete Habit</h3>
+                    <h3 className="text-xl font-bold text-content-primary">Delete Habit</h3>
                     <button
                         onClick={handleCancel}
                         disabled={isDeleting}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors disabled:opacity-50 -mr-2"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50 -mr-2"
                         aria-label="Close"
                     >
                         <X size={20} />
@@ -77,19 +77,19 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
                         <AlertTriangle className="text-amber-400 flex-shrink-0 mt-0.5" size={20} />
                         <div className="flex-1">
                             <div className="text-amber-400 font-medium mb-1">This habit is linked to a goal</div>
-                            <div className="text-white text-sm">
+                            <div className="text-content-primary text-sm">
                                 Deleting <span className="font-semibold">"{habitName}"</span> will remove it from the following goal{linkedGoalTitles.length === 1 ? '' : 's'}. Past entries continue to count toward goal progress — historical progress is preserved — but you won't be able to log new entries for this habit.
                             </div>
                         </div>
                     </div>
 
                     {/* Linked goals list */}
-                    <div className="p-3 bg-neutral-800/50 rounded-lg">
-                        <div className="text-neutral-400 text-xs mb-2">Linked goal{linkedGoalTitles.length === 1 ? '' : 's'}</div>
+                    <div className="p-3 bg-surface-1/50 rounded-lg">
+                        <div className="text-content-secondary text-xs mb-2">Linked goal{linkedGoalTitles.length === 1 ? '' : 's'}</div>
                         <ul className="space-y-1.5">
                             {linkedGoalTitles.map((title, idx) => (
-                                <li key={idx} className="flex items-center gap-2 text-white text-sm">
-                                    <Target size={14} className="text-emerald-400 flex-shrink-0" />
+                                <li key={idx} className="flex items-center gap-2 text-content-primary text-sm">
+                                    <Target size={14} className="text-accent-contrast flex-shrink-0" />
                                     <span className="truncate">{title}</span>
                                 </li>
                             ))}
@@ -98,10 +98,10 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
 
                     {/* Error display */}
                     {error && (
-                        <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg flex items-start gap-3">
-                            <AlertTriangle className="text-red-400 flex-shrink-0 mt-0.5" size={16} />
+                        <div className="p-3 bg-danger-soft border border-danger/50 rounded-lg flex items-start gap-3">
+                            <AlertTriangle className="text-danger-contrast flex-shrink-0 mt-0.5" size={16} />
                             <div className="flex-1">
-                                <div className="text-red-400 text-sm">{error}</div>
+                                <div className="text-danger-contrast text-sm">{error}</div>
                             </div>
                         </div>
                     )}
@@ -112,7 +112,7 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
                             type="button"
                             onClick={handleCancel}
                             disabled={isDeleting}
-                            className="flex-1 px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="flex-1 px-4 py-2 bg-surface-2 hover:bg-surface-2 text-content-primary rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             Cancel
                         </button>
@@ -120,7 +120,7 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
                             type="button"
                             onClick={handleConfirm}
                             disabled={isDeleting}
-                            className="flex-1 px-4 py-2 bg-red-500 hover:bg-red-400 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                            className="flex-1 px-4 py-2 bg-danger hover:bg-danger/80 text-content-primary font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                         >
                             {isDeleting ? (
                                 <>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -24,15 +24,15 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
 }) => {
   return (
     <div className={`flex flex-col items-center justify-center p-8 sm:p-12 text-center ${className}`}>
-      <div className="w-14 h-14 bg-neutral-800 rounded-full flex items-center justify-center mb-5">
-        <Icon size={28} className="text-neutral-500" />
+      <div className="w-14 h-14 bg-surface-1 rounded-full flex items-center justify-center mb-5">
+        <Icon size={28} className="text-content-muted" />
       </div>
 
-      <h3 className="text-lg font-semibold text-white mb-2 max-w-md">
+      <h3 className="text-lg font-semibold text-content-primary mb-2 max-w-md">
         {title}
       </h3>
 
-      <p className="text-sm text-neutral-400 mb-4 max-w-sm leading-relaxed">
+      <p className="text-sm text-content-secondary mb-4 max-w-sm leading-relaxed">
         {description}
       </p>
 
@@ -41,7 +41,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
           {examples.map((example) => (
             <span
               key={example}
-              className="px-3 py-1 text-xs text-neutral-400 bg-neutral-800/80 rounded-full border border-white/5"
+              className="px-3 py-1 text-xs text-content-secondary bg-surface-1/80 rounded-full border border-line-subtle"
             >
               {example}
             </span>
@@ -52,7 +52,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
       {ctaLabel && onCtaClick && (
         <button
           onClick={onCtaClick}
-          className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-medium rounded-lg transition-colors text-sm"
+          className="flex items-center gap-2 px-5 py-2.5 bg-accent hover:bg-accent-strong text-content-on-accent font-medium rounded-lg transition-colors text-sm"
         >
           {ctaLabel}
         </button>

--- a/src/components/GoalCreationInlineModal.tsx
+++ b/src/components/GoalCreationInlineModal.tsx
@@ -91,10 +91,10 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
             onClick={(e) => { if (e.target === e.currentTarget) handleCancel(); }}
             onKeyDown={(e) => { if (e.key === 'Escape') { e.stopPropagation(); handleCancel(); } }}
         >
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Create New Goal</h3>
-                    <button onClick={handleCancel} className="text-neutral-400 hover:text-white transition-colors">
+                    <h3 className="text-xl font-bold text-content-primary">Create New Goal</h3>
+                    <button onClick={handleCancel} className="text-content-secondary hover:text-content-primary transition-colors">
                         <X size={20} />
                     </button>
                 </div>
@@ -102,14 +102,14 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
                 <form onSubmit={handleSubmit} className="space-y-4">
                     {/* Title */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
-                            Title <span className="text-red-400">*</span>
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
+                            Title <span className="text-danger-contrast">*</span>
                         </label>
                         <input
                             type="text"
                             value={title}
                             onChange={(e) => setTitle(e.target.value)}
-                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                             placeholder="e.g., Run a Marathon"
                             autoFocus
                         />
@@ -117,31 +117,31 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
 
                     {/* Goal Type */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
-                            Goal Type <span className="text-red-400">*</span>
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
+                            Goal Type <span className="text-danger-contrast">*</span>
                         </label>
                         <div className="flex gap-2">
                             <button
                                 type="button"
                                 onClick={() => setType('cumulative')}
                                 className={`flex items-center gap-2 px-4 py-2 rounded-lg border transition-all ${type === 'cumulative'
-                                    ? 'bg-emerald-500/10 border-emerald-500/50 ring-1 ring-emerald-500/20'
-                                    : 'bg-neutral-800 border-white/5 hover:border-white/10 hover:bg-neutral-700'
+                                    ? 'bg-accent-soft border-accent/50 ring-1 ring-focus/20'
+                                    : 'bg-surface-1 border-line-subtle hover:border-line-subtle hover:bg-surface-2'
                                     }`}
                             >
-                                <Target size={16} className={type === 'cumulative' ? 'text-emerald-400' : 'text-neutral-400'} />
-                                <span className="text-white text-sm font-medium">Cumulative</span>
+                                <Target size={16} className={type === 'cumulative' ? 'text-accent-contrast' : 'text-content-secondary'} />
+                                <span className="text-content-primary text-sm font-medium">Cumulative</span>
                             </button>
                             <button
                                 type="button"
                                 onClick={() => setType('onetime')}
                                 className={`flex items-center gap-2 px-4 py-2 rounded-lg border transition-all ${type === 'onetime'
-                                    ? 'bg-emerald-500/10 border-emerald-500/50 ring-1 ring-emerald-500/20'
-                                    : 'bg-neutral-800 border-white/5 hover:border-white/10 hover:bg-neutral-700'
+                                    ? 'bg-accent-soft border-accent/50 ring-1 ring-focus/20'
+                                    : 'bg-surface-1 border-line-subtle hover:border-line-subtle hover:bg-surface-2'
                                     }`}
                             >
-                                <CalendarCheck size={16} className={type === 'onetime' ? 'text-emerald-400' : 'text-neutral-400'} />
-                                <span className="text-white text-sm font-medium">One-Time</span>
+                                <CalendarCheck size={16} className={type === 'onetime' ? 'text-accent-contrast' : 'text-content-secondary'} />
+                                <span className="text-content-primary text-sm font-medium">One-Time</span>
                             </button>
                         </div>
                     </div>
@@ -150,28 +150,28 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
                     {type === 'cumulative' && (
                         <div className="flex gap-3">
                             <div className="flex-1">
-                                <label className="block text-sm font-medium text-neutral-400 mb-1">
-                                    Target Value <span className="text-red-400">*</span>
+                                <label className="block text-sm font-medium text-content-secondary mb-1">
+                                    Target Value <span className="text-danger-contrast">*</span>
                                 </label>
                                 <input
                                     type="number"
                                     value={targetValue}
                                     onChange={(e) => setTargetValue(e.target.value)}
-                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                    className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                     placeholder="e.g., 100"
                                     min="0.01"
                                     step="0.01"
                                 />
                             </div>
                             <div className="flex-1">
-                                <label className="block text-sm font-medium text-neutral-400 mb-1">
-                                    Unit <span className="text-neutral-500">(Optional)</span>
+                                <label className="block text-sm font-medium text-content-secondary mb-1">
+                                    Unit <span className="text-content-muted">(Optional)</span>
                                 </label>
                                 <input
                                     type="text"
                                     value={unit}
                                     onChange={(e) => setUnit(e.target.value)}
-                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                    className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                     placeholder="e.g., miles"
                                 />
                             </div>
@@ -180,8 +180,8 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
 
                     {/* Deadline */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
-                            {type === 'onetime' ? 'Event Date' : 'Deadline'} <span className="text-neutral-500">(Optional)</span>
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
+                            {type === 'onetime' ? 'Event Date' : 'Deadline'} <span className="text-content-muted">(Optional)</span>
                         </label>
                         <div className="flex items-center gap-3">
                             <div className="relative">
@@ -190,8 +190,8 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
                                     onClick={() => deadlineInputRef.current?.showPicker()}
                                     className={`min-h-[40px] min-w-[40px] flex items-center justify-center rounded-lg border transition-all ${
                                         deadline
-                                            ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
-                                            : 'bg-neutral-800 border-white/10 text-neutral-400 hover:border-white/20 hover:text-white'
+                                            ? 'bg-accent-soft border-accent/50 text-accent-contrast'
+                                            : 'bg-surface-1 border-line-subtle text-content-secondary hover:border-line-strong hover:text-content-primary'
                                     }`}
                                     aria-label={deadline ? `Date: ${deadline}` : 'Set date'}
                                 >
@@ -208,14 +208,14 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
                                 />
                             </div>
                             {deadline && (
-                                <span className="text-sm text-emerald-400">{deadline}</span>
+                                <span className="text-sm text-accent-contrast">{deadline}</span>
                             )}
                         </div>
                     </div>
 
                     {/* Error */}
                     {error && (
-                        <div className="text-sm text-red-400 bg-red-400/10 border border-red-400/20 rounded-lg px-3 py-2">
+                        <div className="text-sm text-danger-contrast bg-danger-soft border border-danger/30 rounded-lg px-3 py-2">
                             {error}
                         </div>
                     )}
@@ -225,7 +225,7 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
                         <button
                             type="button"
                             onClick={handleCancel}
-                            className="px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                            className="px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                         >
                             Cancel
                         </button>
@@ -234,8 +234,8 @@ export const GoalCreationInlineModal: React.FC<GoalCreationInlineModalProps> = (
                             disabled={!isFormValid || isSubmitting}
                             className={`px-4 py-2 font-medium rounded-lg transition-colors ${
                                 isFormValid && !isSubmitting
-                                    ? 'bg-emerald-500 text-neutral-900 hover:bg-emerald-400'
-                                    : 'bg-neutral-800 text-neutral-500 cursor-not-allowed'
+                                    ? 'bg-accent text-content-on-accent hover:bg-accent-strong'
+                                    : 'bg-surface-1 text-content-muted cursor-not-allowed'
                             }`}
                         >
                             {isSubmitting ? 'Creating...' : 'Create Goal'}

--- a/src/components/HabitCreationInlineModal.tsx
+++ b/src/components/HabitCreationInlineModal.tsx
@@ -92,10 +92,10 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Create New Habit</h3>
-                    <button onClick={handleCancel} className="text-neutral-400 hover:text-white transition-colors">
+                    <h3 className="text-xl font-bold text-content-primary">Create New Habit</h3>
+                    <button onClick={handleCancel} className="text-content-secondary hover:text-content-primary transition-colors">
                         <X size={20} />
                     </button>
                 </div>
@@ -103,14 +103,14 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
                 <form onSubmit={handleSubmit} className="space-y-4">
                     {/* Title/Name */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
                             Habit Name <span className="text-red-400">*</span>
                         </label>
                         <input
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
-                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                             placeholder="e.g., Morning Run"
                             required
                         />
@@ -118,7 +118,7 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
 
                     {/* Type */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
                             Type <span className="text-red-400">*</span>
                         </label>
                         <select
@@ -131,7 +131,7 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
                                     setUnit('');
                                 }
                             }}
-                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                         >
                             <option value="binary">Binary</option>
                             <option value="quantified">Quantified</option>
@@ -141,14 +141,14 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
                     {/* Target (only for quantified) */}
                     {type === 'quantified' && (
                         <div>
-                            <label className="block text-sm font-medium text-neutral-400 mb-1">
+                            <label className="block text-sm font-medium text-content-secondary mb-1">
                                 Target Value <span className="text-red-400">*</span>
                             </label>
                             <input
                                 type="number"
                                 value={target}
                                 onChange={(e) => setTarget(e.target.value)}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                 placeholder="e.g., 30"
                                 min="0.01"
                                 step="0.01"
@@ -160,14 +160,14 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
                     {/* Unit (only for quantified) */}
                     {type === 'quantified' && (
                         <div>
-                            <label className="block text-sm font-medium text-neutral-400 mb-1">
+                            <label className="block text-sm font-medium text-content-secondary mb-1">
                                 Unit <span className="text-red-400">*</span>
                             </label>
                             <input
                                 type="text"
                                 value={unit}
                                 onChange={(e) => setUnit(e.target.value)}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                 placeholder="e.g., minutes, miles, glasses"
                                 required
                             />
@@ -176,13 +176,13 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
 
                     {/* Category */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
                             Category <span className="text-red-400">*</span>
                         </label>
                         <select
                             value={categoryId}
                             onChange={(e) => setCategoryId(e.target.value)}
-                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                             required
                         >
                             <option value="">Select a category...</option>
@@ -196,17 +196,17 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
 
                     {/* Icon/Image (Optional) */}
                     <div>
-                        <label className="block text-sm font-medium text-neutral-400 mb-1">
-                            Icon/Image URL <span className="text-neutral-500">(Optional)</span>
+                        <label className="block text-sm font-medium text-content-secondary mb-1">
+                            Icon/Image URL <span className="text-content-muted">(Optional)</span>
                         </label>
                         <input
                             type="url"
                             value={imageUrl}
                             onChange={(e) => setImageUrl(e.target.value)}
-                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                             placeholder="https://example.com/image.png"
                         />
-                        <p className="mt-1 text-xs text-neutral-500">
+                        <p className="mt-1 text-xs text-content-muted">
                             URL to an icon or image for this habit
                         </p>
                     </div>
@@ -215,7 +215,7 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
                         <button
                             type="button"
                             onClick={handleCancel}
-                            className="px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                            className="px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                         >
                             Cancel
                         </button>
@@ -224,8 +224,8 @@ export const HabitCreationInlineModal: React.FC<HabitCreationInlineModalProps> =
                             disabled={!isFormValid}
                             className={`px-4 py-2 font-medium rounded-lg transition-colors ${
                                 isFormValid
-                                    ? 'bg-emerald-500 text-neutral-900 hover:bg-emerald-400'
-                                    : 'bg-neutral-800 text-neutral-500 cursor-not-allowed'
+                                    ? 'bg-accent text-content-on-accent hover:bg-accent-strong'
+                                    : 'bg-surface-1 text-content-muted cursor-not-allowed'
                             }`}
                         >
                             Create Habit

--- a/src/components/HabitHistoryModal.tsx
+++ b/src/components/HabitHistoryModal.tsx
@@ -164,17 +164,17 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
     return (
         <div className="modal-overlay fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onClose}>
             <div
-                className="bg-neutral-900 border border-white/10 rounded-xl shadow-2xl w-full max-w-lg max-h-[85dvh] flex flex-col"
+                className="bg-surface-0 border border-line-subtle rounded-xl shadow-2xl w-full max-w-lg max-h-[85dvh] flex flex-col"
                 onClick={e => e.stopPropagation()}
             >
                 {/* Header */}
-                <div className="flex justify-between items-center px-5 py-4 border-b border-white/5">
-                    <h2 className="text-lg font-bold text-neutral-100">
+                <div className="flex justify-between items-center px-5 py-4 border-b border-line-subtle">
+                    <h2 className="text-lg font-bold text-content-primary">
                         {habit.name}
                     </h2>
                     <button
                         onClick={onClose}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-500 hover:text-neutral-300 -mr-2"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-muted hover:text-content-secondary -mr-2"
                         aria-label="Close"
                     >
                         <X size={20} />
@@ -183,7 +183,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
 
                 <div className="flex-1 overflow-y-auto modal-scroll">
                     {loading ? (
-                        <div className="text-center py-12 text-neutral-500">Loading history...</div>
+                        <div className="text-center py-12 text-content-muted">Loading history...</div>
                     ) : (
                         <>
                             {/* Calendar Section */}
@@ -192,16 +192,16 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                 <div className="flex items-center justify-between mb-3">
                                     <button
                                         onClick={() => setCurrentMonth(prev => subMonths(prev, 1))}
-                                        className="p-1.5 rounded-lg hover:bg-white/5 text-neutral-400 hover:text-white transition-colors"
+                                        className="p-1.5 rounded-lg hover:bg-surface-2 text-content-secondary hover:text-content-primary transition-colors"
                                     >
                                         <ChevronLeft size={18} />
                                     </button>
-                                    <span className="text-sm font-semibold text-neutral-200">
+                                    <span className="text-sm font-semibold text-content-primary">
                                         {format(currentMonth, 'MMMM yyyy')}
                                     </span>
                                     <button
                                         onClick={() => setCurrentMonth(prev => addMonths(prev, 1))}
-                                        className="p-1.5 rounded-lg hover:bg-white/5 text-neutral-400 hover:text-white transition-colors"
+                                        className="p-1.5 rounded-lg hover:bg-surface-2 text-content-secondary hover:text-content-primary transition-colors"
                                         disabled={isSameMonth(currentMonth, today)}
                                     >
                                         <ChevronRight size={18} className={isSameMonth(currentMonth, today) ? 'opacity-30' : ''} />
@@ -211,7 +211,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                 {/* Weekday Headers */}
                                 <div className="grid grid-cols-7 gap-1 mb-1">
                                     {WEEKDAY_LABELS.map(d => (
-                                        <div key={d} className="text-center text-[10px] font-medium text-neutral-600 py-1">
+                                        <div key={d} className="text-center text-[10px] font-medium text-content-muted py-1">
                                             {d}
                                         </div>
                                     ))}
@@ -239,10 +239,10 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                     !inMonth && "opacity-30",
                                                     isFuture && "opacity-20 cursor-not-allowed",
                                                     isSelected
-                                                        ? "bg-emerald-500/20 border border-emerald-500/50 text-emerald-400"
+                                                        ? "bg-accent-soft border border-emerald-500/50 text-accent-contrast"
                                                         : isToday
-                                                            ? "bg-white/5 border border-white/10 text-white font-bold"
-                                                            : "hover:bg-white/5 text-neutral-400",
+                                                            ? "bg-white/5 border border-line-subtle text-content-primary font-bold"
+                                                            : "hover:bg-surface-2 text-content-secondary",
                                                     !isFuture && !isSelected && "cursor-pointer"
                                                 )}
                                             >
@@ -250,7 +250,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                 {hasEntries && (
                                                     <span className={cn(
                                                         "mt-0.5 text-[8px] font-bold leading-none",
-                                                        isSelected ? "text-emerald-400" : "text-emerald-500"
+                                                        isSelected ? "text-accent-contrast" : "text-emerald-500"
                                                     )}>
                                                         {isQuantity ? dayTotal : '●'}
                                                     </span>
@@ -269,12 +269,12 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                 {selectedDate ? (
                                     <div>
                                         <div className="flex items-center justify-between mb-3">
-                                            <h3 className="text-sm font-semibold text-neutral-200">
+                                            <h3 className="text-sm font-semibold text-content-primary">
                                                 {format(new Date(selectedDate + 'T12:00:00'), 'EEEE, MMM d, yyyy')}
                                             </h3>
                                             <button
                                                 onClick={() => { setShowNewEntry(true); setEditingId(null); }}
-                                                className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10 rounded-md transition-colors"
+                                                className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-accent-contrast hover:text-accent-contrast hover:bg-accent-strong/10 rounded-md transition-colors"
                                             >
                                                 <Plus size={14} />
                                                 Add Entry
@@ -283,28 +283,28 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
 
                                         {/* New Entry Form */}
                                         {showNewEntry && (
-                                            <div className="flex items-center gap-2 mb-3 p-3 bg-emerald-500/5 border border-emerald-500/20 rounded-lg">
+                                            <div className="flex items-center gap-2 mb-3 p-3 bg-emerald-500/5 border border-accent/20 rounded-lg">
                                                 <input
                                                     type="number"
                                                     value={newEntryValue}
                                                     onChange={e => setNewEntryValue(Number(e.target.value))}
-                                                    className="w-20 px-2 py-1.5 text-sm bg-neutral-800 border border-white/10 rounded-md text-neutral-200 focus:outline-none focus:border-emerald-500/50"
+                                                    className="w-20 px-2 py-1.5 text-sm bg-surface-1 border border-line-subtle rounded-md text-content-primary focus:outline-none focus:border-emerald-500/50"
                                                     autoFocus
                                                 />
                                                 {habit.goal?.unit && (
-                                                    <span className="text-xs text-neutral-500">{habit.goal.unit}</span>
+                                                    <span className="text-xs text-content-muted">{habit.goal.unit}</span>
                                                 )}
                                                 <div className="ml-auto flex gap-2">
                                                     <button
                                                         onClick={handleCreateEntry}
                                                         disabled={saving}
-                                                        className="px-3 py-1.5 text-xs font-medium bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30 rounded-md transition-colors disabled:opacity-50"
+                                                        className="px-3 py-1.5 text-xs font-medium bg-accent-soft text-accent-contrast hover:bg-accent-strong/30 rounded-md transition-colors disabled:opacity-50"
                                                     >
                                                         {saving ? 'Saving...' : 'Save'}
                                                     </button>
                                                     <button
                                                         onClick={() => setShowNewEntry(false)}
-                                                        className="px-3 py-1.5 text-xs text-neutral-500 hover:text-neutral-300 rounded-md transition-colors"
+                                                        className="px-3 py-1.5 text-xs text-content-muted hover:text-content-secondary rounded-md transition-colors"
                                                     >
                                                         Cancel
                                                     </button>
@@ -314,34 +314,34 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
 
                                         {/* Existing Entries for Selected Date */}
                                         {selectedEntries.length === 0 && !showNewEntry ? (
-                                            <p className="text-sm text-neutral-600 py-4 text-center">No entries for this date.</p>
+                                            <p className="text-sm text-content-muted py-4 text-center">No entries for this date.</p>
                                         ) : (
                                             <div className="space-y-2">
                                                 {selectedEntries.map(entry => (
-                                                    <div key={entry.id} className="flex items-center gap-3 p-3 bg-neutral-800/50 border border-white/5 rounded-lg">
+                                                    <div key={entry.id} className="flex items-center gap-3 p-3 bg-surface-1/50 border border-line-subtle rounded-lg">
                                                         {editingId === entry.id ? (
                                                             <div className="flex items-center gap-2 flex-1">
                                                                 <input
                                                                     type="number"
                                                                     value={editValue}
                                                                     onChange={e => setEditValue(Number(e.target.value))}
-                                                                    className="w-20 px-2 py-1.5 text-sm bg-neutral-800 border border-white/10 rounded-md text-neutral-200 focus:outline-none focus:border-emerald-500/50"
+                                                                    className="w-20 px-2 py-1.5 text-sm bg-surface-1 border border-line-subtle rounded-md text-content-primary focus:outline-none focus:border-emerald-500/50"
                                                                     autoFocus
                                                                 />
                                                                 {habit.goal?.unit && (
-                                                                    <span className="text-xs text-neutral-500">{habit.goal.unit}</span>
+                                                                    <span className="text-xs text-content-muted">{habit.goal.unit}</span>
                                                                 )}
                                                                 <div className="ml-auto flex gap-2">
                                                                     <button
                                                                         onClick={() => handleSaveEdit(entry)}
                                                                         disabled={saving}
-                                                                        className="px-3 py-1.5 text-xs font-medium text-emerald-400 hover:text-emerald-300 transition-colors disabled:opacity-50"
+                                                                        className="px-3 py-1.5 text-xs font-medium text-accent-contrast hover:text-accent-contrast transition-colors disabled:opacity-50"
                                                                     >
                                                                         {saving ? 'Saving...' : 'Save'}
                                                                     </button>
                                                                     <button
                                                                         onClick={() => setEditingId(null)}
-                                                                        className="px-3 py-1.5 text-xs text-neutral-500 hover:text-neutral-300 transition-colors"
+                                                                        className="px-3 py-1.5 text-xs text-content-muted hover:text-content-secondary transition-colors"
                                                                     >
                                                                         Cancel
                                                                     </button>
@@ -351,14 +351,14 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                             <>
                                                                 <div className="flex-1 min-w-0">
                                                                     <div className="flex items-center gap-2">
-                                                                        <span className="font-mono font-bold text-neutral-200 text-sm">
+                                                                        <span className="font-mono font-bold text-content-primary text-sm">
                                                                             {entry.value ?? '—'}
                                                                         </span>
                                                                         {habit.goal?.unit && (
-                                                                            <span className="text-xs text-neutral-500">{habit.goal.unit}</span>
+                                                                            <span className="text-xs text-content-muted">{habit.goal.unit}</span>
                                                                         )}
                                                                     </div>
-                                                                    <div className="text-[10px] text-neutral-600 mt-0.5">
+                                                                    <div className="text-[10px] text-content-muted mt-0.5">
                                                                         {entry.source}
                                                                         {(() => {
                                                                             const d = new Date(entry.timestamp);
@@ -374,14 +374,14 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                                 <div className="flex items-center gap-1">
                                                                     <button
                                                                         onClick={() => handleStartEdit(entry)}
-                                                                        className="p-1.5 rounded-md text-neutral-500 hover:text-neutral-300 hover:bg-white/5 transition-colors"
+                                                                        className="p-1.5 rounded-md text-content-muted hover:text-content-secondary hover:bg-surface-2 transition-colors"
                                                                         title="Edit"
                                                                     >
                                                                         <Pencil size={14} />
                                                                     </button>
                                                                     <button
                                                                         onClick={() => handleDelete(entry.id)}
-                                                                        className="p-1.5 rounded-md text-neutral-500 hover:text-red-400 hover:bg-white/5 transition-colors"
+                                                                        className="p-1.5 rounded-md text-content-muted hover:text-red-400 hover:bg-surface-2 transition-colors"
                                                                         title="Delete"
                                                                     >
                                                                         <Trash2 size={14} />
@@ -397,11 +397,11 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                 ) : (
                                     /* Date List - show all dates with entries */
                                     <div>
-                                        <h3 className="text-xs font-semibold text-neutral-500 uppercase tracking-wider mb-2">
+                                        <h3 className="text-xs font-semibold text-content-muted uppercase tracking-wider mb-2">
                                             Entry History ({entryDates.length} {entryDates.length === 1 ? 'day' : 'days'})
                                         </h3>
                                         {entryDates.length === 0 ? (
-                                            <p className="text-sm text-neutral-600 py-4 text-center">No entries yet. Select a date on the calendar to add one.</p>
+                                            <p className="text-sm text-content-muted py-4 text-center">No entries yet. Select a date on the calendar to add one.</p>
                                         ) : (
                                             <div className="space-y-1">
                                                 {entryDates.map(dayKey => {
@@ -412,24 +412,24 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                         <button
                                                             key={dayKey}
                                                             onClick={() => { setSelectedDate(dayKey); setEditingId(null); setShowNewEntry(false); }}
-                                                            className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg hover:bg-white/5 transition-colors text-left"
+                                                            className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg hover:bg-surface-2 transition-colors text-left"
                                                         >
-                                                            <span className="text-sm text-neutral-300">
+                                                            <span className="text-sm text-content-secondary">
                                                                 {format(new Date(dayKey + 'T12:00:00'), 'EEE, MMM d, yyyy')}
                                                             </span>
                                                             <div className="flex items-center gap-2">
                                                                 {isQuantity && (
-                                                                    <span className="font-mono text-sm font-bold text-neutral-200">
+                                                                    <span className="font-mono text-sm font-bold text-content-primary">
                                                                         {total}
-                                                                        {habit.goal?.unit && <span className="text-xs text-neutral-500 ml-0.5">{habit.goal.unit}</span>}
+                                                                        {habit.goal?.unit && <span className="text-xs text-content-muted ml-0.5">{habit.goal.unit}</span>}
                                                                     </span>
                                                                 )}
                                                                 {count > 1 && (
-                                                                    <span className="text-[10px] text-neutral-600 bg-white/5 px-1.5 py-0.5 rounded">
+                                                                    <span className="text-[10px] text-content-muted bg-white/5 px-1.5 py-0.5 rounded">
                                                                         {count}x
                                                                     </span>
                                                                 )}
-                                                                <ChevronRight size={14} className="text-neutral-600" />
+                                                                <ChevronRight size={14} className="text-content-muted" />
                                                             </div>
                                                         </button>
                                                     );

--- a/src/components/HabitLogModal.tsx
+++ b/src/components/HabitLogModal.tsx
@@ -74,15 +74,15 @@ export const HabitLogModal: React.FC<HabitLogModalProps> = ({ isOpen, onClose, h
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200">
-            <div className="w-full max-w-sm bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl scale-100 animate-in zoom-in-95 duration-200 max-h-[90dvh] flex flex-col">
+            <div className="w-full max-w-sm bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl scale-100 animate-in zoom-in-95 duration-200 max-h-[90dvh] flex flex-col">
 
                 {/* Header */}
                 <div className="flex items-center justify-between mb-6">
                     <div>
-                        <h3 className="text-lg font-bold text-white">{habit.name}</h3>
-                        <p className="text-xs text-neutral-400">{date}</p>
+                        <h3 className="text-lg font-bold text-content-primary">{habit.name}</h3>
+                        <p className="text-xs text-content-secondary">{date}</p>
                     </div>
-                    <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors -mr-2" aria-label="Close">
+                    <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary transition-colors -mr-2" aria-label="Close">
                         <X size={20} />
                     </button>
                 </div>
@@ -101,26 +101,26 @@ export const HabitLogModal: React.FC<HabitLogModalProps> = ({ isOpen, onClose, h
                                     "w-full flex items-center justify-between p-4 rounded-xl border transition-all duration-200",
                                     isSelected
                                         ? "bg-amber-500/10 border-amber-500/50 shadow-[0_0_15px_rgba(245,158,11,0.1)]"
-                                        : "bg-neutral-800/50 border-white/5 hover:bg-neutral-800 hover:border-white/10"
+                                        : "bg-surface-1/50 border-line-subtle hover:bg-surface-1 hover:border-line-subtle"
                                 )}
                             >
                                 <div className="flex items-center gap-3">
                                     <div className={cn(
                                         "w-5 h-5 rounded-full border flex items-center justify-center transition-colors",
-                                        isSelected ? "border-amber-500 bg-amber-500" : "border-neutral-600"
+                                        isSelected ? "border-amber-500 bg-amber-500" : "border-line-strong"
                                     )}>
                                         {isSelected && <CheckCircle2 size={12} className="text-black" strokeWidth={3} />}
                                     </div>
                                     <span className={cn(
                                         "text-sm font-medium",
-                                        isSelected ? "text-amber-400" : "text-neutral-300"
+                                        isSelected ? "text-amber-400" : "text-content-secondary"
                                     )}>
                                         {option.label}
                                     </span>
                                 </div>
 
                                 {hasMetric && (
-                                    <span className="text-xs text-neutral-500 flex items-center gap-1">
+                                    <span className="text-xs text-content-muted flex items-center gap-1">
                                         <Hash size={12} />
                                         {option.metricConfig?.unit || 'value'}
                                     </span>
@@ -133,7 +133,7 @@ export const HabitLogModal: React.FC<HabitLogModalProps> = ({ isOpen, onClose, h
                 {/* Metric Input (Conditional) */}
                 {selectedOption && isMetricRequired && (
                     <div className="mb-6 animate-in slide-in-from-top-2 fade-in">
-                        <label className="block text-xs font-semibold text-neutral-500 uppercase tracking-wider mb-2">
+                        <label className="block text-xs font-semibold text-content-muted uppercase tracking-wider mb-2">
                             Enter Amount ({selectedOption.metricConfig?.unit || 'value'})
                         </label>
                         <input
@@ -142,7 +142,7 @@ export const HabitLogModal: React.FC<HabitLogModalProps> = ({ isOpen, onClose, h
                             onChange={(e) => setMetricValue(e.target.value)}
                             // Auto-focus when appearing
                             autoFocus
-                            className="w-full bg-neutral-800 border border-white/10 rounded-xl px-4 py-3 text-white text-lg font-bold focus:outline-none focus:border-amber-500 transition-colors"
+                            className="w-full bg-surface-1 border border-line-subtle rounded-xl px-4 py-3 text-content-primary text-lg font-bold focus:outline-none focus:border-amber-500 transition-colors"
                             placeholder="0"
                         />
                     </div>

--- a/src/components/HeatmapLegend.tsx
+++ b/src/components/HeatmapLegend.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { getHeatmapColor } from '../utils/analytics';
+import { getHeatmapColor, HEATMAP_LEVELS } from '../theme/heatmap';
+import { useTheme } from '../theme/ThemeContext';
 
 export const HeatmapLegend: React.FC = React.memo(() => {
+    const { resolvedMode } = useTheme();
+    const levels = Array.from({ length: HEATMAP_LEVELS }, (_, i) => i);
     return (
-        <div className="flex items-center justify-end gap-2 mt-4 text-xs text-neutral-500">
+        <div className="flex items-center justify-end gap-2 mt-4 text-xs text-content-muted">
             <span>Low</span>
             <div className="flex items-center gap-1">
-                {/* 0 (Empty) */}
-                <div className={`w-3 h-3 rounded-sm ${getHeatmapColor(0)}`} />
-                {/* 1 */}
-                <div className={`w-3 h-3 rounded-sm ${getHeatmapColor(1)}`} />
-                {/* 2 */}
-                <div className={`w-3 h-3 rounded-sm ${getHeatmapColor(2)}`} />
-                {/* 3 */}
-                <div className={`w-3 h-3 rounded-sm ${getHeatmapColor(3)}`} />
-                {/* 4 (Max) */}
-                <div className={`w-3 h-3 rounded-sm ${getHeatmapColor(4)}`} />
+                {levels.map((level) => (
+                    <div
+                        key={level}
+                        className="w-3 h-3 rounded-sm"
+                        style={{ background: getHeatmapColor(level, resolvedMode) }}
+                    />
+                ))}
             </div>
             <span>High</span>
         </div>

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -69,15 +69,15 @@ function renderExamples(examples: Example[]) {
     <ul className="mt-2 space-y-1.5">
       {examples.map((ex) =>
         typeof ex === 'string' ? (
-          <li key={ex} className="text-xs text-neutral-400 italic pl-2">
+          <li key={ex} className="text-xs text-content-secondary italic pl-2">
             — {ex}
           </li>
         ) : (
           <li key={ex.title} className="pl-2">
-            <p className="text-xs text-neutral-400 italic">— {ex.title}</p>
+            <p className="text-xs text-content-secondary italic">— {ex.title}</p>
             <ol className="mt-1 space-y-0.5 pl-4">
               {ex.steps.map((step, idx) => (
-                <li key={step} className="text-xs text-neutral-500">
+                <li key={step} className="text-xs text-content-muted">
                   {idx + 1}. {step}
                 </li>
               ))}
@@ -102,22 +102,22 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
       />
       <div className="absolute inset-0 overflow-y-auto modal-scroll p-4">
         <div
-          className="relative bg-neutral-900 border border-white/10 rounded-xl shadow-xl max-w-sm w-full mx-auto my-8 sm:my-16"
+          className="relative bg-surface-0 border border-line-subtle rounded-xl shadow-xl max-w-sm w-full mx-auto my-8 sm:my-16"
           role="dialog"
           aria-labelledby="info-title"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="p-4 border-b border-white/5 flex items-center justify-between">
+          <div className="p-4 border-b border-line-subtle flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Info size={18} className="text-emerald-400" />
-              <h2 id="info-title" className="text-lg font-semibold text-white">
+              <Info size={18} className="text-accent-contrast" />
+              <h2 id="info-title" className="text-lg font-semibold text-content-primary">
                 How HabitFlow Works
               </h2>
             </div>
             <button
               type="button"
               onClick={onClose}
-              className="p-2 text-neutral-400 hover:text-white rounded-lg hover:bg-white/5"
+              className="p-2 text-content-secondary hover:text-content-primary rounded-lg hover:bg-surface-2"
               aria-label="Close"
             >
               ✕
@@ -125,45 +125,45 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
           </div>
 
           {/* Tab bar */}
-          <div className="flex gap-3 px-4 pt-4 border-b border-white/5 overflow-x-auto">
+          <div className="flex gap-3 px-4 pt-4 border-b border-line-subtle overflow-x-auto">
             <button
               type="button"
               onClick={() => setActiveTab('basics')}
               className={`flex items-center gap-1.5 pb-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${activeTab === 'basics'
-                ? 'border-emerald-400 text-emerald-400'
-                : 'border-transparent text-neutral-500 hover:text-neutral-300'}`}
+                ? 'border-emerald-400 text-accent-contrast'
+                : 'border-transparent text-content-muted hover:text-content-secondary'}`}
             >
-              <BookOpen size={14} className={activeTab === 'basics' ? 'text-emerald-400' : ''} />
+              <BookOpen size={14} className={activeTab === 'basics' ? 'text-accent-contrast' : ''} />
               Basics
             </button>
             <button
               type="button"
               onClick={() => setActiveTab('advanced')}
               className={`flex items-center gap-1.5 pb-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${activeTab === 'advanced'
-                ? 'border-emerald-400 text-emerald-400'
-                : 'border-transparent text-neutral-500 hover:text-neutral-300'}`}
+                ? 'border-emerald-400 text-accent-contrast'
+                : 'border-transparent text-content-muted hover:text-content-secondary'}`}
             >
-              <Sparkles size={14} className={activeTab === 'advanced' ? 'text-emerald-400' : ''} />
+              <Sparkles size={14} className={activeTab === 'advanced' ? 'text-accent-contrast' : ''} />
               Advanced
             </button>
             <button
               type="button"
               onClick={() => setActiveTab('ai')}
               className={`flex items-center gap-1.5 pb-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${activeTab === 'ai'
-                ? 'border-emerald-400 text-emerald-400'
-                : 'border-transparent text-neutral-500 hover:text-neutral-300'}`}
+                ? 'border-emerald-400 text-accent-contrast'
+                : 'border-transparent text-content-muted hover:text-content-secondary'}`}
             >
-              <Brain size={14} className={activeTab === 'ai' ? 'text-emerald-400' : ''} />
+              <Brain size={14} className={activeTab === 'ai' ? 'text-accent-contrast' : ''} />
               AI
             </button>
             <button
               type="button"
               onClick={() => setActiveTab('health')}
               className={`flex items-center gap-1.5 pb-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${activeTab === 'health'
-                ? 'border-emerald-400 text-emerald-400'
-                : 'border-transparent text-neutral-500 hover:text-neutral-300'}`}
+                ? 'border-emerald-400 text-accent-contrast'
+                : 'border-transparent text-content-muted hover:text-content-secondary'}`}
             >
-              <Activity size={14} className={activeTab === 'health' ? 'text-emerald-400' : ''} />
+              <Activity size={14} className={activeTab === 'health' ? 'text-accent-contrast' : ''} />
               Health
               <span className="text-[9px] uppercase tracking-wide bg-amber-500/20 text-amber-400 px-1 py-0.5 rounded font-semibold">Beta</span>
             </button>
@@ -173,12 +173,12 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
           {activeTab === 'basics' && (
             <div className="p-4 space-y-5">
               {/* The Rules */}
-              <div className="bg-emerald-500/5 border border-emerald-500/20 rounded-lg px-3 py-2.5">
-                <p className="text-xs text-emerald-400 uppercase tracking-wide font-semibold mb-1.5">The Rules</p>
-                <ul className="space-y-0.5 text-sm text-neutral-300">
-                  <li>Habits are <span className="text-emerald-400 font-medium">performed</span></li>
-                  <li>Routines are <span className="text-emerald-400 font-medium">completed</span></li>
-                  <li>Goals are <span className="text-emerald-400 font-medium">achieved</span></li>
+              <div className="bg-emerald-500/5 border border-accent/20 rounded-lg px-3 py-2.5">
+                <p className="text-xs text-accent-contrast uppercase tracking-wide font-semibold mb-1.5">The Rules</p>
+                <ul className="space-y-0.5 text-sm text-content-secondary">
+                  <li>Habits are <span className="text-accent-contrast font-medium">performed</span></li>
+                  <li>Routines are <span className="text-accent-contrast font-medium">completed</span></li>
+                  <li>Goals are <span className="text-accent-contrast font-medium">achieved</span></li>
                 </ul>
               </div>
 
@@ -186,18 +186,18 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
               {primaryItems.map((item, i) => (
                 <div key={item.term}>
                   <div className="pl-3 border-l-2 border-emerald-500/40">
-                    <p className="text-sm text-neutral-200">
-                      <span className="font-bold text-emerald-400">{item.term}</span>
+                    <p className="text-sm text-content-primary">
+                      <span className="font-bold text-accent-contrast">{item.term}</span>
                     </p>
-                    <p className="text-sm text-neutral-300 mt-1">{item.definition}</p>
+                    <p className="text-sm text-content-secondary mt-1">{item.definition}</p>
                     {item.trackingTypes && (
                       <div className="mt-2 space-y-1">
-                        <p className="text-xs text-neutral-500 uppercase tracking-wide font-medium">Tracking types</p>
-                        <div className="flex items-center gap-1.5 text-xs text-neutral-400 pl-2">
+                        <p className="text-xs text-content-muted uppercase tracking-wide font-medium">Tracking types</p>
+                        <div className="flex items-center gap-1.5 text-xs text-content-secondary pl-2">
                           <CheckCircle2 size={13} className="text-blue-400 shrink-0" />
                           <span><span className="font-semibold text-blue-400">Done (Y/N)</span> — Simply mark as performed or not</span>
                         </div>
-                        <div className="flex items-center gap-1.5 text-xs text-neutral-400 pl-2">
+                        <div className="flex items-center gap-1.5 text-xs text-content-secondary pl-2">
                           <Calculator size={13} className="text-amber-400 shrink-0" />
                           <span><span className="font-semibold text-amber-400">Quantity</span> — Track a numeric value (e.g., minutes, reps, pages)</span>
                         </div>
@@ -206,29 +206,29 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                     {renderExamples(item.examples)}
                   </div>
                   {i < primaryItems.length - 1 && (
-                    <div className="border-b border-white/5 mt-5" />
+                    <div className="border-b border-line-subtle mt-5" />
                   )}
                 </div>
               ))}
 
               {/* Secondary divider */}
               <div className="pt-1">
-                <p className="text-xs text-neutral-600 uppercase tracking-wide font-medium">Secondary</p>
+                <p className="text-xs text-content-muted uppercase tracking-wide font-medium">Secondary</p>
               </div>
 
               {/* Secondary: Tasks, Journal */}
               {secondaryItems.map((item) => (
-                <div key={item.term} className="pl-3 border-l-2 border-neutral-700/60 opacity-80">
-                  <p className="text-sm text-neutral-300">
-                    <span className="font-semibold text-neutral-400">{item.term}</span>
-                    <span className="ml-2 text-[10px] uppercase tracking-wide bg-neutral-800 text-neutral-500 px-1.5 py-0.5 rounded">
+                <div key={item.term} className="pl-3 border-l-2 border-line-strong/60 opacity-80">
+                  <p className="text-sm text-content-secondary">
+                    <span className="font-semibold text-content-secondary">{item.term}</span>
+                    <span className="ml-2 text-[10px] uppercase tracking-wide bg-surface-1 text-content-muted px-1.5 py-0.5 rounded">
                       {item.badge}
                     </span>
                   </p>
-                  <p className="text-sm text-neutral-400 mt-1">{item.definition}</p>
+                  <p className="text-sm text-content-secondary mt-1">{item.definition}</p>
                   <ul className="mt-1.5 space-y-0.5">
                     {item.examples.map((ex) => (
-                      <li key={ex} className="text-xs text-neutral-500 italic pl-2">
+                      <li key={ex} className="text-xs text-content-muted italic pl-2">
                         — {ex}
                       </li>
                     ))}
@@ -237,11 +237,11 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
               ))}
 
               {/* Link to advanced tab */}
-              <div className="pt-2 border-t border-white/5">
+              <div className="pt-2 border-t border-line-subtle">
                 <button
                   type="button"
                   onClick={() => setActiveTab('advanced')}
-                  className="text-xs text-emerald-400/70 hover:text-emerald-400 transition-colors"
+                  className="text-xs text-accent-contrast/70 hover:text-accent-contrast transition-colors"
                 >
                   Learn about bundles, linking, and more →
                 </button>
@@ -255,44 +255,44 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
 
               {/* Habit Bundles */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Habit Bundles</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">Habit Bundles</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">A bundle groups multiple habits together. Two types:</p>
+                <p className="text-sm text-content-secondary mt-1">A bundle groups multiple habits together. Two types:</p>
 
                 {/* Checklist: definition then example */}
                 <div className="mt-2.5 space-y-1">
-                  <div className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
+                  <div className="text-xs text-content-secondary pl-2 flex items-start gap-1.5">
                     <CheckSquare size={13} className="text-indigo-400 mt-0.5 shrink-0" />
                     <span><span className="font-bold text-indigo-400">Checklist Bundle</span> — Complete a set of habits as a group. Configure how many must be done: all, any, a specific count, or a percentage.</span>
                   </div>
                   <div className="pl-2">
-                    <p className="text-xs text-neutral-400 italic pl-5">— Checklist: "Morning Health"</p>
+                    <p className="text-xs text-content-secondary italic pl-5">— Checklist: "Morning Health"</p>
                     <ol className="mt-1 space-y-0.5 pl-9">
-                      <li className="text-xs text-neutral-500">1. Take vitamins</li>
-                      <li className="text-xs text-neutral-500">2. Drink water</li>
-                      <li className="text-xs text-neutral-500">3. Stretch — success rule: complete all 3</li>
+                      <li className="text-xs text-content-muted">1. Take vitamins</li>
+                      <li className="text-xs text-content-muted">2. Drink water</li>
+                      <li className="text-xs text-content-muted">3. Stretch — success rule: complete all 3</li>
                     </ol>
                   </div>
                 </div>
 
                 {/* Choice: definition then example */}
                 <div className="mt-3 space-y-1">
-                  <div className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
+                  <div className="text-xs text-content-secondary pl-2 flex items-start gap-1.5">
                     <Layers size={13} className="text-amber-400 mt-0.5 shrink-0" />
                     <span><span className="font-bold text-amber-400">Choice Bundle</span> — Pick one option from a set of alternatives each day. Only one needs to be performed.</span>
                   </div>
                   <div className="pl-2">
-                    <p className="text-xs text-neutral-400 italic pl-5">— Choice: "Cardio"</p>
+                    <p className="text-xs text-content-secondary italic pl-5">— Choice: "Cardio"</p>
                     <ol className="mt-1 space-y-0.5 pl-9">
-                      <li className="text-xs text-neutral-500">1. Run, Cycle, or Swim — perform whichever suits the day</li>
+                      <li className="text-xs text-content-muted">1. Run, Cycle, or Swim — perform whichever suits the day</li>
                     </ol>
                   </div>
                 </div>
 
                 {/* Note about moving habits into bundles */}
-                <div className="mt-3 bg-neutral-800/50 rounded-lg px-2.5 py-2 text-xs text-neutral-400">
-                  <p className="font-medium text-neutral-300 mb-1">Managing bundles</p>
+                <div className="mt-3 bg-surface-1/50 rounded-lg px-2.5 py-2 text-xs text-content-secondary">
+                  <p className="font-medium text-content-secondary mb-1">Managing bundles</p>
                   <ul className="space-y-0.5">
                     <li>- You can move an existing habit into a checklist or choice bundle</li>
                     <li>- You can remove a habit from a bundle (end or archive the membership)</li>
@@ -301,70 +301,70 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                 </div>
               </div>
 
-              <div className="border-b border-white/5" />
+              <div className="border-b border-line-subtle" />
 
               {/* Linking */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Linking</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">Linking</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">Connect habits to goals and routines for automatic progress tracking.</p>
+                <p className="text-sm text-content-secondary mt-1">Connect habits to goals and routines for automatic progress tracking.</p>
                 <ul className="mt-1.5 space-y-1">
-                  <li className="text-xs text-neutral-400 pl-2">- Habit-Goal Link — When you perform a linked habit, it counts as evidence toward your goal&apos;s progress.</li>
-                  <li className="text-xs text-neutral-400 pl-2">- Habit-Routine Link — When you complete a routine, its linked habits are automatically marked as performed.</li>
+                  <li className="text-xs text-content-secondary pl-2">- Habit-Goal Link — When you perform a linked habit, it counts as evidence toward your goal&apos;s progress.</li>
+                  <li className="text-xs text-content-secondary pl-2">- Habit-Routine Link — When you complete a routine, its linked habits are automatically marked as performed.</li>
                 </ul>
-                <div className="flex items-center gap-1.5 mt-2 pl-2 text-xs text-neutral-500">
+                <div className="flex items-center gap-1.5 mt-2 pl-2 text-xs text-content-muted">
                   <Trophy size={12} className="text-amber-500 shrink-0" />
                   <span className="italic">Habits linked to a goal display this icon in the tracker.</span>
                 </div>
                 {renderExamples(['"Run for 20 minutes" linked to "Run a 10K" goal — every run updates your goal progress automatically'])}
               </div>
 
-              <div className="border-b border-white/5" />
+              <div className="border-b border-line-subtle" />
 
               {/* Routine Variants */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Routine Variants</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">Routine Variants</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">Create multiple versions of the same routine for different situations — like Quick, Standard, and Deep versions. Each variant has its own steps, duration, and linked habits.</p>
+                <p className="text-sm text-content-secondary mt-1">Create multiple versions of the same routine for different situations — like Quick, Standard, and Deep versions. Each variant has its own steps, duration, and linked habits.</p>
                 {renderExamples([{ title: '"Portuguese Study" variants:', steps: ['Quick (10 min) — Review flashcards', 'Standard (30 min) — Flashcards + practice sentences + podcast', 'Deep (60 min) — All of the above + write in Portuguese'] }])}
               </div>
 
-              <div className="border-b border-white/5" />
+              <div className="border-b border-line-subtle" />
 
               {/* Wellbeing Check-ins */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Wellbeing Check-ins</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">Wellbeing Check-ins</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">Track how you feel with morning and evening check-ins. Rate subjective metrics like mood, energy, stress, focus, and sleep quality on simple scales.</p>
+                <p className="text-sm text-content-secondary mt-1">Track how you feel with morning and evening check-ins. Rate subjective metrics like mood, energy, stress, focus, and sleep quality on simple scales.</p>
                 {renderExamples(['"Morning: rate sleep quality, energy, readiness"', '"Evening: rate stress, satisfaction, focus for the day"'])}
               </div>
 
-              <div className="border-b border-white/5" />
+              <div className="border-b border-line-subtle" />
 
               {/* Goal Types */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Goal Types</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">Goal Types</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">Two types of goals to match different objectives:</p>
+                <p className="text-sm text-content-secondary mt-1">Two types of goals to match different objectives:</p>
                 <ul className="mt-1.5 space-y-1.5">
-                  <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
-                    <Target size={13} className="text-emerald-400 mt-0.5 shrink-0" />
-                    <span><span className="font-semibold text-emerald-400">Cumulative</span> — Track total progress toward a target number (e.g., "Run 100 miles").</span>
+                  <li className="text-xs text-content-secondary pl-2 flex items-start gap-1.5">
+                    <Target size={13} className="text-accent-contrast mt-0.5 shrink-0" />
+                    <span><span className="font-semibold text-accent-contrast">Cumulative</span> — Track total progress toward a target number (e.g., "Run 100 miles").</span>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
-                    <CalendarCheck size={13} className="text-emerald-400 mt-0.5 shrink-0" />
-                    <span><span className="font-semibold text-emerald-400">One-time</span> — A binary milestone to achieve (e.g., "Pass the Portuguese B2 exam").</span>
+                  <li className="text-xs text-content-secondary pl-2 flex items-start gap-1.5">
+                    <CalendarCheck size={13} className="text-accent-contrast mt-0.5 shrink-0" />
+                    <span><span className="font-semibold text-accent-contrast">One-time</span> — A binary milestone to achieve (e.g., "Pass the Portuguese B2 exam").</span>
                   </li>
                 </ul>
-                <p className="text-xs text-neutral-500 mt-2">
-                  The Goals page has three views: <span className="text-neutral-400">All</span> (active goals), <span className="text-neutral-400">Schedule</span> (calendar with deadlines, forecasts, and milestones), and <span className="text-neutral-400">Achievements</span> (completed goals gallery).
+                <p className="text-xs text-content-muted mt-2">
+                  The Goals page has three views: <span className="text-content-secondary">All</span> (active goals), <span className="text-content-secondary">Schedule</span> (calendar with deadlines, forecasts, and milestones), and <span className="text-content-secondary">Achievements</span> (completed goals gallery).
                 </p>
-                <p className="text-xs text-neutral-500 mt-2">
-                  <span className="font-semibold text-emerald-400">Goal Tracks</span> — Create ordered sequences of goals within a category (e.g., Exam 1 → Exam 2 → Exam 3). Only one goal per track is active at a time. When you complete the active goal, the next one unlocks automatically. Progress for each goal only counts from when it became active, so shared habits won't leak progress forward.
+                <p className="text-xs text-content-muted mt-2">
+                  <span className="font-semibold text-accent-contrast">Goal Tracks</span> — Create ordered sequences of goals within a category (e.g., Exam 1 → Exam 2 → Exam 3). Only one goal per track is active at a time. When you complete the active goal, the next one unlocks automatically. Progress for each goal only counts from when it became active, so shared habits won't leak progress forward.
                 </p>
               </div>
             </div>
@@ -374,21 +374,21 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
           {activeTab === 'ai' && (
             <div className="p-4 space-y-5">
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">AI Features</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">AI Features</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">AI-powered tools to enhance your experience (uses your own API key):</p>
+                <p className="text-sm text-content-secondary mt-1">AI-powered tools to enhance your experience (uses your own API key):</p>
                 <ul className="mt-2 space-y-2">
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Variant Suggestions</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Variant Suggestions</span>
                     <p className="mt-0.5">AI analyzes your routine and suggests Quick/Standard/Deep variants with full step lists.</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Journal Summaries</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Journal Summaries</span>
                     <p className="mt-0.5">Auto-generated weekly summary of your journal entries with themes, highlights, actionable feedback, and follow-up reminders. Appears as a dismissible banner on the Journal page and is saved to your journal history.</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Persona-Driven Insights</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Persona-Driven Insights</span>
                     <p className="mt-0.5">Choose an AI persona (like "The Strategic Coach") to guide your journaling prompts.</p>
                   </li>
                 </ul>
@@ -401,38 +401,38 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
             <div className="p-4 space-y-5">
               <div className="bg-amber-500/5 border border-amber-500/20 rounded-lg px-3 py-2.5">
                 <p className="text-xs text-amber-400 uppercase tracking-wide font-semibold">Beta Feature</p>
-                <p className="text-xs text-neutral-400 mt-1">Apple Health integration is currently available to select users.</p>
+                <p className="text-xs text-content-secondary mt-1">Apple Health integration is currently available to select users.</p>
               </div>
 
               <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Apple Health Integration</span>
+                <p className="text-sm text-content-primary">
+                  <span className="font-bold text-accent-contrast">Apple Health Integration</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">Sync health data from Apple Health to automatically track habits based on real-world activity.</p>
+                <p className="text-sm text-content-secondary mt-1">Sync health data from Apple Health to automatically track habits based on real-world activity.</p>
 
                 <ul className="mt-2 space-y-2">
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Getting Started</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Getting Started</span>
                     <p className="mt-0.5">Go to Settings &rarr; Apple Health to connect metrics and create health-tracked habits from a dedicated page.</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Supported Metrics</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Supported Metrics</span>
                     <p className="mt-0.5">Steps, active calories, sleep hours, workout minutes, and weight.</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Health Rules</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Health Rules</span>
                     <p className="mt-0.5">Define rules that auto-log habits when health data meets a threshold (e.g., auto-log "Walk" when steps exceed 8,000).</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Suggestions</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Suggestions</span>
                     <p className="mt-0.5">Receive suggestions to log habits based on your health data. Accept or dismiss each suggestion.</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Backfill</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Backfill</span>
                     <p className="mt-0.5">When creating a health-tracked habit, pick a backfill window of 7, 30, or 90 days (or none). Backfill reads Apple Health data already synced into HabitFlow and creates entries for qualifying days in the window. It never overwrites existing entries and is capped at 365 days.</p>
                   </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Auto-Logged Entries</span>
+                  <li className="text-xs text-content-secondary pl-2">
+                    <span className="font-semibold text-content-secondary">Auto-Logged Entries</span>
                     <div className="flex items-center gap-1.5 mt-0.5">
                       <Activity size={11} className="text-emerald-500/70 shrink-0" />
                       <span>Entries from Apple Health are marked with this icon in the tracker.</span>

--- a/src/components/Journal/JournalDisplay.tsx
+++ b/src/components/Journal/JournalDisplay.tsx
@@ -62,22 +62,22 @@ export function JournalDisplay({ onEdit, lastSavedEntry }: JournalDisplayProps) 
     };
 
     if (loading) {
-        return <div className="text-center p-8 text-white/50">Loading journal history...</div>;
+        return <div className="text-center p-8 text-content-primary/50">Loading journal history...</div>;
     }
 
     if (entries.length === 0) {
         return (
-            <div className="flex flex-col items-center text-center p-8 sm:p-12 bg-white/5 rounded-2xl border border-white/10">
-                <div className="w-14 h-14 bg-neutral-800 rounded-full flex items-center justify-center mb-5">
-                    <BookOpen size={28} className="text-neutral-500" />
+            <div className="flex flex-col items-center text-center p-8 sm:p-12 bg-white/5 rounded-2xl border border-line-subtle">
+                <div className="w-14 h-14 bg-surface-1 rounded-full flex items-center justify-center mb-5">
+                    <BookOpen size={28} className="text-content-muted" />
                 </div>
-                <h3 className="text-lg font-semibold text-white mb-2">No entries yet</h3>
-                <p className="text-sm text-neutral-400 mb-4 max-w-sm leading-relaxed">
+                <h3 className="text-lg font-semibold text-content-primary mb-2">No entries yet</h3>
+                <p className="text-sm text-content-secondary mb-4 max-w-sm leading-relaxed">
                     Use journaling to reflect, review, or just get thoughts out of your head.
                 </p>
                 <div className="flex flex-wrap justify-center gap-2">
                     {['Quick Free Write', 'Morning Reflection', 'Evening Review'].map((ex) => (
-                        <span key={ex} className="px-3 py-1 text-xs text-neutral-400 bg-neutral-800/80 rounded-full border border-white/5">
+                        <span key={ex} className="px-3 py-1 text-xs text-content-secondary bg-surface-1/80 rounded-full border border-line-subtle">
                             {ex}
                         </span>
                     ))}
@@ -91,12 +91,12 @@ export function JournalDisplay({ onEdit, lastSavedEntry }: JournalDisplayProps) 
             {entries.map((entry) => (
                 <div
                     key={entry.id}
-                    className="group relative bg-white/5 hover:bg-white/10 border border-white/5 hover:border-white/20 rounded-xl p-5 transition-all duration-300"
+                    className="group relative bg-white/5 hover:bg-surface-2 border border-line-subtle hover:border-line-strong rounded-xl p-5 transition-all duration-300"
                 >
                     <div className="flex justify-between items-start mb-3">
                         <div>
                             <div className="flex items-center gap-2 mb-1">
-                                <span className="text-xs font-semibold uppercase tracking-wider text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded-full">
+                                <span className="text-xs font-semibold uppercase tracking-wider text-accent-contrast bg-emerald-400/10 px-2 py-0.5 rounded-full">
                                     {getTemplateTitle(entry.templateId)}
                                 </span>
                                 {entry.mode === 'deep' && (
@@ -111,7 +111,7 @@ export function JournalDisplay({ onEdit, lastSavedEntry }: JournalDisplayProps) 
                                     </span>
                                 )}
                             </div>
-                            <h4 className="text-lg font-medium text-white">
+                            <h4 className="text-lg font-medium text-content-primary">
                                 {format(new Date(entry.date + 'T00:00:00'), 'EEEE, MMMM do, yyyy')}
                             </h4>
                         </div>
@@ -119,14 +119,14 @@ export function JournalDisplay({ onEdit, lastSavedEntry }: JournalDisplayProps) 
                         <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                             <button
                                 onClick={() => onEdit(entry)}
-                                className="p-2 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+                                className="p-2 text-content-primary/40 hover:text-content-primary hover:bg-surface-2 rounded-lg transition-colors"
                                 title="Edit Entry"
                             >
                                 <Edit2 size={16} />
                             </button>
                             <button
                                 onClick={() => handleDelete(entry.id)}
-                                className="p-2 text-red-400/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+                                className="p-2 text-danger-contrast/40 hover:text-danger-contrast hover:bg-danger-soft rounded-lg transition-colors"
                                 title="Delete Entry"
                             >
                                 <Trash2 size={16} />
@@ -134,8 +134,8 @@ export function JournalDisplay({ onEdit, lastSavedEntry }: JournalDisplayProps) 
                         </div>
                     </div>
 
-                    <div className="text-white/70 line-clamp-3 text-sm font-light italic leading-relaxed">
-                        {entry.persona && <span className="text-white/40 not-italic mr-2">[{entry.persona}]</span>}
+                    <div className="text-content-primary/70 line-clamp-3 text-sm font-light italic leading-relaxed">
+                        {entry.persona && <span className="text-content-primary/40 not-italic mr-2">[{entry.persona}]</span>}
                         {Object.values(entry.content).join(' ').slice(0, 200)}...
                     </div>
                 </div>

--- a/src/components/Journal/JournalEditor.tsx
+++ b/src/components/Journal/JournalEditor.tsx
@@ -80,9 +80,9 @@ const CATEGORY_COLORS: Record<string, CategoryColor> = {
         border: 'hover:border-cyan-400/30',
     },
     'personal-growth': {
-        idleIcon: 'text-emerald-400/80',
+        idleIcon: 'text-accent-contrast/80',
         idleBg: 'bg-emerald-400/10',
-        activeIcon: 'text-emerald-300',
+        activeIcon: 'text-accent-contrast',
         activeBg: 'bg-emerald-400/20',
         border: 'hover:border-emerald-400/30',
     },
@@ -95,11 +95,11 @@ const CATEGORY_COLORS: Record<string, CategoryColor> = {
     },
 };
 const DEFAULT_CATEGORY_COLOR: CategoryColor = {
-    idleIcon: 'text-white/50',
+    idleIcon: 'text-content-primary/50',
     idleBg: 'bg-white/5',
-    activeIcon: 'text-white',
+    activeIcon: 'text-content-primary',
     activeBg: 'bg-white/10',
-    border: 'hover:border-white/20',
+    border: 'hover:border-line-strong',
 };
 
 /**
@@ -250,24 +250,24 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
             <div key={template.id} className="relative group">
                 <button
                     onClick={() => handleSelectTemplate(template.id)}
-                    className={`w-full text-left p-3.5 bg-white/[0.03] hover:bg-white/[0.07] border border-white/5 ${colors.border} rounded-lg transition-all duration-200`}
+                    className={`w-full text-left p-3.5 bg-white/[0.03] hover:bg-white/[0.07] border border-line-subtle ${colors.border} rounded-lg transition-all duration-200`}
                 >
                     <div className="flex items-start gap-2.5">
                         <div className={`p-1.5 ${colors.idleBg} rounded-lg ${colors.idleIcon} flex-shrink-0 mt-0.5 transition-colors`}>
                             <Icon size={14} />
                         </div>
                         <div className="min-w-0 pr-5">
-                            <h4 className="text-sm font-semibold text-white leading-tight">{template.title}</h4>
-                            <p className="text-white/40 text-xs mt-1 line-clamp-1">{template.description}</p>
+                            <h4 className="text-sm font-semibold text-content-primary leading-tight">{template.title}</h4>
+                            <p className="text-content-primary/40 text-xs mt-1 line-clamp-1">{template.description}</p>
                         </div>
                     </div>
                 </button>
                 <button
                     onClick={(e) => { e.stopPropagation(); togglePin(template.id); }}
-                    className={`absolute top-2.5 right-2.5 p-1 rounded-md hover:bg-white/10 transition-all ${pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
+                    className={`absolute top-2.5 right-2.5 p-1 rounded-md hover:bg-surface-2 transition-all ${pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
                     aria-label={pinned ? 'Unpin template' : 'Pin template'}
                 >
-                    <Star size={12} className={pinned ? 'text-amber-400 fill-amber-400' : 'text-white/30'} />
+                    <Star size={12} className={pinned ? 'text-amber-400 fill-amber-400' : 'text-content-primary/30'} />
                 </button>
             </div>
         );
@@ -284,7 +284,7 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                 {/* Pinned section */}
                 {pinnedTemplates.length > 0 && (
                     <div className="mb-1">
-                        <h3 className="text-xs font-semibold text-white/30 uppercase tracking-widest mb-3 flex items-center gap-2">
+                        <h3 className="text-xs font-semibold text-content-primary/30 uppercase tracking-widest mb-3 flex items-center gap-2">
                             <Star size={12} className="text-amber-400 fill-amber-400" />
                             Pinned
                         </h3>
@@ -307,18 +307,18 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                         <div key={category.id}>
                             <button
                                 onClick={() => toggleCategory(category.id)}
-                                className="w-full text-left flex items-center justify-between p-3.5 bg-white/[0.03] hover:bg-white/[0.06] border border-white/5 hover:border-white/10 rounded-xl transition-all"
+                                className="w-full text-left flex items-center justify-between p-3.5 bg-white/[0.03] hover:bg-white/[0.06] border border-line-subtle hover:border-line-subtle rounded-xl transition-all"
                             >
                                 <div className="flex items-center gap-3">
                                     <div className={`p-2 ${iconBgClass} ${iconTextClass} rounded-lg transition-colors`}>
                                         <Icon size={18} />
                                     </div>
                                     <div>
-                                        <h3 className="text-sm font-semibold text-white">{category.title}</h3>
-                                        <p className="text-white/40 text-xs">{category.description}</p>
+                                        <h3 className="text-sm font-semibold text-content-primary">{category.title}</h3>
+                                        <p className="text-content-primary/40 text-xs">{category.description}</p>
                                     </div>
                                 </div>
-                                <div className="flex items-center gap-2 text-white/30">
+                                <div className="flex items-center gap-2 text-content-primary/30">
                                     <span className="text-xs">{categoryTemplates.length}</span>
                                     {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                                 </div>
@@ -354,7 +354,7 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                     {selectedTemplateId === 'free-write' ? (
                         <div className="relative h-full">
                             <textarea
-                                className="w-full h-full min-h-[300px] bg-white/[0.02] border border-white/5 rounded-xl p-4 sm:p-6 text-white/90 text-lg leading-relaxed focus:bg-white/[0.04] focus:border-white/10 focus:ring-0 focus:outline-none resize-none font-sans placeholder:text-white/20"
+                                className="w-full h-full min-h-[300px] bg-white/[0.02] border border-line-subtle rounded-xl p-4 sm:p-6 text-content-primary/90 text-lg leading-relaxed focus:bg-white/[0.04] focus:border-line-subtle focus:ring-0 focus:outline-none resize-none font-sans placeholder:text-content-primary/20"
                                 placeholder="Start writing..."
                                 value={content['free-write'] || ''}
                                 onChange={(e) => handleAnswerChange('free-write', e.target.value)}
@@ -364,11 +364,11 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                         <div className="space-y-6">
                             {prompts.map((prompt) => (
                                 <div key={prompt.id} className="group">
-                                    <label className="block text-white/90 text-lg font-medium mb-3">
+                                    <label className="block text-content-primary/90 text-lg font-medium mb-3">
                                         {prompt.text}
                                     </label>
                                     <textarea
-                                        className="w-full bg-[#151515] border border-white/10 hover:border-white/20 focus:border-emerald-500/50 rounded-xl p-4 text-white/90 placeholder:text-white/10 focus:outline-none focus:bg-[#1a1a1a] transition-all resize-none min-h-[120px]"
+                                        className="w-full bg-[#151515] border border-line-subtle hover:border-line-strong focus:border-accent/50 rounded-xl p-4 text-content-primary/90 placeholder:text-content-primary/10 focus:outline-none focus:bg-[#1a1a1a] transition-all resize-none min-h-[120px]"
                                         placeholder="Type your thoughts here..."
                                         value={content[prompt.id] || ''}
                                         onChange={(e) => handleAnswerChange(prompt.id, e.target.value)}
@@ -381,14 +381,14 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                 <div className="flex justify-between items-center pt-3 pb-3 flex-shrink-0">
                     <button
                         onClick={handleDiscard}
-                        className="text-white/40 hover:text-red-400 text-sm font-medium transition-colors px-2 py-1"
+                        className="text-content-primary/40 hover:text-danger-contrast text-sm font-medium transition-colors px-2 py-1"
                     >
                         Discard Draft
                     </button>
                     <button
                         onClick={handleSave}
                         disabled={isSubmitting}
-                        className="flex items-center gap-2 px-6 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold rounded-xl shadow-lg shadow-emerald-500/20 transition-all hover:scale-105 disabled:opacity-50 disabled:scale-100"
+                        className="flex items-center gap-2 px-6 py-2.5 bg-accent hover:bg-accent-strong text-black font-semibold rounded-xl shadow-lg shadow-emerald-500/20 transition-all hover:scale-105 disabled:opacity-50 disabled:scale-100"
                     >
                         <Save size={18} />
                         {isSubmitting ? 'Saving...' : 'Save Entry'}
@@ -399,10 +399,10 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
     }
 
     return (
-        <div className="bg-zinc-900 border border-white/10 rounded-2xl p-0 shadow-2xl relative max-w-4xl mx-auto h-[calc(100vh-14rem)] flex flex-col overflow-hidden">
-            <div className="flex justify-between items-center px-6 py-4 border-b border-white/5 bg-zinc-900/95 backdrop-blur z-10">
-                <h2 className="text-lg font-bold text-white flex items-center gap-2">
-                    <span className="text-emerald-400">
+        <div className="bg-zinc-900 border border-line-subtle rounded-2xl p-0 shadow-2xl relative max-w-4xl mx-auto h-[calc(100vh-14rem)] flex flex-col overflow-hidden">
+            <div className="flex justify-between items-center px-6 py-4 border-b border-line-subtle bg-zinc-900/95 backdrop-blur z-10">
+                <h2 className="text-lg font-bold text-content-primary flex items-center gap-2">
+                    <span className="text-accent-contrast">
                         <WritingIcon size={20} />
                     </span>
                     {currentTemplate.title}
@@ -410,7 +410,7 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                 {!existingEntry && (
                     <button
                         onClick={handleBackToSelection}
-                        className="text-white/40 hover:text-white p-1.5 rounded-lg hover:bg-white/10 transition-colors"
+                        className="text-content-primary/40 hover:text-content-primary p-1.5 rounded-lg hover:bg-surface-2 transition-colors"
                         aria-label="Close template"
                     >
                         <X size={20} />
@@ -422,7 +422,7 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                 {selectedTemplateId === 'free-write' ? (
                     <div className="relative h-full min-h-[500px]">
                         <textarea
-                            className="w-full h-full min-h-[500px] bg-white/[0.02] border border-white/5 rounded-xl p-6 text-white/90 text-lg leading-relaxed focus:bg-white/[0.04] focus:border-white/10 focus:ring-0 focus:outline-none resize-none font-sans placeholder:text-white/20"
+                            className="w-full h-full min-h-[500px] bg-white/[0.02] border border-line-subtle rounded-xl p-6 text-content-primary/90 text-lg leading-relaxed focus:bg-white/[0.04] focus:border-line-subtle focus:ring-0 focus:outline-none resize-none font-sans placeholder:text-content-primary/20"
                             placeholder="Start writing..."
                             value={content['free-write'] || ''}
                             onChange={(e) => handleAnswerChange('free-write', e.target.value)}
@@ -434,11 +434,11 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                         <div className="space-y-6">
                             {prompts.map((prompt) => (
                                 <div key={prompt.id} className="group animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-backwards" style={{ animationDelay: `${prompts.indexOf(prompt) * 100}ms` }}>
-                                    <label className="block text-white/90 text-lg font-medium mb-3">
+                                    <label className="block text-content-primary/90 text-lg font-medium mb-3">
                                         {prompt.text}
                                     </label>
                                     <textarea
-                                        className="w-full bg-[#151515] border border-white/10 hover:border-white/20 focus:border-emerald-500/50 rounded-xl p-4 text-white/90 placeholder:text-white/10 focus:outline-none focus:bg-[#1a1a1a] transition-all resize-none min-h-[120px]"
+                                        className="w-full bg-[#151515] border border-line-subtle hover:border-line-strong focus:border-accent/50 rounded-xl p-4 text-content-primary/90 placeholder:text-content-primary/10 focus:outline-none focus:bg-[#1a1a1a] transition-all resize-none min-h-[120px]"
                                         placeholder="Type your thoughts here..."
                                         value={content[prompt.id] || ''}
                                         onChange={(e) => handleAnswerChange(prompt.id, e.target.value)}
@@ -452,7 +452,7 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                                     onClick={() => setMode(mode === 'standard' ? 'deep' : 'standard')}
                                     className={`group flex items-center gap-2 px-6 py-3 rounded-full text-sm font-medium transition-all ${mode === 'deep'
                                         ? 'bg-purple-900/30 text-purple-300 border border-purple-500/30 hover:bg-purple-900/50'
-                                        : 'bg-white/5 text-emerald-400/80 hover:text-emerald-300 hover:bg-emerald-500/20 border border-emerald-500/20'
+                                        : 'bg-white/5 text-accent-contrast/80 hover:text-accent-contrast hover:bg-accent-strong/20 border border-accent/20'
                                         }`}
                                 >
                                     {mode === 'standard' ? (
@@ -474,10 +474,10 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                 )}
             </div>
 
-            <div className="px-6 py-4 border-t border-white/5 bg-zinc-900 flex justify-between items-center">
+            <div className="px-6 py-4 border-t border-line-subtle bg-zinc-900 flex justify-between items-center">
                 <button
                     onClick={handleDiscard}
-                    className="text-white/40 hover:text-red-400 text-sm font-medium transition-colors px-2 py-1"
+                    className="text-content-primary/40 hover:text-danger-contrast text-sm font-medium transition-colors px-2 py-1"
                 >
                     Discard Draft
                 </button>
@@ -485,7 +485,7 @@ export function JournalEditor({ existingEntry, onSave, onCancel, initialTemplate
                     <button
                         onClick={handleSave}
                         disabled={isSubmitting}
-                        className="flex items-center gap-2 px-6 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold rounded-xl shadow-lg shadow-emerald-500/20 transition-all hover:scale-105 disabled:opacity-50 disabled:scale-100"
+                        className="flex items-center gap-2 px-6 py-2.5 bg-accent hover:bg-accent-strong text-black font-semibold rounded-xl shadow-lg shadow-emerald-500/20 transition-all hover:scale-105 disabled:opacity-50 disabled:scale-100"
                     >
                         <Save size={18} />
                         {isSubmitting ? 'Saving...' : 'Save Entry'}

--- a/src/components/Journal/JournalSummaryBanner.tsx
+++ b/src/components/Journal/JournalSummaryBanner.tsx
@@ -81,17 +81,17 @@ export function JournalSummaryBanner() {
   if (!loading && !error && !summary) return null;
 
   return (
-    <div className="bg-neutral-900/50 rounded-2xl border border-purple-500/20 p-4 sm:p-5 backdrop-blur-sm mb-4">
+    <div className="bg-surface-0/50 rounded-2xl border border-purple-500/20 p-4 sm:p-5 backdrop-blur-sm mb-4">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <Sparkles size={16} className="text-purple-400" />
-          <h3 className="text-sm font-semibold text-white">Weekly Journal Summary</h3>
+          <h3 className="text-sm font-semibold text-content-primary">Weekly Journal Summary</h3>
         </div>
         <div className="flex items-center gap-1">
           {summary && (
             <button
               onClick={() => setExpanded(!expanded)}
-              className="p-1.5 text-neutral-500 hover:text-white rounded-lg hover:bg-white/5 transition-colors"
+              className="p-1.5 text-content-muted hover:text-content-primary rounded-lg hover:bg-surface-2 transition-colors"
               aria-label={expanded ? 'Collapse' : 'Expand'}
             >
               {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
@@ -100,7 +100,7 @@ export function JournalSummaryBanner() {
           {(summary || error) && (
             <button
               onClick={handleDismiss}
-              className="p-1.5 text-neutral-500 hover:text-white rounded-lg hover:bg-white/5 transition-colors"
+              className="p-1.5 text-content-muted hover:text-content-primary rounded-lg hover:bg-surface-2 transition-colors"
               aria-label="Dismiss"
             >
               <X size={14} />
@@ -113,14 +113,14 @@ export function JournalSummaryBanner() {
       {loading && (
         <div className="flex items-center gap-3 py-2">
           <Loader2 size={16} className="text-purple-400 animate-spin" />
-          <span className="text-sm text-neutral-400">Generating your weekly summary...</span>
+          <span className="text-sm text-content-secondary">Generating your weekly summary...</span>
         </div>
       )}
 
       {/* Error */}
       {error && !loading && (
-        <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-3">
-          <p className="text-sm text-red-300">{error}</p>
+        <div className="rounded-lg bg-danger-soft border border-danger/30 p-3">
+          <p className="text-sm text-danger-contrast">{error}</p>
         </div>
       )}
 
@@ -129,17 +129,17 @@ export function JournalSummaryBanner() {
         <div className="space-y-2">
           {period && (
             <div className="flex items-center gap-3">
-              <p className="text-[11px] text-neutral-500">
+              <p className="text-[11px] text-content-muted">
                 {period.start} to {period.end}
               </p>
               {entryCount > 0 && (
-                <p className="text-[11px] text-neutral-500">
+                <p className="text-[11px] text-content-muted">
                   {entryCount} {entryCount === 1 ? 'entry' : 'entries'}
                 </p>
               )}
             </div>
           )}
-          <div className="prose prose-sm prose-invert max-w-none text-neutral-300 leading-relaxed [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-white [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-white [&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-neutral-200 [&_strong]:text-white [&_ul]:space-y-1 [&_li]:text-sm">
+          <div className="prose prose-sm prose-invert max-w-none text-content-secondary leading-relaxed [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-content-primary [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-content-primary [&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-content-primary [&_strong]:text-content-primary [&_ul]:space-y-1 [&_li]:text-sm">
             {summary.split('\n').map((line, i) => {
               if (!line.trim()) return <br key={i} />;
               const formatted = line

--- a/src/components/Journal/JournalSummaryCard.tsx
+++ b/src/components/Journal/JournalSummaryCard.tsx
@@ -41,12 +41,12 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
   if (!hasKey) {
     if (compact) return null;
     return (
-      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
+      <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-6 backdrop-blur-sm">
         <div className="flex items-center gap-2 mb-3">
           <Sparkles size={18} className="text-purple-400" />
-          <h3 className="text-lg font-semibold text-white">Journal Summary</h3>
+          <h3 className="text-lg font-semibold text-content-primary">Journal Summary</h3>
         </div>
-        <p className="text-sm text-neutral-400">
+        <p className="text-sm text-content-secondary">
           Add your Gemini API key in Settings to unlock AI-powered weekly journal summaries with themes, highlights, and actionable feedback.
         </p>
       </div>
@@ -54,11 +54,11 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
   }
 
   return (
-    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
+    <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-6 backdrop-blur-sm">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <Sparkles size={18} className="text-purple-400" />
-          <h3 className={`font-semibold text-white ${compact ? 'text-base' : 'text-lg'}`}>
+          <h3 className={`font-semibold text-content-primary ${compact ? 'text-base' : 'text-lg'}`}>
             {compact ? 'Journal Summary' : 'Weekly Journal Summary'}
           </h3>
         </div>
@@ -66,7 +66,7 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
           {summary && (
             <button
               onClick={() => setExpanded(!expanded)}
-              className="p-1.5 text-neutral-500 hover:text-white rounded-lg hover:bg-white/5 transition-colors"
+              className="p-1.5 text-content-muted hover:text-content-primary rounded-lg hover:bg-surface-2 transition-colors"
               aria-label={expanded ? 'Collapse' : 'Expand'}
             >
               {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
@@ -75,7 +75,7 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
           {summary && (
             <button
               onClick={handleDismiss}
-              className="p-1.5 text-neutral-500 hover:text-white rounded-lg hover:bg-white/5 transition-colors"
+              className="p-1.5 text-content-muted hover:text-content-primary rounded-lg hover:bg-surface-2 transition-colors"
               aria-label="Dismiss"
             >
               <X size={16} />
@@ -87,14 +87,14 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
       {/* Idle state */}
       {!summary && !loading && !error && (
         <div>
-          <p className="text-sm text-neutral-400 mb-4">
+          <p className="text-sm text-content-secondary mb-4">
             {compact
               ? 'Get AI-powered insights from your recent journal entries.'
               : 'Generate a personalized summary of your past week\'s journal entries — themes, highlights, feedback, and follow-up reminders.'}
           </p>
           <button
             onClick={handleGenerate}
-            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-purple-600/80 text-white hover:bg-purple-600 text-sm font-medium transition-colors"
+            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-purple-600/80 text-content-primary hover:bg-purple-600 text-sm font-medium transition-colors"
           >
             <Sparkles size={14} />
             Generate Journal Summary
@@ -106,15 +106,15 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
       {loading && (
         <div className="flex items-center gap-3 py-4">
           <Loader2 size={18} className="text-purple-400 animate-spin" />
-          <span className="text-sm text-neutral-400">Analyzing your journal entries...</span>
+          <span className="text-sm text-content-secondary">Analyzing your journal entries...</span>
         </div>
       )}
 
       {/* Error */}
       {error && (
         <div className="space-y-3">
-          <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-3">
-            <p className="text-sm text-red-300">{error}</p>
+          <div className="rounded-lg bg-danger-soft border border-danger/30 p-3">
+            <p className="text-sm text-danger-contrast">{error}</p>
           </div>
           <button
             onClick={handleGenerate}
@@ -130,17 +130,17 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
         <div className="space-y-3">
           {period && (
             <div className="flex items-center gap-3">
-              <p className="text-[11px] text-neutral-500">
+              <p className="text-[11px] text-content-muted">
                 {period.start} to {period.end}
               </p>
               {entryCount > 0 && (
-                <p className="text-[11px] text-neutral-500">
+                <p className="text-[11px] text-content-muted">
                   {entryCount} {entryCount === 1 ? 'entry' : 'entries'}
                 </p>
               )}
             </div>
           )}
-          <div className="prose prose-sm prose-invert max-w-none text-neutral-300 leading-relaxed [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-white [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-white [&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-neutral-200 [&_strong]:text-white [&_ul]:space-y-1 [&_li]:text-sm">
+          <div className="prose prose-sm prose-invert max-w-none text-content-secondary leading-relaxed [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-content-primary [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-content-primary [&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-content-primary [&_strong]:text-content-primary [&_ul]:space-y-1 [&_li]:text-sm">
             {summary.split('\n').map((line, i) => {
               if (!line.trim()) return <br key={i} />;
               const formatted = line
@@ -154,7 +154,7 @@ export function JournalSummaryCard({ compact }: JournalSummaryCardProps) {
               );
             })}
           </div>
-          <div className="pt-2 border-t border-white/5">
+          <div className="pt-2 border-t border-line-subtle">
             <button
               onClick={handleGenerate}
               className="text-xs text-purple-400 hover:text-purple-300 transition-colors"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
-import { LayoutGrid, Settings, User, LogOut, Info, Eye, EyeOff, FlaskConical } from 'lucide-react';
+import { LayoutGrid, Settings, User, LogOut, Info, Eye, EyeOff, FlaskConical, Sun, Moon, Monitor } from 'lucide-react';
 import { useHabitStore } from '../store/HabitContext';
 import { useAuth } from '../store/AuthContext';
 import { useDashboardPrefs } from '../store/DashboardPrefsContext';
+import { useTheme } from '../theme/ThemeContext';
+import type { ThemeMode } from '../theme/palette';
 import { getActiveUserMode, seedDemoEmotionalWellbeing, resetDemoEmotionalWellbeing } from '../lib/persistenceClient';
 import { SettingsModal } from './SettingsModal';
 import { InfoModal } from './InfoModal';
@@ -11,10 +13,17 @@ interface LayoutProps {
     children: React.ReactNode;
 }
 
+const THEME_OPTIONS: ReadonlyArray<{ mode: ThemeMode; label: string; Icon: typeof Sun }> = [
+    { mode: 'light', label: 'Light', Icon: Sun },
+    { mode: 'dark', label: 'Dark', Icon: Moon },
+    { mode: 'system', label: 'System', Icon: Monitor },
+];
+
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
     const { refreshHabitsAndCategories } = useHabitStore();
     const { user, logout } = useAuth();
-    const { hideStreaks, setHideStreaks } = useDashboardPrefs();
+    const { hideStreaks, setHideStreaks, setThemeMode } = useDashboardPrefs();
+    const { mode } = useTheme();
     const isBetaUser = user?.email?.toLowerCase() === 'tj.galloway1@gmail.com';
     const isDev = import.meta.env.DEV;
     const isDemo = getActiveUserMode() === 'demo';
@@ -27,7 +36,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     const demoBadge = useMemo(() => {
         if (!isDemo) return null;
         return (
-            <span className="ml-3 inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold tracking-wide bg-rose-500/15 text-rose-300 border border-rose-500/30">
+            <span className="ml-3 inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold tracking-wide bg-danger-soft text-danger-contrast border border-danger/30">
                 DEMO DATA
             </span>
         );
@@ -81,14 +90,14 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     }, [userMenuOpen]);
 
     return (
-        <div className="min-h-screen bg-neutral-900 text-white font-sans selection:bg-emerald-500/30">
+        <div className="min-h-screen bg-surface-0 text-content-primary font-sans selection:bg-accent/30">
             {/* Header */}
-            <header className="fixed top-0 left-0 right-0 pt-[env(safe-area-inset-top,0px)] h-[calc(4rem+env(safe-area-inset-top,0px))] bg-neutral-900/80 backdrop-blur-md border-b border-white/5 flex items-center justify-between px-6 z-50">
+            <header className="fixed top-0 left-0 right-0 pt-[env(safe-area-inset-top,0px)] h-[calc(4rem+env(safe-area-inset-top,0px))] bg-surface-0/80 backdrop-blur-md border-b border-line-subtle flex items-center justify-between px-6 z-50">
                 <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 bg-gradient-to-br from-emerald-400 to-cyan-500 rounded-lg flex items-center justify-center shadow-lg shadow-emerald-500/20">
-                        <LayoutGrid size={18} className="text-white" />
+                    <div className="w-8 h-8 bg-gradient-to-br from-accent to-accent-contrast rounded-lg flex items-center justify-center shadow-lg shadow-accent/20">
+                        <LayoutGrid size={18} className="text-content-on-accent" />
                     </div>
-                    <h1 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white to-neutral-400">
+                    <h1 className="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-content-primary to-content-muted">
                         HabitFlow
                     </h1>
                     {demoBadge}
@@ -96,7 +105,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
 
                 <div className="flex items-center gap-4">
                     {isDev && devNotice && (
-                        <div className="text-xs px-3 py-1.5 rounded-full bg-emerald-500/15 text-emerald-200 border border-emerald-500/20">
+                        <div className="text-xs px-3 py-1.5 rounded-full bg-accent-soft text-accent-contrast border border-accent/20">
                             {devNotice}
                         </div>
                     )}
@@ -104,14 +113,14 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                                 <div className="flex items-center gap-2">
                                     <button
                                         onClick={handleSeedDemo}
-                                        className="px-3 py-1.5 text-xs font-semibold rounded-full bg-emerald-500/15 text-emerald-200 border border-emerald-500/30 hover:bg-emerald-500/25 transition-colors"
+                                        className="px-3 py-1.5 text-xs font-semibold rounded-full bg-accent-soft text-accent-contrast border border-accent/30 hover:bg-surface-2 transition-colors"
                                         title="Seed demo wellbeing + gratitude journal data (server-guarded)"
                                     >
                                         Seed Demo Data
                                     </button>
                                     <button
                                         onClick={handleResetDemo}
-                                        className="px-3 py-1.5 text-xs font-semibold rounded-full bg-rose-500/15 text-rose-200 border border-rose-500/30 hover:bg-rose-500/25 transition-colors"
+                                        className="px-3 py-1.5 text-xs font-semibold rounded-full bg-danger-soft text-danger-contrast border border-danger/30 hover:bg-surface-2 transition-colors"
                                         title="Reset demo wellbeing + gratitude journal data (server-guarded)"
                                     >
                                         Reset Demo Data
@@ -120,14 +129,14 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                     )}
                     <button
                         onClick={() => setInfoOpen(true)}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-white/5 rounded-full transition-colors text-neutral-400 hover:text-white"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-surface-2 rounded-full transition-colors text-content-secondary hover:text-content-primary"
                         title="How HabitFlow Works"
                     >
                         <Info size={20} />
                     </button>
                     <button
                         onClick={() => setSettingsOpen(true)}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-white/5 rounded-full transition-colors text-neutral-400 hover:text-white"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-surface-2 rounded-full transition-colors text-content-secondary hover:text-content-primary"
                         title="Settings"
                     >
                         <Settings size={20} />
@@ -135,28 +144,58 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                     <div ref={userMenuRef} className="relative">
                         <button
                             onClick={() => setUserMenuOpen(!userMenuOpen)}
-                            className="min-h-[44px] min-w-[44px] bg-neutral-800 rounded-full flex items-center justify-center border border-white/10 text-neutral-400 hover:bg-neutral-700 hover:text-white transition-colors"
+                            className="min-h-[44px] min-w-[44px] bg-surface-1 rounded-full flex items-center justify-center border border-line-subtle text-content-secondary hover:bg-surface-2 hover:text-content-primary transition-colors"
                             aria-label="User menu"
                         >
                             <User size={16} />
                         </button>
 
                         {userMenuOpen && (
-                            <div className="absolute right-0 top-full mt-2 w-56 bg-neutral-900 border border-white/10 rounded-xl shadow-lg overflow-hidden z-50 animate-in fade-in slide-in-from-top-2">
+                            <div className="absolute right-0 top-full mt-2 w-60 bg-surface-1 border border-line-subtle rounded-xl shadow-lg overflow-hidden z-50 animate-in fade-in slide-in-from-top-2">
                                 <div className="py-1">
                                     {user?.displayName && (
-                                        <div className="px-4 py-2 text-sm text-neutral-300 border-b border-white/5">
+                                        <div className="px-4 py-2 text-sm text-content-secondary border-b border-line-subtle">
                                             {user.displayName}
                                         </div>
                                     )}
                                     {user?.email && (
-                                        <div className="px-4 py-1.5 text-xs text-neutral-500">
+                                        <div className="px-4 py-1.5 text-xs text-content-muted">
                                             {user.email}
                                         </div>
                                     )}
+                                    {/* Appearance quick toggle — sits inside the user menu. */}
+                                    <div className="px-4 py-2 border-b border-line-subtle">
+                                        <div className="text-[11px] uppercase tracking-wide text-content-muted mb-1.5">Appearance</div>
+                                        <div
+                                            role="radiogroup"
+                                            aria-label="Theme"
+                                            className="flex items-center gap-1 p-0.5 rounded-lg bg-surface-2 border border-line-subtle"
+                                        >
+                                            {THEME_OPTIONS.map(({ mode: optionMode, label, Icon }) => {
+                                                const isActive = mode === optionMode;
+                                                return (
+                                                    <button
+                                                        key={optionMode}
+                                                        type="button"
+                                                        role="radio"
+                                                        aria-checked={isActive}
+                                                        onClick={() => setThemeMode(optionMode)}
+                                                        className={`flex-1 inline-flex items-center justify-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium transition-colors ${
+                                                            isActive
+                                                                ? 'bg-surface-1 text-accent-contrast shadow-sm'
+                                                                : 'text-content-secondary hover:text-content-primary'
+                                                        }`}
+                                                    >
+                                                        <Icon size={13} />
+                                                        {label}
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
                                     <button
                                         onClick={() => setHideStreaks(!hideStreaks)}
-                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-400 hover:text-white hover:bg-white/5 transition-colors"
+                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-content-secondary hover:text-content-primary hover:bg-surface-2 transition-colors"
                                     >
                                         {hideStreaks ? <Eye size={14} /> : <EyeOff size={14} />}
                                         {hideStreaks ? 'Show streaks' : 'Hide streaks'}
@@ -171,7 +210,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                                                 window.dispatchEvent(new PopStateEvent('popstate'));
                                                 setUserMenuOpen(false);
                                             }}
-                                            className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-400 hover:text-white hover:bg-white/5 transition-colors"
+                                            className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-content-secondary hover:text-content-primary hover:bg-surface-2 transition-colors"
                                         >
                                             <FlaskConical size={14} />
                                             Analysis (Beta)
@@ -182,7 +221,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                                             setUserMenuOpen(false);
                                             await logout();
                                         }}
-                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-400 hover:text-white hover:bg-white/5 transition-colors"
+                                        className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-content-secondary hover:text-content-primary hover:bg-surface-2 transition-colors"
                                     >
                                         <LogOut size={14} />
                                         Sign out

--- a/src/components/MomentumHeader.tsx
+++ b/src/components/MomentumHeader.tsx
@@ -69,7 +69,7 @@ export const MomentumHeader: React.FC<MomentumHeaderProps> = ({ globalMomentum }
                 </p>
 
                 {activeDays > 0 && (
-                    <div className="mt-4 flex items-center gap-2 px-3 py-1 bg-white/5 rounded-full border border-line-subtle text-xs text-content-secondary">
+                    <div className="mt-4 flex items-center gap-2 px-3 py-1 bg-surface-1 rounded-full border border-line-subtle text-xs text-content-secondary">
                         <span>{activeDays} Active Days (Last 7)</span>
                         {trend === 'up' && <TrendingUp size={12} className="text-emerald-500" />}
                         {trend === 'down' && <TrendingDown size={12} className="text-rose-500" />}

--- a/src/components/MomentumHeader.tsx
+++ b/src/components/MomentumHeader.tsx
@@ -17,13 +17,13 @@ export const MomentumHeader: React.FC<MomentumHeaderProps> = ({ globalMomentum }
     const { hideStreaks } = useDashboardPrefs();
 
     const strongIcon = hideStreaks
-        ? <Sparkles className="text-emerald-400 animate-pulse" size={24} />
-        : <Flame className="text-emerald-400 animate-pulse" size={24} />;
+        ? <Sparkles className="text-accent-contrast animate-pulse" size={24} />
+        : <Flame className="text-accent-contrast animate-pulse" size={24} />;
 
     // Visual configurations for each state
     const stateConfig: Record<string, { color: string; icon: React.ReactNode; bgGradient: string }> = {
         'Strong': {
-            color: 'text-emerald-400',
+            color: 'text-accent-contrast',
             icon: strongIcon,
             bgGradient: 'from-emerald-500/20 to-transparent'
         },
@@ -43,8 +43,8 @@ export const MomentumHeader: React.FC<MomentumHeaderProps> = ({ globalMomentum }
             bgGradient: 'from-violet-500/20 to-transparent'
         },
         'Ready': {
-            color: 'text-neutral-400',
-            icon: <Sparkles className="text-neutral-400" size={24} />,
+            color: 'text-content-secondary',
+            icon: <Sparkles className="text-content-secondary" size={24} />,
             bgGradient: 'from-white/10 to-transparent'
         }
     };
@@ -52,7 +52,7 @@ export const MomentumHeader: React.FC<MomentumHeaderProps> = ({ globalMomentum }
     const config = stateConfig[state] || stateConfig['Ready'];
 
     return (
-        <div className={`relative overflow-hidden rounded-2xl border border-white/5 bg-neutral-900/50 p-6 backdrop-blur-sm mb-6 group`}>
+        <div className={`relative overflow-hidden rounded-2xl border border-line-subtle bg-surface-0/50 p-6 backdrop-blur-sm mb-6 group`}>
             {/* Ambient Gradient Background */}
             <div className={`absolute top-0 left-0 right-0 h-32 bg-gradient-to-b ${config.bgGradient} opacity-30 pointer-events-none transition-opacity duration-1000`} />
 
@@ -64,16 +64,16 @@ export const MomentumHeader: React.FC<MomentumHeaderProps> = ({ globalMomentum }
                     </h2>
                 </div>
 
-                <p className="text-neutral-300 text-base max-w-lg leading-relaxed font-medium">
+                <p className="text-content-secondary text-base max-w-lg leading-relaxed font-medium">
                     {copy}
                 </p>
 
                 {activeDays > 0 && (
-                    <div className="mt-4 flex items-center gap-2 px-3 py-1 bg-white/5 rounded-full border border-white/5 text-xs text-neutral-400">
+                    <div className="mt-4 flex items-center gap-2 px-3 py-1 bg-white/5 rounded-full border border-line-subtle text-xs text-content-secondary">
                         <span>{activeDays} Active Days (Last 7)</span>
                         {trend === 'up' && <TrendingUp size={12} className="text-emerald-500" />}
                         {trend === 'down' && <TrendingDown size={12} className="text-rose-500" />}
-                        {trend === 'neutral' && <Minus size={12} className="text-neutral-500" />}
+                        {trend === 'neutral' && <Minus size={12} className="text-content-muted" />}
                     </div>
                 )}
             </div>

--- a/src/components/NumberChipSelector.tsx
+++ b/src/components/NumberChipSelector.tsx
@@ -32,8 +32,8 @@ export const NumberChipSelector: React.FC<NumberChipSelectorProps> = ({
                     className={`
                         w-9 h-9 rounded-lg text-xs font-bold transition-all
                         ${value === n
-                            ? 'bg-emerald-500 text-neutral-900 shadow-[0_0_10px_rgba(16,185,129,0.3)]'
-                            : 'bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-white'}
+                            ? 'bg-accent text-content-on-accent shadow-[0_0_10px_rgba(16,185,129,0.3)]'
+                            : 'bg-surface-1 text-content-secondary hover:bg-surface-2 hover:text-content-primary'}
                         ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
                     `}
                 >

--- a/src/components/NumericInputPopover.tsx
+++ b/src/components/NumericInputPopover.tsx
@@ -72,7 +72,7 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
             <div className="fixed inset-0" onClick={onClose} />
             <form
                 onSubmit={handleSubmit}
-                className="relative bg-neutral-800 border border-white/10 rounded-xl p-3 shadow-xl flex items-center gap-2 w-48 animate-in fade-in zoom-in-95 duration-200"
+                className="relative bg-surface-1 border border-line-subtle rounded-xl p-3 shadow-xl flex items-center gap-2 w-48 animate-in fade-in zoom-in-95 duration-200"
             >
                 <input
                     ref={inputRef}
@@ -81,13 +81,13 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
                     pattern="[0-9]*\.?[0-9]*"
                     value={value}
                     onChange={(e) => setValue(e.target.value)}
-                    className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-1.5 text-white text-sm focus:outline-none focus:border-emerald-500"
+                    className="w-full bg-surface-0 border border-line-subtle rounded-lg px-3 py-1.5 text-content-primary text-sm focus:outline-none focus:border-focus"
                     placeholder="0"
                 />
-                {unit && <span className="text-xs text-neutral-500 font-medium">{unit}</span>}
+                {unit && <span className="text-xs text-content-muted font-medium">{unit}</span>}
                 <button
                     type="submit"
-                    className="p-1.5 bg-emerald-500 text-neutral-900 rounded-lg hover:bg-emerald-400 transition-colors"
+                    className="p-1.5 bg-accent text-content-on-accent rounded-lg hover:bg-accent-strong transition-colors"
                 >
                     <Check size={14} strokeWidth={3} />
                 </button>

--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -218,21 +218,21 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
             <JournalSummaryCard compact />
 
             {/* Goals at a glance */}
-            <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
+            <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-6 backdrop-blur-sm">
                 <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-semibold text-white">Goals at a glance</h3>
+                    <h3 className="text-lg font-semibold text-content-primary">Goals at a glance</h3>
                     <div className="flex items-center gap-2">
                         {progressData && progressData.goalsWithProgress.length > 0 && (
                             <button
                                 onClick={() => setShowGoalManage(s => !s)}
-                                className={`text-[11px] transition-colors ${showGoalManage ? 'text-white' : 'text-emerald-400 hover:text-emerald-300'}`}
+                                className={`text-[11px] transition-colors ${showGoalManage ? 'text-content-primary' : 'text-accent-contrast hover:text-accent-contrast'}`}
                             >
                                 {showGoalManage ? 'Done' : 'Manage'}
                             </button>
                         )}
                         <button
                             onClick={() => onViewGoal && onViewGoal('all')}
-                            className="text-xs text-neutral-500 hover:text-white transition-colors"
+                            className="text-xs text-content-muted hover:text-content-primary transition-colors"
                         >
                             View all
                         </button>
@@ -245,11 +245,11 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
                     </div>
                 ) : !progressData || progressData.goalsWithProgress.length === 0 ? (
                     <div className="text-center py-6">
-                        <h4 className="text-neutral-400 text-sm mb-2">No active goals</h4>
+                        <h4 className="text-content-secondary text-sm mb-2">No active goals</h4>
                         {onCreateGoal && (
                             <button
                                 onClick={onCreateGoal}
-                                className="text-emerald-500 hover:text-emerald-400 text-xs font-medium transition-colors"
+                                className="text-emerald-500 hover:text-accent-contrast text-xs font-medium transition-colors"
                             >
                                 + Add a goal
                             </button>
@@ -263,19 +263,19 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
                                 <button
                                     key={goal.id}
                                     onClick={() => toggleGoalPin(goal.id)}
-                                    className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg hover:bg-neutral-800/50 transition-colors text-left min-h-[44px]"
+                                    className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg hover:bg-surface-1/50 transition-colors text-left min-h-[44px]"
                                 >
                                     <Pin
                                         size={14}
-                                        className={isGoalPinned(goal.id) ? 'text-emerald-400' : 'text-neutral-600'}
+                                        className={isGoalPinned(goal.id) ? 'text-accent-contrast' : 'text-content-muted'}
                                         fill={isGoalPinned(goal.id) ? 'currentColor' : 'none'}
                                     />
-                                    <span className={`text-sm ${isGoalPinned(goal.id) ? 'text-white' : 'text-neutral-400'}`}>
+                                    <span className={`text-sm ${isGoalPinned(goal.id) ? 'text-content-primary' : 'text-content-secondary'}`}>
                                         {goal.title}
                                     </span>
                                 </button>
                             ))}
-                        <p className="text-[10px] text-neutral-600 px-3 pt-2">
+                        <p className="text-[10px] text-content-muted px-3 pt-2">
                             {pinnedGoalIds.length === 0
                                 ? 'Pin goals to choose which ones appear here. Showing first 4 by default.'
                                 : `${pinnedGoalIds.length} goal${pinnedGoalIds.length !== 1 ? 's' : ''} pinned`}

--- a/src/components/ProgressRings.tsx
+++ b/src/components/ProgressRings.tsx
@@ -4,33 +4,41 @@ import { useHabitStore } from '../store/HabitContext';
 import { format, subDays } from 'date-fns';
 import { Brain, Activity, Battery, Moon } from 'lucide-react';
 import { getDailyHabitRingProgress } from '../utils/habitUtils';
+import { useThemeColors } from '../theme/useThemeColors';
+import type { ThemeColors } from '../theme/palette';
 
-// Custom Tooltip for dual-line charts
-const DualTooltip = ({ active, payload, label }: any) => {
-    if (active && payload && payload.length) {
-        // Dedup payload in case we have multiple lines (solid + dashed) for same data
-        const uniquePayload = payload.filter((entry: any, index: number, self: any[]) =>
-            index === self.findIndex((e: any) => e.name === entry.name)
-        );
+// Custom Tooltip for dual-line charts — theme-aware via a factory that
+// closes over the current palette.
+const makeDualTooltip = (c: ThemeColors) => {
+    const DualTooltip = ({ active, payload, label }: any) => {
+        if (active && payload && payload.length) {
+            const uniquePayload = payload.filter((entry: any, index: number, self: any[]) =>
+                index === self.findIndex((e: any) => e.name === entry.name)
+            );
 
-        return (
-            <div className="bg-neutral-800 border border-neutral-700 p-2 rounded shadow-lg text-xs z-50">
-                <p className="text-white font-medium mb-1">{label}</p>
-                {uniquePayload.map((entry: any, index: number) => (
-                    <div key={index} className="flex items-center gap-2">
-                        <div
-                            className="w-2 h-2 rounded-full"
-                            style={{ backgroundColor: entry.color }}
-                        />
-                        <span style={{ color: entry.color }}>
-                            {entry.name}: {entry.value}
-                        </span>
-                    </div>
-                ))}
-            </div>
-        );
-    }
-    return null;
+            return (
+                <div
+                    className="p-2 rounded shadow-lg text-xs z-50 border"
+                    style={{ background: c.chartTooltipBg, borderColor: c.lineSubtle }}
+                >
+                    <p className="font-medium mb-1" style={{ color: c.contentPrimary }}>{label}</p>
+                    {uniquePayload.map((entry: any, index: number) => (
+                        <div key={index} className="flex items-center gap-2">
+                            <div
+                                className="w-2 h-2 rounded-full"
+                                style={{ backgroundColor: entry.color }}
+                            />
+                            <span style={{ color: entry.color }}>
+                                {entry.name}: {entry.value}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            );
+        }
+        return null;
+    };
+    return DualTooltip;
 };
 
 // Custom Diamond Dot for Evening
@@ -49,6 +57,8 @@ const DiamondDot = (props: any) => {
 
 export const ProgressRings: React.FC = React.memo(() => {
     const { habits, logs, wellbeingLogs } = useHabitStore();
+    const themeColors = useThemeColors();
+    const DualTooltip = useMemo(() => makeDualTooltip(themeColors), [themeColors]);
     const today = format(new Date(), 'yyyy-MM-dd');
 
     // Calculate Habit Completion (exclude bundle sub-habits, derive bundle completion from children)
@@ -161,11 +171,11 @@ export const ProgressRings: React.FC = React.memo(() => {
                                 stroke="none"
                             >
                                 <Cell key="val" fill={color} />
-                                <Cell key="empty" fill="#262626" />
+                                <Cell key="empty" fill={themeColors.surface2} />
                             </Pie>
                         </PieChart>
                     </ResponsiveContainer>
-                    <div className="absolute inset-0 flex items-center justify-center text-white font-bold text-lg">
+                    <div className="absolute inset-0 flex items-center justify-center text-content-primary font-bold text-lg">
                         {value > 0 ? value : '-'}
                     </div>
                 </div>
@@ -174,31 +184,31 @@ export const ProgressRings: React.FC = React.memo(() => {
         );
 
         return (
-            <div className="flex items-center justify-between p-6 bg-neutral-900/50 rounded-2xl border border-white/5 h-full">
+            <div className="flex items-center justify-between p-6 bg-surface-1/60 rounded-2xl border border-line-subtle h-full">
                 <div className="flex items-center">
                     {/* Icon and Label Section */}
                     <div className="mr-6 min-w-[100px]">
-                        <div className="flex items-center gap-2 text-neutral-400 mb-1 font-medium">
+                        <div className="flex items-center gap-2 text-content-secondary mb-1 font-medium">
                             <Icon size={18} style={{ color: iconColor }} />
                             {label}
                         </div>
-                        <div className="text-xs text-neutral-500">Last 7 Days (M vs E)</div>
+                        <div className="text-xs text-content-muted">Last 7 Days (M vs E)</div>
                     </div>
 
                     {/* Dual Rings */}
-                    <div className="flex items-center gap-4 border-l border-white/5 pl-6">
+                    <div className="flex items-center gap-4 border-l border-line-subtle pl-6">
                         {renderRing(morningRingData, morningColor, morningValue, 'Morning')}
                         {renderRing(eveningRingData, eveningColor, eveningValue, 'Evening')}
                     </div>
                 </div>
 
                 {/* Dual Line Chart */}
-                <div className="flex-1 h-24 ml-8 border-l border-white/5 pl-8">
+                <div className="flex-1 h-24 ml-8 border-l border-line-subtle pl-8">
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={weeklyData}>
                             <XAxis
                                 dataKey="day"
-                                stroke="#525252"
+                                stroke={themeColors.chartAxis}
                                 fontSize={10}
                                 tickLine={false}
                                 axisLine={false}
@@ -208,7 +218,7 @@ export const ProgressRings: React.FC = React.memo(() => {
                                 domain={[0, 5]}
                                 hide
                             />
-                            <Tooltip content={<DualTooltip />} cursor={{ stroke: 'rgba(255,255,255,0.1)', strokeWidth: 1 }} />
+                            <Tooltip content={<DualTooltip />} cursor={{ stroke: themeColors.chartGrid, strokeWidth: 1 }} />
 
                             {/* Morning - Dashed Layer (connects gaps) */}
                             <Line
@@ -273,8 +283,8 @@ export const ProgressRings: React.FC = React.memo(() => {
     return (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Left Column: Daily Overview & Main Ring */}
-            <div className="flex flex-col items-center justify-between p-6 bg-neutral-900/50 rounded-2xl border border-white/5 h-full">
-                <h3 className="text-xl font-bold text-white mb-4">Daily Overview</h3>
+            <div className="flex flex-col items-center justify-between p-6 bg-surface-1/60 rounded-2xl border border-line-subtle h-full">
+                <h3 className="text-xl font-bold text-content-primary mb-4">Daily Overview</h3>
 
                 <div className="relative w-48 h-48 mb-6">
                     <ResponsiveContainer width="100%" height="100%">
@@ -290,31 +300,31 @@ export const ProgressRings: React.FC = React.memo(() => {
                                 dataKey="value"
                                 stroke="none"
                             >
-                                <Cell key="completed" fill="#10b981" />
-                                <Cell key="remaining" fill="#262626" />
+                                <Cell key="completed" fill={themeColors.accent} />
+                                <Cell key="remaining" fill={themeColors.surface2} />
                             </Pie>
                         </PieChart>
                     </ResponsiveContainer>
                     <div className="absolute inset-0 flex flex-col items-center justify-center">
-                        <span className="text-4xl font-bold text-white">{completionRate}%</span>
-                        <span className="text-sm text-neutral-500 uppercase tracking-wider">Done</span>
+                        <span className="text-4xl font-bold text-content-primary">{completionRate}%</span>
+                        <span className="text-sm text-content-muted uppercase tracking-wider">Done</span>
                     </div>
                 </div>
 
                 {/* Sleep & Energy Stacked Below Ring */}
                 <div className="flex flex-col gap-3 w-full">
-                    <div className="flex items-center gap-3 px-4 py-3 bg-neutral-800/50 rounded-xl border border-white/5 w-full">
+                    <div className="flex items-center gap-3 px-4 py-3 bg-surface-1/50 rounded-xl border border-line-subtle w-full">
                         <Moon size={20} className="text-indigo-400" />
                         <div className="flex items-center justify-between w-full">
-                            <span className="text-sm text-neutral-400">Sleep Score</span>
-                            <span className="text-lg font-bold text-white">{currentWellbeing.sleepScore}</span>
+                            <span className="text-sm text-content-secondary">Sleep Score</span>
+                            <span className="text-lg font-bold text-content-primary">{currentWellbeing.sleepScore}</span>
                         </div>
                     </div>
-                    <div className="flex items-center gap-3 px-4 py-3 bg-neutral-800/50 rounded-xl border border-white/5 w-full">
-                        <Battery size={20} className="text-emerald-400" />
+                    <div className="flex items-center gap-3 px-4 py-3 bg-surface-1/50 rounded-xl border border-line-subtle w-full">
+                        <Battery size={20} className="text-accent-contrast" />
                         <div className="flex items-center justify-between w-full">
-                            <span className="text-sm text-neutral-400">Energy</span>
-                            <span className="text-lg font-bold text-white">{currentWellbeing.energy}</span>
+                            <span className="text-sm text-content-secondary">Energy</span>
+                            <span className="text-lg font-bold text-content-primary">{currentWellbeing.energy}</span>
                         </div>
                     </div>
                 </div>
@@ -329,8 +339,8 @@ export const ProgressRings: React.FC = React.memo(() => {
                         eveningValue={currentWellbeing.depression.evening}
                         max={5}
                         metricKey="depression"
-                        morningColor="#3b82f6" // Blue
-                        eveningColor="#8b5cf6" // Violet
+                        morningColor="#3b82f6" // Blue — semantic: morning
+                        eveningColor="#8b5cf6" // Violet — semantic: evening
                         iconColor="#3b82f6"
                         icon={Brain}
                     />

--- a/src/components/RecentHeatmapGrid.tsx
+++ b/src/components/RecentHeatmapGrid.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useRef } from 'react';
 import { useHabitStore } from '../store/HabitContext';
-import { getHeatmapColor } from '../utils/analytics';
+import { getHeatmapColor } from '../theme/heatmap';
+import { useTheme } from '../theme/ThemeContext';
+import { useThemeColors } from '../theme/useThemeColors';
 import { getBundleChildIds, isHabitComplete } from '../utils/habitUtils';
 import { eachDayOfInterval, subDays, format, startOfDay } from 'date-fns';
 import { Tooltip } from 'react-tooltip';
@@ -13,6 +15,8 @@ interface RecentHeatmapGridProps {
 
 export const RecentHeatmapGrid: React.FC<RecentHeatmapGridProps> = React.memo(({ habits, range }) => {
     const { logs } = useHabitStore();
+    const { resolvedMode } = useTheme();
+    const themeColors = useThemeColors();
     const containerRef = useRef<HTMLDivElement>(null);
     // const [containerWidth, setContainerWidth] = useState(0);
 
@@ -120,14 +124,19 @@ export const RecentHeatmapGrid: React.FC<RecentHeatmapGridProps> = React.memo(({
                         key={day.date.toISOString()}
                         data-tooltip-id="recent-heatmap-tooltip"
                         data-tooltip-content={`${format(day.date, 'MMM d, yyyy')}: ${day.count} completions across ${day.categoryCount} categories`}
-                        className={`${cellSizeClasses} ${getHeatmapColor(day.intensity)} transition-all hover:scale-105 hover:ring-2 hover:ring-white/20`}
+                        className={`${cellSizeClasses} transition-all hover:scale-105 hover:ring-2 hover:ring-focus/40`}
+                        style={{ background: getHeatmapColor(day.intensity, resolvedMode) }}
                     />
                 ))}
             </div>
 
             <HeatmapLegend />
 
-            <Tooltip id="recent-heatmap-tooltip" className="z-50 !bg-neutral-800 !text-white !opacity-100 !rounded-lg !px-3 !py-1 !text-xs" />
+            <Tooltip
+                id="recent-heatmap-tooltip"
+                className="z-50 !opacity-100 !rounded-lg !px-3 !py-1 !text-xs"
+                style={{ background: themeColors.chartTooltipBg, color: themeColors.contentPrimary, border: `1px solid ${themeColors.lineSubtle}` }}
+            />
         </div>
     );
 });

--- a/src/components/RoutineEditorModal.tsx
+++ b/src/components/RoutineEditorModal.tsx
@@ -331,15 +331,15 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-            <div className="w-full max-w-4xl max-h-[90dvh] h-[85vh] bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl flex flex-col overflow-hidden">
+            <div className="w-full max-w-4xl max-h-[90dvh] h-[85vh] bg-surface-0 border border-line-subtle rounded-2xl shadow-2xl flex flex-col overflow-hidden">
 
                 {/* Header — hidden when editing a step to maximize space */}
                 {!isEditingStep && (
-                <div className="flex items-center justify-between p-6 border-b border-white/10 bg-neutral-900 z-10">
-                    <h2 className="text-xl font-bold text-white">
+                <div className="flex items-center justify-between p-6 border-b border-line-subtle bg-surface-0 z-10">
+                    <h2 className="text-xl font-bold text-content-primary">
                         {mode === 'create' ? 'Create Routine' : 'Edit Routine'}
                     </h2>
-                    <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white -mr-2" aria-label="Close">
+                    <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary -mr-2" aria-label="Close">
                         <X size={24} />
                     </button>
                 </div>
@@ -352,22 +352,22 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                         {/* Title & Category — hidden when editing a step */}
                         {!isEditingStep && <div className="space-y-4">
                             <div>
-                                <label className="block text-sm font-medium text-neutral-400 mb-2">Title</label>
+                                <label className="block text-sm font-medium text-content-secondary mb-2">Title</label>
                                 <input
                                     type="text"
                                     value={title}
                                     onChange={e => { setTitle(e.target.value); setValidationError(null); }}
-                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-3 text-lg text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                                    className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-3 text-lg text-content-primary focus:outline-none focus:border-focus placeholder-neutral-600"
                                     placeholder="e.g., Morning Startup"
                                 />
                             </div>
 
                             <div>
-                                <label className="block text-sm font-medium text-neutral-400 mb-2">Category (Optional)</label>
+                                <label className="block text-sm font-medium text-content-secondary mb-2">Category (Optional)</label>
                                 <select
                                     value={categoryId || ''}
                                     onChange={e => setCategoryId(e.target.value || undefined)}
-                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-emerald-500"
+                                    className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-3 text-content-primary focus:outline-none focus:border-focus"
                                 >
                                     <option value="">-- No Category --</option>
                                     {categories.map(cat => (
@@ -379,10 +379,10 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                             {/* Routine Image Upload (edit mode only) */}
                             {mode === 'edit' && initialRoutine?.id && (
                                 <div>
-                                    <label className="block text-sm font-medium text-neutral-400 mb-2">Routine Image (Optional)</label>
+                                    <label className="block text-sm font-medium text-content-secondary mb-2">Routine Image (Optional)</label>
                                     <div className="space-y-2">
                                         {currentRoutineImageUrl && (
-                                            <div className="relative w-full aspect-video bg-neutral-800 rounded-lg overflow-hidden border border-white/5">
+                                            <div className="relative w-full aspect-video bg-surface-1 rounded-lg overflow-hidden border border-line-subtle">
                                                 <img src={currentRoutineImageUrl} alt={title} className="w-full h-full object-cover" />
                                                 <button
                                                     onClick={async () => {
@@ -396,7 +396,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                                                             }
                                                         }
                                                     }}
-                                                    className="absolute top-2 right-2 p-1.5 bg-black/50 text-white rounded-full opacity-0 hover:opacity-100 transition-opacity hover:bg-black/70"
+                                                    className="absolute top-2 right-2 p-1.5 bg-black/50 text-content-primary rounded-full opacity-0 hover:opacity-100 transition-opacity hover:bg-black/70"
                                                     title="Remove Image"
                                                 >
                                                     <X size={14} />
@@ -417,7 +417,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                                             />
                                             <label
                                                 htmlFor="routine-image-upload"
-                                                className={`flex items-center gap-2 px-4 py-2 bg-neutral-800 border border-white/10 rounded-lg text-sm text-neutral-300 hover:bg-neutral-700 transition-colors cursor-pointer ${uploadingRoutineImage ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                className={`flex items-center gap-2 px-4 py-2 bg-surface-1 border border-line-subtle rounded-lg text-sm text-content-secondary hover:bg-surface-2 transition-colors cursor-pointer ${uploadingRoutineImage ? 'opacity-50 cursor-not-allowed' : ''}`}
                                             >
                                                 {uploadingRoutineImage ? (
                                                     <><Loader2 size={16} className="animate-spin" /> Uploading...</>
@@ -425,7 +425,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                                                     <><ImageIcon size={16} /> {currentRoutineImageUrl ? 'Replace Image' : 'Upload Image'}</>
                                                 )}
                                             </label>
-                                            <span className="text-xs text-neutral-500">JPEG, PNG, or WebP (max 5MB)</span>
+                                            <span className="text-xs text-content-muted">JPEG, PNG, or WebP (max 5MB)</span>
                                         </div>
                                         {routineImageError && <p className="text-xs text-red-400">{routineImageError}</p>}
                                     </div>
@@ -436,7 +436,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                         {/* Variant Tabs — header/tabs hidden when editing a step */}
                         <div className="space-y-4">
                             {!isEditingStep && <><div className="flex items-center justify-between">
-                                <label className="text-sm font-medium text-neutral-400">Variants</label>
+                                <label className="text-sm font-medium text-content-secondary">Variants</label>
                                 {hasGeminiApiKey() && (
                                     <button
                                         type="button"
@@ -456,27 +456,27 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                             )}
 
                             {/* Tab Bar */}
-                            <div className="flex items-center gap-1 overflow-x-auto pb-1 border-b border-white/5">
+                            <div className="flex items-center gap-1 overflow-x-auto pb-1 border-b border-line-subtle">
                                 {variants.map((v, i) => (
                                     <button
                                         key={v.id}
                                         onClick={() => setActiveVariantIndex(i)}
                                         className={`px-4 py-2 text-sm font-medium rounded-t-lg whitespace-nowrap transition-colors ${
                                             i === activeVariantIndex
-                                                ? 'bg-neutral-800 text-white border-b-2 border-emerald-500'
-                                                : 'text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800/50'
+                                                ? 'bg-surface-1 text-content-primary border-b-2 border-emerald-500'
+                                                : 'text-content-muted hover:text-content-secondary hover:bg-surface-1/50'
                                         } ${v.isAiGenerated ? 'italic' : ''}`}
                                     >
                                         {v.name || 'Untitled'}
                                         {v.isAiGenerated && <Sparkles size={10} className="inline ml-1 text-purple-400" />}
                                     </button>
                                 ))}
-                                <div className="flex items-center gap-1 border-l border-white/10 pl-2 ml-1 flex-shrink-0">
+                                <div className="flex items-center gap-1 border-l border-line-subtle pl-2 ml-1 flex-shrink-0">
                                     <button
                                         type="button"
                                         onClick={copyVariant}
                                         disabled={variants.length >= 10}
-                                        className="p-2 text-neutral-500 hover:text-white transition-colors disabled:opacity-40 rounded-lg hover:bg-neutral-800/50"
+                                        className="p-2 text-content-muted hover:text-content-primary transition-colors disabled:opacity-40 rounded-lg hover:bg-surface-1/50"
                                         title="Copy current variant"
                                     >
                                         <Copy size={14} />
@@ -485,7 +485,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                                         type="button"
                                         onClick={addVariant}
                                         disabled={variants.length >= 10}
-                                        className="p-2 text-emerald-400 hover:text-emerald-300 transition-colors disabled:opacity-40 rounded-lg hover:bg-neutral-800/50"
+                                        className="p-2 text-accent-contrast hover:text-accent-contrast transition-colors disabled:opacity-40 rounded-lg hover:bg-surface-1/50"
                                         title="Add variant"
                                     >
                                         <Plus size={14} />
@@ -510,7 +510,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                 </div>
 
                 {/* Footer — hidden when editing a step to maximize space */}
-                {!isEditingStep && <div className="px-6 py-3 border-t border-white/10 bg-neutral-900 flex justify-between items-center">
+                {!isEditingStep && <div className="px-6 py-3 border-t border-line-subtle bg-surface-0 flex justify-between items-center">
                     <div>
                         {validationError && (
                             <span className="text-red-400 text-sm">{validationError}</span>
@@ -519,13 +519,13 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                     <div className="flex gap-3">
                         <button
                             onClick={onClose}
-                            className="px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                            className="px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                         >
                             Cancel
                         </button>
                         <button
                             onClick={handleSubmit}
-                            className="px-6 py-2 bg-emerald-500 text-neutral-900 font-bold rounded-lg hover:bg-emerald-400 transition-colors shadow-lg shadow-emerald-500/20"
+                            className="px-6 py-2 bg-accent text-content-on-accent font-bold rounded-lg hover:bg-accent-strong transition-colors shadow-lg shadow-emerald-500/20"
                         >
                             {mode === 'create' ? 'Create Routine' : 'Save Changes'}
                         </button>

--- a/src/components/RoutineList.tsx
+++ b/src/components/RoutineList.tsx
@@ -32,8 +32,8 @@ const RoutineCard: React.FC<{
             className={cn(
                 "relative flex flex-col rounded-lg border transition-all duration-300 overflow-hidden",
                 isExpanded
-                    ? "bg-neutral-800 border-white/10 shadow-lg scale-[1.02] z-10"
-                    : "bg-neutral-900/40 border-white/5 hover:bg-neutral-800/60 hover:border-white/10"
+                    ? "bg-surface-1 border-line-subtle shadow-lg scale-[1.02] z-10"
+                    : "bg-surface-0/40 border-line-subtle hover:bg-surface-1/60 hover:border-line-subtle"
             )}
         >
             {/* Routine Image (if available) */}
@@ -53,13 +53,13 @@ const RoutineCard: React.FC<{
                 onClick={onExpand}
             >
                 {/* Title */}
-                <span className="flex-1 text-sm font-medium truncate select-none text-neutral-300">
+                <span className="flex-1 text-sm font-medium truncate select-none text-content-secondary">
                     {routine.title}
                 </span>
 
                 {/* Metadata */}
                 <div className="flex items-center gap-2 flex-shrink-0">
-                    <span className="text-[11px] text-neutral-600">
+                    <span className="text-[11px] text-content-muted">
                         {totalSteps} steps
                     </span>
                     {hasMultipleVariants && (
@@ -69,7 +69,7 @@ const RoutineCard: React.FC<{
                         </span>
                     )}
                     <ChevronRight size={14} className={cn(
-                        "text-neutral-600 transition-transform duration-200",
+                        "text-content-muted transition-transform duration-200",
                         isExpanded && "rotate-90"
                     )} />
                 </div>
@@ -87,16 +87,16 @@ const RoutineCard: React.FC<{
                                 <button
                                     key={variant.id}
                                     onClick={() => onPreview(routine)}
-                                    className="w-full text-left p-3 rounded-lg border border-white/5 bg-neutral-800/50 hover:border-white/15 hover:bg-neutral-800 transition-all"
+                                    className="w-full text-left p-3 rounded-lg border border-line-subtle bg-surface-1/50 hover:border-white/15 hover:bg-surface-1 transition-all"
                                 >
                                     <div className="flex items-center justify-between gap-2">
                                         <div className="flex items-center gap-2 min-w-0">
-                                            <span className="text-xs font-medium text-white truncate">{variant.name}</span>
+                                            <span className="text-xs font-medium text-content-primary truncate">{variant.name}</span>
                                             {variant.isAiGenerated && (
                                                 <Sparkles size={10} className="text-purple-400 flex-shrink-0" />
                                             )}
                                         </div>
-                                        <div className="flex items-center gap-3 text-[10px] text-neutral-500 flex-shrink-0">
+                                        <div className="flex items-center gap-3 text-[10px] text-content-muted flex-shrink-0">
                                             <span className="flex items-center gap-1">
                                                 <ListChecks size={10} />
                                                 {variant.steps.length}
@@ -110,7 +110,7 @@ const RoutineCard: React.FC<{
                                         </div>
                                     </div>
                                     {variant.description && (
-                                        <p className="text-[10px] text-neutral-500 mt-1 line-clamp-1">{variant.description}</p>
+                                        <p className="text-[10px] text-content-muted mt-1 line-clamp-1">{variant.description}</p>
                                     )}
                                 </button>
                             ))}
@@ -121,7 +121,7 @@ const RoutineCard: React.FC<{
                     {!hasMultipleVariants && (
                         <button
                             onClick={() => onPreview(routine)}
-                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors text-xs text-emerald-400 hover:bg-emerald-500/10 w-fit"
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-colors text-xs text-accent-contrast hover:bg-accent-strong/10 w-fit"
                         >
                             <Play size={12} />
                             <span>Start Routine</span>
@@ -132,7 +132,7 @@ const RoutineCard: React.FC<{
                     <div className="flex items-center justify-end gap-1">
                         <button
                             onClick={() => onEdit(routine)}
-                            className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                            className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-content-muted hover:text-content-secondary hover:bg-surface-2"
                         >
                             <Edit size={12} />
                             <span>Edit</span>
@@ -175,16 +175,16 @@ const CategorySection: React.FC<{
                 onClick={onToggle}
                 className="flex items-center gap-2 px-1 w-full text-left group transition-opacity hover:opacity-80"
             >
-                <div className={`flex-shrink-0 ${textColorClass || 'text-neutral-500'}`} style={styleColor}>
+                <div className={`flex-shrink-0 ${textColorClass || 'text-content-muted'}`} style={styleColor}>
                     {isExpanded ? <ChevronDown size={20} /> : <ChevronRight size={20} />}
                 </div>
                 <h3
-                    className={`text-lg font-bold transition-colors ${textColorClass || 'text-neutral-300'}`}
+                    className={`text-lg font-bold transition-colors ${textColorClass || 'text-content-secondary'}`}
                     style={styleColor}
                 >
                     {category.name}
                 </h3>
-                <span className="text-xs text-neutral-500 font-medium ml-1">
+                <span className="text-xs text-content-muted font-medium ml-1">
                     {routines.length}
                 </span>
             </button>
@@ -274,7 +274,7 @@ export const RoutineList: React.FC<RoutineListProps> = ({ onCreate, onEdit, onPr
 
     if (loading) {
         return (
-            <div className="flex items-center justify-center h-full text-neutral-500">
+            <div className="flex items-center justify-center h-full text-content-muted">
                 Loading routines...
             </div>
         );
@@ -290,26 +290,26 @@ export const RoutineList: React.FC<RoutineListProps> = ({ onCreate, onEdit, onPr
 
     if (routines.length === 0) {
         return (
-            <div className="flex-1 flex flex-col items-center justify-center p-8 sm:p-12 text-center bg-neutral-900/50 rounded-2xl border border-white/5">
-                <div className="w-14 h-14 bg-neutral-800 rounded-full flex items-center justify-center mb-5">
-                    <ClipboardList size={28} className="text-neutral-500" />
+            <div className="flex-1 flex flex-col items-center justify-center p-8 sm:p-12 text-center bg-surface-0/50 rounded-2xl border border-line-subtle">
+                <div className="w-14 h-14 bg-surface-1 rounded-full flex items-center justify-center mb-5">
+                    <ClipboardList size={28} className="text-content-muted" />
                 </div>
-                <h3 className="text-lg font-semibold text-white mb-2">
+                <h3 className="text-lg font-semibold text-content-primary mb-2">
                     Routines group actions into repeatable flows that reduce friction.
                 </h3>
-                <p className="text-sm text-neutral-400 mb-4 max-w-sm leading-relaxed">
+                <p className="text-sm text-content-secondary mb-4 max-w-sm leading-relaxed">
                     Use routines for things like a morning reset, gym prep, or an evening shutdown.
                 </p>
                 <div className="flex flex-wrap justify-center gap-2 mb-6 max-w-sm">
                     {['Morning reset', 'Workout prep', 'Evening shutdown'].map((ex) => (
-                        <span key={ex} className="px-3 py-1 text-xs text-neutral-400 bg-neutral-800/80 rounded-full border border-white/5">
+                        <span key={ex} className="px-3 py-1 text-xs text-content-secondary bg-surface-1/80 rounded-full border border-line-subtle">
                             {ex}
                         </span>
                     ))}
                 </div>
                 <button
                     onClick={onCreate}
-                    className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-medium rounded-lg transition-colors text-sm"
+                    className="flex items-center gap-2 px-5 py-2.5 bg-accent hover:bg-accent-strong text-neutral-900 font-medium rounded-lg transition-colors text-sm"
                 >
                     <Plus size={18} />
                     Create Your First Routine
@@ -342,7 +342,7 @@ export const RoutineList: React.FC<RoutineListProps> = ({ onCreate, onEdit, onPr
                 {/* Uncategorized Section */}
                 {groupedRoutines['uncategorized']?.length > 0 && (
                     <CategorySection
-                        category={{ id: 'uncategorized', name: 'Uncategorized', color: 'bg-neutral-600', isUncategorized: true }}
+                        category={{ id: 'uncategorized', name: 'Uncategorized', color: 'bg-surface-2', isUncategorized: true }}
                         routines={groupedRoutines['uncategorized']}
                         isExpanded={!!expandedCategories['uncategorized']}
                         onToggle={() => toggleCategory('uncategorized')}

--- a/src/components/RoutinePreviewModal.tsx
+++ b/src/components/RoutinePreviewModal.tsx
@@ -46,16 +46,16 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4">
-            <div className="w-full max-w-2xl bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90dvh] animate-fade-in-up">
+            <div className="w-full max-w-2xl bg-surface-0 border border-line-subtle rounded-2xl shadow-2xl flex flex-col max-h-[90dvh] animate-fade-in-up">
 
                 {/* Header */}
-                <div className="flex items-center justify-between p-6 border-b border-white/5">
+                <div className="flex items-center justify-between p-6 border-b border-line-subtle">
                     <div>
-                        <h2 className="text-2xl font-bold text-white">{routine.title}</h2>
+                        <h2 className="text-2xl font-bold text-content-primary">{routine.title}</h2>
                     </div>
                     <button
                         onClick={onClose}
-                        className="p-2 rounded-lg text-neutral-400 hover:text-white hover:bg-neutral-800 transition-colors"
+                        className="p-2 rounded-lg text-content-secondary hover:text-content-primary hover:bg-surface-1 transition-colors"
                     >
                         <X size={24} />
                     </button>
@@ -63,7 +63,7 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
 
                 {/* Routine Image */}
                 {routine.imageUrl && (
-                    <div className="w-full aspect-video bg-neutral-800/50 border-b border-white/5 overflow-hidden">
+                    <div className="w-full aspect-video bg-surface-1/50 border-b border-line-subtle overflow-hidden">
                         <img src={routine.imageUrl} alt={routine.title} className="w-full h-full object-cover" />
                     </div>
                 )}
@@ -74,7 +74,7 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
                     {/* Variant Selector */}
                     {hasMultipleVariants && routine.variants && (
                         <div className="space-y-3">
-                            <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider flex items-center gap-2">
+                            <h3 className="text-sm font-medium text-content-muted uppercase tracking-wider flex items-center gap-2">
                                 <Layers size={14} />
                                 Choose Variant
                             </h3>
@@ -97,12 +97,12 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
 
                     {/* Stats */}
                     <div className="flex gap-4">
-                        <div className="flex items-center gap-2 px-3 py-1.5 bg-neutral-800 rounded-lg text-neutral-300 text-sm">
+                        <div className="flex items-center gap-2 px-3 py-1.5 bg-surface-1 rounded-lg text-content-secondary text-sm">
                             <ListChecks size={16} />
                             <span>{totalSteps} Steps</span>
                         </div>
                         {durationMinutes > 0 && (
-                            <div className="flex items-center gap-2 px-3 py-1.5 bg-neutral-800 rounded-lg text-neutral-300 text-sm">
+                            <div className="flex items-center gap-2 px-3 py-1.5 bg-surface-1 rounded-lg text-content-secondary text-sm">
                                 <Clock size={16} />
                                 <span>~{durationMinutes} mins</span>
                             </div>
@@ -112,7 +112,7 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
                     {/* Linked Habits */}
                     {linkedHabits.length > 0 && (
                         <div className="space-y-3">
-                            <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider flex items-center gap-2">
+                            <h3 className="text-sm font-medium text-content-muted uppercase tracking-wider flex items-center gap-2">
                                 <LinkIcon size={14} />
                                 Linked Habits
                             </h3>
@@ -120,13 +120,13 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
                                 {linkedHabits.map(habit => (
                                     <div
                                         key={habit.id}
-                                        className="px-3 py-1 bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 rounded-full text-sm font-medium"
+                                        className="px-3 py-1 bg-accent-soft border border-accent/20 text-accent-contrast rounded-full text-sm font-medium"
                                     >
                                         {habit.name}
                                     </div>
                                 ))}
                             </div>
-                            <p className="text-xs text-neutral-500 italic">
+                            <p className="text-xs text-content-muted italic">
                                 * Starting this routine will prepare these habits for confirmation.
                             </p>
                         </div>
@@ -134,19 +134,19 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
 
                     {/* Steps Preview */}
                     <div className="space-y-4">
-                        <h3 className="text-sm font-medium text-neutral-500 uppercase tracking-wider">
+                        <h3 className="text-sm font-medium text-content-muted uppercase tracking-wider">
                             Steps Sequence
                         </h3>
-                        <div className="space-y-2 relative before:absolute before:left-4 before:top-4 before:bottom-4 before:w-0.5 before:bg-neutral-800">
+                        <div className="space-y-2 relative before:absolute before:left-4 before:top-4 before:bottom-4 before:w-0.5 before:bg-surface-1">
                             {steps.map((step, index) => (
-                                <div key={step.id} className="relative flex items-start gap-4 p-2 rounded-lg hover:bg-neutral-800/50 transition-colors">
-                                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-neutral-800 border border-neutral-700 flex items-center justify-center text-sm font-medium text-neutral-400 z-10">
+                                <div key={step.id} className="relative flex items-start gap-4 p-2 rounded-lg hover:bg-surface-1/50 transition-colors">
+                                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-surface-1 border border-line-strong flex items-center justify-center text-sm font-medium text-content-secondary z-10">
                                         {index + 1}
                                     </div>
                                     <div className="flex-1 pt-1">
-                                        <h4 className="text-white font-medium">{step.title}</h4>
+                                        <h4 className="text-content-primary font-medium">{step.title}</h4>
                                         {step.timerSeconds && (
-                                            <span className="text-xs text-neutral-500 flex items-center gap-1 mt-1">
+                                            <span className="text-xs text-content-muted flex items-center gap-1 mt-1">
                                                 <Clock size={12} />
                                                 {Math.floor(step.timerSeconds / 60)}:{(step.timerSeconds % 60).toString().padStart(2, '0')}
                                             </span>
@@ -159,10 +159,10 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
                 </div>
 
                 {/* Footer */}
-                <div className="p-6 border-t border-white/10 bg-neutral-900/50 backdrop-blur-md flex justify-end gap-3">
+                <div className="p-6 border-t border-line-subtle bg-surface-0/50 backdrop-blur-md flex justify-end gap-3">
                     <button
                         onClick={onClose}
-                        className="px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                        className="px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                     >
                         Cancel
                     </button>
@@ -171,7 +171,7 @@ export const RoutinePreviewModal: React.FC<RoutinePreviewModalProps> = ({
                             onStart(routine, selectedVariantId);
                             onClose();
                         }}
-                        className="flex items-center gap-2 px-6 py-2 bg-emerald-500 text-neutral-900 font-bold rounded-lg hover:bg-emerald-400 transition-colors shadow-lg shadow-emerald-500/20"
+                        className="flex items-center gap-2 px-6 py-2 bg-accent text-content-on-accent font-bold rounded-lg hover:bg-accent-strong transition-colors shadow-lg shadow-emerald-500/20"
                     >
                         <Play size={18} />
                         {hasMultipleVariants && selectedVariant

--- a/src/components/RoutineRunnerModal.tsx
+++ b/src/components/RoutineRunnerModal.tsx
@@ -143,7 +143,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
-            <div className="w-full max-w-4xl max-h-[90dvh] h-[85vh] bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl flex flex-col overflow-hidden relative">
+            <div className="w-full max-w-4xl max-h-[90dvh] h-[85vh] bg-surface-0 border border-line-subtle rounded-2xl shadow-2xl flex flex-col overflow-hidden relative">
 
                 {/* Header / Progress Bar */}
                 <div className="absolute top-0 left-0 w-full z-10">
@@ -156,7 +156,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                         </div>
                     )}
                     <div className="flex items-center justify-between p-4 bg-gradient-to-b from-black/50 to-transparent">
-                        <h2 className="text-sm font-medium text-white/70 uppercase tracking-wider">
+                        <h2 className="text-sm font-medium text-content-primary/70 uppercase tracking-wider">
                             {isCompletionView ? 'Routine Complete' : (
                                 <>
                                     {routine.title}
@@ -166,7 +166,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                 </>
                             )}
                         </h2>
-                        <button onClick={handleClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-white/50 hover:text-white transition-colors -mr-2" aria-label="Close">
+                        <button onClick={handleClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-primary/50 hover:text-content-primary transition-colors -mr-2" aria-label="Close">
                             <X size={24} />
                         </button>
                     </div>
@@ -177,11 +177,11 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                     {isCompletionView ? (
                         <div className="max-w-md w-full space-y-8 animate-fade-in-up my-auto">
                             <div className="text-center space-y-2">
-                                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-emerald-500/20 text-emerald-400 mb-4">
+                                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-accent-soft text-accent-contrast mb-4">
                                     <Check size={32} strokeWidth={3} />
                                 </div>
-                                <h3 className="text-3xl font-bold text-white">All Done!</h3>
-                                <p className="text-neutral-400">Great job completing your routine.</p>
+                                <h3 className="text-3xl font-bold text-content-primary">All Done!</h3>
+                                <p className="text-content-secondary">Great job completing your routine.</p>
                             </div>
                         </div>
                     ) : (
@@ -192,7 +192,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                 {timer.displayTime !== null && (
                                     <div className="flex flex-col items-center gap-2">
                                         <div className={`text-6xl font-mono font-bold tabular-nums tracking-tight ${
-                                            timer.mode === 'stopwatch' ? 'text-blue-400' : 'text-emerald-400'
+                                            timer.mode === 'stopwatch' ? 'text-blue-400' : 'text-accent-contrast'
                                         }`}>
                                             {timer.formatTime(timer.displayTime)}
                                         </div>
@@ -202,7 +202,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                             )}
                                             <button
                                                 onClick={timer.toggle}
-                                                className="px-6 py-2 bg-neutral-800 rounded-full text-white hover:bg-neutral-700 transition-colors flex items-center gap-2 font-medium"
+                                                className="px-6 py-2 bg-surface-1 rounded-full text-content-primary hover:bg-surface-2 transition-colors flex items-center gap-2 font-medium"
                                             >
                                                 {timer.isRunning ? (
                                                     <><Pause size={18} fill="currentColor" /> Pause</>
@@ -212,7 +212,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                             </button>
                                             <button
                                                 onClick={timer.reset}
-                                                className="min-h-[44px] min-w-[44px] flex items-center justify-center bg-neutral-800 rounded-full text-neutral-400 hover:text-white hover:bg-neutral-700 transition-colors"
+                                                className="min-h-[44px] min-w-[44px] flex items-center justify-center bg-surface-1 rounded-full text-content-secondary hover:text-content-primary hover:bg-surface-2 transition-colors"
                                                 title="Reset Timer"
                                             >
                                                 <RotateCcw size={18} />
@@ -220,13 +220,13 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                         </div>
                                     </div>
                                 )}
-                                <h3 className="text-2xl md:text-3xl font-bold text-white leading-tight">
+                                <h3 className="text-2xl md:text-3xl font-bold text-content-primary leading-tight">
                                     {currentStep?.title}
                                 </h3>
                             </div>
 
                             {/* CENTER: Visual (Image or Placeholder) */}
-                            <div className={`w-full aspect-video max-h-[40vh] bg-neutral-800/50 rounded-2xl overflow-hidden shadow-lg border border-white/5 flex items-center justify-center relative flex-shrink-0 ${!currentStep?.imageUrl ? 'bg-neutral-900 border-dashed opacity-50' : ''}`}>
+                            <div className={`w-full aspect-video max-h-[40vh] bg-surface-1/50 rounded-2xl overflow-hidden shadow-lg border border-line-subtle flex items-center justify-center relative flex-shrink-0 ${!currentStep?.imageUrl ? 'bg-surface-0 border-dashed opacity-50' : ''}`}>
                                 {currentStep?.imageUrl ? (
                                     <img
                                         src={currentStep.imageUrl}
@@ -242,8 +242,8 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
 
                             {/* BOTTOM: Instructions */}
                             {currentStep?.instruction && (
-                                <div className="w-full bg-neutral-800/50 rounded-xl p-5 border border-white/5 text-center">
-                                    <p className="text-neutral-200 text-lg whitespace-pre-wrap leading-relaxed">
+                                <div className="w-full bg-surface-1/50 rounded-xl p-5 border border-line-subtle text-center">
+                                    <p className="text-content-primary text-lg whitespace-pre-wrap leading-relaxed">
                                         {currentStep.instruction}
                                     </p>
                                 </div>
@@ -251,8 +251,8 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
 
                             {/* Tracking Fields */}
                             {currentStep?.trackingFields && currentStep.trackingFields.length > 0 && (
-                                <div className="w-full bg-neutral-800/50 rounded-xl p-5 border border-white/5 space-y-3">
-                                    <h4 className="text-xs font-medium text-neutral-500 uppercase tracking-wider">Track</h4>
+                                <div className="w-full bg-surface-1/50 rounded-xl p-5 border border-line-subtle space-y-3">
+                                    <h4 className="text-xs font-medium text-content-muted uppercase tracking-wider">Track</h4>
                                     {currentStep.trackingFields.map(field => (
                                         <TrackingFieldInput
                                             key={field.id}
@@ -276,12 +276,12 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                                 role="listitem"
                                                 className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-medium transition-colors ${
                                                     status === 'done'
-                                                        ? 'bg-emerald-500/30 text-emerald-400'
+                                                        ? 'bg-emerald-500/30 text-accent-contrast'
                                                         : status === 'skipped'
-                                                            ? 'bg-neutral-600/50 text-neutral-500'
+                                                            ? 'bg-surface-2/50 text-content-muted'
                                                             : isCurrent
-                                                                ? 'bg-white/20 text-white ring-1 ring-white/30'
-                                                                : 'bg-white/5 text-neutral-400'
+                                                                ? 'bg-white/20 text-content-primary ring-1 ring-white/30'
+                                                                : 'bg-white/5 text-content-secondary'
                                                 }`}
                                                 title={status === 'done' ? `${s.title} – Done` : status === 'skipped' ? `${s.title} – Skipped` : s.title}
                                             >
@@ -298,7 +298,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                     <button
                                         type="button"
                                         onClick={() => setStepState(currentStep.id, 'done')}
-                                        className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30 transition-colors text-sm font-medium"
+                                        className="flex items-center gap-2 px-4 py-2 rounded-lg bg-accent-soft text-accent-contrast hover:bg-accent-strong/30 transition-colors text-sm font-medium"
                                     >
                                         <CircleCheck size={18} />
                                         Mark done
@@ -306,7 +306,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                     <button
                                         type="button"
                                         onClick={() => setStepState(currentStep.id, 'skipped')}
-                                        className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-600/50 text-neutral-400 hover:bg-neutral-600/70 hover:text-neutral-300 transition-colors text-sm font-medium"
+                                        className="flex items-center gap-2 px-4 py-2 rounded-lg bg-surface-2/50 text-content-secondary hover:bg-surface-2/70 hover:text-content-secondary transition-colors text-sm font-medium"
                                     >
                                         <Forward size={18} />
                                         Skip step
@@ -318,20 +318,20 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                 </div>
 
                 {/* Footer / Controls */}
-                <div className="p-6 border-t border-white/10 bg-neutral-900/50 backdrop-blur-md">
+                <div className="p-6 border-t border-line-subtle bg-surface-0/50 backdrop-blur-md">
                     <div className="flex justify-between items-center max-w-4xl mx-auto w-full">
                         {!isCompletionView ? (
                             <>
                                 <button
                                     onClick={handlePrevious}
                                     disabled={currentStepIndex === 0}
-                                    className="flex items-center gap-2 px-4 py-2 text-neutral-400 hover:text-white disabled:opacity-30 disabled:hover:text-neutral-400 transition-colors"
+                                    className="flex items-center gap-2 px-4 py-2 text-content-secondary hover:text-content-primary disabled:opacity-30 disabled:hover:text-content-secondary transition-colors"
                                 >
                                     <ChevronLeft size={20} />
                                     Back
                                 </button>
 
-                                <div className="flex items-center gap-2 text-neutral-500 font-mono text-sm">
+                                <div className="flex items-center gap-2 text-content-muted font-mono text-sm">
                                     {currentStepIndex + 1} / {steps.length}
                                 </div>
 
@@ -347,7 +347,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                             <>
                                 <button
                                     onClick={handlePrevious}
-                                    className="flex items-center gap-2 px-4 py-2 text-neutral-400 hover:text-white transition-colors"
+                                    className="flex items-center gap-2 px-4 py-2 text-content-secondary hover:text-content-primary transition-colors"
                                 >
                                     Back to Routine
                                 </button>
@@ -355,7 +355,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                     <button
                                         type="button"
                                         onClick={() => setShowCompletedHabitsModal(true)}
-                                        className="flex items-center gap-2 px-6 py-3 bg-neutral-700 text-white font-semibold rounded-lg hover:bg-neutral-600 transition-colors touch-manipulation"
+                                        className="flex items-center gap-2 px-6 py-3 bg-surface-2 text-content-primary font-semibold rounded-lg hover:bg-surface-2 transition-colors touch-manipulation"
                                     >
                                         Complete Routine
                                     </button>
@@ -363,7 +363,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
                                         <button
                                             onClick={() => handleFinish(true)}
                                             disabled={submitting}
-                                            className="flex items-center gap-2 px-6 py-3 bg-emerald-500 text-neutral-900 font-bold rounded-lg hover:bg-emerald-400 transition-colors shadow-lg shadow-emerald-500/20"
+                                            className="flex items-center gap-2 px-6 py-3 bg-accent text-content-on-accent font-bold rounded-lg hover:bg-accent-strong transition-colors shadow-lg shadow-emerald-500/20"
                                         >
                                             {submitting ? 'Saving...' : 'Complete + Log Habits'}
                                             <Check size={20} />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -42,19 +42,19 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
       {/* Scroll wrapper */}
       <div className="absolute inset-0 overflow-y-auto modal-scroll p-4">
         <div
-          className="relative bg-neutral-900 border border-white/10 rounded-xl shadow-xl max-w-sm w-full mx-auto my-8 sm:my-16"
+          className="relative bg-surface-0 border border-line-subtle rounded-xl shadow-xl max-w-sm w-full mx-auto my-8 sm:my-16"
           role="dialog"
           aria-labelledby="settings-title"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="p-4 border-b border-white/5 flex items-center justify-between">
-            <h2 id="settings-title" className="text-lg font-semibold text-white">
+          <div className="p-4 border-b border-line-subtle flex items-center justify-between">
+            <h2 id="settings-title" className="text-lg font-semibold text-content-primary">
               Settings
             </h2>
             <button
               type="button"
               onClick={onClose}
-              className="p-2 text-neutral-400 hover:text-white rounded-lg hover:bg-white/5"
+              className="p-2 text-content-secondary hover:text-content-primary rounded-lg hover:bg-surface-2"
               aria-label="Close"
             >
               ✕
@@ -65,10 +65,10 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
             {/* Account */}
             {user?.displayName && (
               <section>
-                <h3 className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-2">
+                <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider mb-2">
                   Account
                 </h3>
-                <div className="text-sm text-neutral-200">
+                <div className="text-sm text-content-primary">
                   {user.displayName}
                 </div>
               </section>
@@ -79,9 +79,9 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
               <button
                 type="button"
                 onClick={handleReopenGuide}
-                className="w-full px-4 py-2.5 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 hover:bg-neutral-700 text-sm text-left flex items-center gap-2"
+                className="w-full px-4 py-2.5 rounded-lg bg-surface-1 text-content-primary border border-line-subtle hover:bg-surface-2 text-sm text-left flex items-center gap-2"
               >
-                <Sparkles size={16} className="text-emerald-400 flex-shrink-0" />
+                <Sparkles size={16} className="text-accent-contrast flex-shrink-0" />
                 Reopen setup guide
               </button>
             </section>
@@ -89,17 +89,17 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
             {/* Apple Health Integration */}
             {isHealthFeatureEnabled(user?.email) && (
               <section>
-                <h3 className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-2">
+                <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider mb-2">
                   Integrations
                 </h3>
                 <button
                   type="button"
                   onClick={() => { onNavigate?.('health'); onClose(); }}
-                  className="w-full px-4 py-2.5 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 hover:bg-neutral-700 text-sm text-left flex items-center gap-2"
+                  className="w-full px-4 py-2.5 rounded-lg bg-surface-1 text-content-primary border border-line-subtle hover:bg-surface-2 text-sm text-left flex items-center gap-2"
                 >
-                  <Activity size={16} className="text-emerald-400 flex-shrink-0" />
+                  <Activity size={16} className="text-accent-contrast flex-shrink-0" />
                   <span className="flex-1">Apple Health</span>
-                  <ChevronRight size={16} className="text-neutral-500" />
+                  <ChevronRight size={16} className="text-content-muted" />
                 </button>
               </section>
             )}
@@ -107,33 +107,33 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
             {/* AI Integration */}
             <section>
               <div className="flex items-center gap-2 mb-3">
-                <h3 className="text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider">
                   AI Integration
                 </h3>
-                <span className="text-[10px] text-neutral-600 font-medium">(~3 mins to set up)</span>
+                <span className="text-[10px] text-content-muted font-medium">(~3 mins to set up)</span>
               </div>
               <div className="space-y-3">
                 <div>
-                  <label htmlFor="gemini-key" className="block text-sm text-neutral-300 mb-1.5">
+                  <label htmlFor="gemini-key" className="block text-sm text-content-secondary mb-1.5">
                     Gemini API Key
                   </label>
-                  <p className="text-[11px] text-neutral-500 mb-2">
+                  <p className="text-[11px] text-content-muted mb-2">
                     Add your Google Gemini API key to enable AI-powered weekly summaries.
                     Your key is stored locally and never saved on the server.
                   </p>
-                  <ol className="text-[11px] text-neutral-500 mb-3 space-y-1 pl-4 list-decimal">
+                  <ol className="text-[11px] text-content-muted mb-3 space-y-1 pl-4 list-decimal">
                     <li>Go to{' '}
                       <a
                         href="https://aistudio.google.com/apikey"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-emerald-400 hover:text-emerald-300 underline underline-offset-2"
+                        className="text-accent-contrast hover:text-accent-contrast underline underline-offset-2"
                       >
                         Google AI Studio
                       </a>
                     </li>
                     <li>Sign in with your Google account</li>
-                    <li>Click <span className="text-neutral-400 font-medium">Create API Key</span></li>
+                    <li>Click <span className="text-content-secondary font-medium">Create API Key</span></li>
                     <li>Copy the key and paste it below</li>
                   </ol>
                   <div className="flex gap-2">
@@ -144,12 +144,12 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                         value={geminiKey}
                         onChange={(e) => setGeminiKey(e.target.value)}
                         placeholder="AIza..."
-                        className="w-full px-3 py-2 pr-9 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 text-sm placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-emerald-500/50"
+                        className="w-full px-3 py-2 pr-9 rounded-lg bg-surface-1 text-content-primary border border-line-subtle text-sm placeholder:text-content-muted focus:outline-none focus:ring-1 focus:ring-focus/50"
                       />
                       <button
                         type="button"
                         onClick={() => setShowGeminiKey(!showGeminiKey)}
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-neutral-300"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-secondary"
                         aria-label={showGeminiKey ? 'Hide key' : 'Show key'}
                       >
                         {showGeminiKey ? <EyeOff size={14} /> : <Eye size={14} />}
@@ -158,7 +158,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                     <button
                       type="button"
                       onClick={handleSaveGeminiKey}
-                      className="px-3 py-2 rounded-lg bg-emerald-600/80 text-white hover:bg-emerald-600 text-sm whitespace-nowrap"
+                      className="px-3 py-2 rounded-lg bg-emerald-600/80 text-content-primary hover:bg-emerald-600 text-sm whitespace-nowrap"
                     >
                       {geminiKeySaved ? 'Saved!' : 'Save'}
                     </button>
@@ -181,7 +181,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
 
             {/* Data */}
             <section>
-              <h3 className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-3">
+              <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider mb-3">
                 Data
               </h3>
               <div className="space-y-3">
@@ -190,20 +190,20 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                   <button
                     type="button"
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="w-full px-4 py-2.5 rounded-lg bg-neutral-800 text-red-400 border border-white/10 hover:bg-neutral-700 text-sm text-left"
+                    className="w-full px-4 py-2.5 rounded-lg bg-surface-1 text-red-400 border border-line-subtle hover:bg-surface-2 text-sm text-left"
                   >
                     Delete my data
                   </button>
                 ) : (
-                  <div className="rounded-lg bg-neutral-800/50 border border-red-500/30 p-3 space-y-3">
-                    <p className="text-sm text-neutral-300">
+                  <div className="rounded-lg bg-surface-1/50 border border-red-500/30 p-3 space-y-3">
+                    <p className="text-sm text-content-secondary">
                       This will permanently delete all your habits, logs, and settings. This action cannot be undone.
                     </p>
                     <div className="flex gap-2">
                       <button
                         type="button"
                         onClick={() => setShowDeleteConfirm(false)}
-                        className="px-3 py-1.5 rounded-lg bg-neutral-700 text-neutral-200 border border-white/10 hover:bg-neutral-600 text-sm"
+                        className="px-3 py-1.5 rounded-lg bg-surface-2 text-content-primary border border-line-subtle hover:bg-surface-2 text-sm"
                       >
                         Cancel
                       </button>
@@ -224,7 +224,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                             setIsDeleting(false);
                           }
                         }}
-                        className="px-3 py-1.5 rounded-lg bg-red-600 text-white hover:bg-red-500 disabled:opacity-50 text-sm"
+                        className="px-3 py-1.5 rounded-lg bg-red-600 text-content-primary hover:bg-red-500 disabled:opacity-50 text-sm"
                       >
                         {isDeleting ? 'Deleting...' : 'Yes, delete everything'}
                       </button>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,8 +1,17 @@
 import { useState, useCallback } from 'react';
 import { useAuth } from '../store/AuthContext';
+import { useDashboardPrefs } from '../store/DashboardPrefsContext';
+import { useTheme } from '../theme/ThemeContext';
+import type { ThemeMode } from '../theme/palette';
 import { getGeminiApiKey, setGeminiApiKey } from '../lib/geminiClient';
 import { deleteAllUserData, isHealthFeatureEnabled } from '../lib/persistenceClient';
-import { Eye, EyeOff, Sparkles, Activity, ChevronRight } from 'lucide-react';
+import { Eye, EyeOff, Sparkles, Activity, ChevronRight, Sun, Moon, Monitor } from 'lucide-react';
+
+const APPEARANCE_OPTIONS: ReadonlyArray<{ mode: ThemeMode; label: string; Icon: typeof Sun; hint: string }> = [
+  { mode: 'light', label: 'Light', Icon: Sun, hint: 'Bright' },
+  { mode: 'dark', label: 'Dark', Icon: Moon, hint: 'Default' },
+  { mode: 'system', label: 'System', Icon: Monitor, hint: 'Match device' },
+];
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -12,6 +21,8 @@ interface SettingsModalProps {
 
 export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProps) {
   const { user } = useAuth();
+  const { setThemeMode } = useDashboardPrefs();
+  const { mode: themeMode } = useTheme();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [geminiKey, setGeminiKey] = useState(() => getGeminiApiKey());
@@ -73,6 +84,43 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                 </div>
               </section>
             )}
+
+            {/* Appearance */}
+            <section>
+              <h3 className="text-xs font-medium text-content-muted uppercase tracking-wider mb-2">
+                Appearance
+              </h3>
+              <div
+                role="radiogroup"
+                aria-label="Theme"
+                className="grid grid-cols-3 gap-2"
+              >
+                {APPEARANCE_OPTIONS.map(({ mode, label, Icon, hint }) => {
+                  const isActive = themeMode === mode;
+                  return (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="radio"
+                      aria-checked={isActive}
+                      onClick={() => setThemeMode(mode)}
+                      className={`flex flex-col items-center gap-1 px-3 py-3 rounded-lg border text-xs font-medium transition-colors ${
+                        isActive
+                          ? 'bg-accent-soft border-accent/40 text-accent-contrast'
+                          : 'bg-surface-1 border-line-subtle text-content-secondary hover:bg-surface-2 hover:text-content-primary'
+                      }`}
+                    >
+                      <Icon size={18} />
+                      <span>{label}</span>
+                      <span className="text-[10px] text-content-muted">{hint}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <p className="text-[11px] text-content-muted mt-2">
+                System follows your device preference. Your choice syncs across devices.
+              </p>
+            </section>
 
             {/* Setup Guide */}
             <section>
@@ -158,7 +206,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                     <button
                       type="button"
                       onClick={handleSaveGeminiKey}
-                      className="px-3 py-2 rounded-lg bg-emerald-600/80 text-content-primary hover:bg-emerald-600 text-sm whitespace-nowrap"
+                      className="px-3 py-2 rounded-lg bg-accent text-content-on-accent hover:bg-accent-strong text-sm whitespace-nowrap transition-colors"
                     >
                       {geminiKeySaved ? 'Saved!' : 'Save'}
                     </button>
@@ -170,7 +218,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                         setGeminiKey('');
                         setGeminiApiKey('');
                       }}
-                      className="mt-2 text-xs text-red-400 hover:text-red-300"
+                      className="mt-2 text-xs text-danger-contrast hover:opacity-80"
                     >
                       Remove key
                     </button>
@@ -190,12 +238,12 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                   <button
                     type="button"
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="w-full px-4 py-2.5 rounded-lg bg-surface-1 text-red-400 border border-line-subtle hover:bg-surface-2 text-sm text-left"
+                    className="w-full px-4 py-2.5 rounded-lg bg-surface-1 text-danger-contrast border border-line-subtle hover:bg-surface-2 text-sm text-left"
                   >
                     Delete my data
                   </button>
                 ) : (
-                  <div className="rounded-lg bg-surface-1/50 border border-red-500/30 p-3 space-y-3">
+                  <div className="rounded-lg bg-danger-soft border border-danger/40 p-3 space-y-3">
                     <p className="text-sm text-content-secondary">
                       This will permanently delete all your habits, logs, and settings. This action cannot be undone.
                     </p>
@@ -203,7 +251,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                       <button
                         type="button"
                         onClick={() => setShowDeleteConfirm(false)}
-                        className="px-3 py-1.5 rounded-lg bg-surface-2 text-content-primary border border-line-subtle hover:bg-surface-2 text-sm"
+                        className="px-3 py-1.5 rounded-lg bg-surface-1 text-content-primary border border-line-subtle hover:bg-surface-2 text-sm"
                       >
                         Cancel
                       </button>
@@ -224,7 +272,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                             setIsDeleting(false);
                           }
                         }}
-                        className="px-3 py-1.5 rounded-lg bg-red-600 text-content-primary hover:bg-red-500 disabled:opacity-50 text-sm"
+                        className="px-3 py-1.5 rounded-lg bg-danger text-content-on-accent hover:opacity-90 disabled:opacity-50 text-sm"
                       >
                         {isDeleting ? 'Deleting...' : 'Yes, delete everything'}
                       </button>

--- a/src/components/StepEditorPanel.tsx
+++ b/src/components/StepEditorPanel.tsx
@@ -77,20 +77,20 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
     return (
         <div className="flex flex-col h-full animate-in slide-in-from-right-4 duration-200">
             {/* Header with back button */}
-            <div className="flex items-center gap-3 pb-4 border-b border-white/10 mb-6">
+            <div className="flex items-center gap-3 pb-4 border-b border-line-subtle mb-6">
                 <button
                     type="button"
                     onClick={onBack}
-                    className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors rounded-lg hover:bg-white/5 -ml-2"
+                    className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary transition-colors rounded-lg hover:bg-surface-2 -ml-2"
                     aria-label="Back to steps"
                 >
                     <ArrowLeft size={20} />
                 </button>
                 <div className="flex-1">
-                    <h3 className="text-lg font-semibold text-white">
+                    <h3 className="text-lg font-semibold text-content-primary">
                         {step.title || 'New Step'}
                     </h3>
-                    <p className="text-xs text-neutral-500">
+                    <p className="text-xs text-content-muted">
                         Step {stepIndex + 1} of {totalSteps}
                     </p>
                 </div>
@@ -100,14 +100,14 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
             <div className="flex-1 overflow-y-auto space-y-6 pb-4 modal-scroll">
                 {/* Title */}
                 <div>
-                    <label className="block text-sm font-medium text-neutral-400 mb-2">
+                    <label className="block text-sm font-medium text-content-secondary mb-2">
                         Step Title
                     </label>
                     <input
                         type="text"
                         value={step.title}
                         onChange={e => onChange({ title: e.target.value })}
-                        className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                        className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-3 text-content-primary focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                         placeholder="e.g., Drink Water"
                         autoFocus
                     />
@@ -115,13 +115,13 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
 
                 {/* Instructions */}
                 <div>
-                    <label className="block text-sm font-medium text-neutral-400 mb-2">
+                    <label className="block text-sm font-medium text-content-secondary mb-2">
                         Instructions (Optional)
                     </label>
                     <textarea
                         value={step.instruction || ''}
                         onChange={e => onChange({ instruction: e.target.value || undefined })}
-                        className="w-full bg-neutral-800 border border-white/10 rounded-lg p-4 text-sm text-neutral-300 placeholder-neutral-600 focus:outline-none focus:border-emerald-500 transition-colors resize-none"
+                        className="w-full bg-surface-1 border border-line-subtle rounded-lg p-4 text-sm text-content-secondary placeholder-neutral-600 focus:outline-none focus:border-emerald-500 transition-colors resize-none"
                         placeholder="Detailed instructions for this step..."
                         rows={3}
                     />
@@ -129,18 +129,18 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
 
                 {/* Timer */}
                 <div>
-                    <label className="block text-sm font-medium text-neutral-400 mb-2">
+                    <label className="block text-sm font-medium text-content-secondary mb-2">
                         Timer
                     </label>
                     <div className="flex flex-wrap items-center gap-2">
-                        <div className="flex items-center gap-1 bg-neutral-800 border border-white/10 rounded-lg p-1">
+                        <div className="flex items-center gap-1 bg-surface-1 border border-line-subtle rounded-lg p-1">
                             <button
                                 type="button"
                                 onClick={() => onChange({ timerMode: undefined, timerSeconds: undefined })}
                                 className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
                                     !step.timerMode && !step.timerSeconds
-                                        ? 'bg-white/10 text-white'
-                                        : 'text-neutral-500 hover:text-neutral-300'
+                                        ? 'bg-white/10 text-content-primary'
+                                        : 'text-content-muted hover:text-content-secondary'
                                 }`}
                             >
                                 Off
@@ -150,8 +150,8 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                 onClick={() => onChange({ timerMode: 'countdown', timerSeconds: step.timerSeconds || 60 })}
                                 className={`px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1.5 ${
                                     step.timerMode === 'countdown' || (!step.timerMode && step.timerSeconds)
-                                        ? 'bg-emerald-500/20 text-emerald-400'
-                                        : 'text-neutral-500 hover:text-neutral-300'
+                                        ? 'bg-accent-soft text-accent-contrast'
+                                        : 'text-content-muted hover:text-content-secondary'
                                 }`}
                             >
                                 <Clock size={14} /> Countdown
@@ -162,7 +162,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                 className={`px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1.5 ${
                                     step.timerMode === 'stopwatch'
                                         ? 'bg-blue-500/20 text-blue-400'
-                                        : 'text-neutral-500 hover:text-neutral-300'
+                                        : 'text-content-muted hover:text-content-secondary'
                                 }`}
                             >
                                 <Timer size={14} /> Stopwatch
@@ -170,8 +170,8 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                         </div>
 
                         {(step.timerMode === 'countdown' || (!step.timerMode && step.timerSeconds)) && (
-                            <div className="flex items-center gap-2 bg-neutral-800 border border-white/10 rounded-lg px-3 py-2">
-                                <Clock size={16} className="text-neutral-500" />
+                            <div className="flex items-center gap-2 bg-surface-1 border border-line-subtle rounded-lg px-3 py-2">
+                                <Clock size={16} className="text-content-muted" />
                                 <input
                                     type="number"
                                     min="0"
@@ -182,9 +182,9 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                         onChange({ timerSeconds: isNaN(val) ? undefined : Math.max(0, Math.round(val * 60)) });
                                     }}
                                     placeholder="Min"
-                                    className="bg-transparent w-20 text-sm focus:outline-none text-white placeholder-neutral-600"
+                                    className="bg-transparent w-20 text-sm focus:outline-none text-content-primary placeholder-neutral-600"
                                 />
-                                <span className="text-xs text-neutral-500">min</span>
+                                <span className="text-xs text-content-muted">min</span>
                             </div>
                         )}
                     </div>
@@ -192,24 +192,24 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
 
                 {/* ── Linked Habit — prominent section ── */}
                 <div>
-                    <label className="block text-sm font-medium text-neutral-400 mb-2 flex items-center gap-1.5">
+                    <label className="block text-sm font-medium text-content-secondary mb-2 flex items-center gap-1.5">
                         <Link2 size={14} /> Link a Habit
                     </label>
-                    <p className="text-xs text-neutral-500 mb-3">
+                    <p className="text-xs text-content-muted mb-3">
                         Completing this step can log progress for a habit automatically.
                     </p>
 
                     {/* Currently linked habit */}
                     {linkedHabit && (
-                        <div className="flex items-center gap-3 bg-emerald-500/10 border border-emerald-500/30 rounded-xl px-4 py-3 mb-3">
-                            <Check size={16} className="text-emerald-400 flex-shrink-0" />
-                            <span className="flex-1 text-sm font-medium text-white">
+                        <div className="flex items-center gap-3 bg-accent-soft border border-accent/30 rounded-xl px-4 py-3 mb-3">
+                            <Check size={16} className="text-accent-contrast flex-shrink-0" />
+                            <span className="flex-1 text-sm font-medium text-content-primary">
                                 {linkedHabit.name}
                             </span>
                             <button
                                 type="button"
                                 onClick={() => onChange({ linkedHabitId: undefined })}
-                                className="p-1.5 text-neutral-400 hover:text-red-400 transition-colors rounded-lg"
+                                className="p-1.5 text-content-secondary hover:text-red-400 transition-colors rounded-lg"
                                 title="Unlink habit"
                             >
                                 <X size={16} />
@@ -225,7 +225,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                     type="text"
                                     value={habitSearch}
                                     onChange={e => setHabitSearch(e.target.value)}
-                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                                    className="w-full bg-surface-1 border border-line-subtle rounded-lg px-3 py-2 text-sm text-content-primary focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                                     placeholder="Search habits..."
                                 />
                             )}
@@ -243,8 +243,8 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                             }
                                             className={`px-3 py-2 rounded-lg text-sm font-medium transition-all ${
                                                 isLinked
-                                                    ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40'
-                                                    : 'bg-neutral-800 text-neutral-300 border border-white/10 hover:border-emerald-500/30 hover:text-white'
+                                                    ? 'bg-accent-soft text-accent-contrast border border-emerald-500/40'
+                                                    : 'bg-surface-1 text-content-secondary border border-line-subtle hover:border-accent/30 hover:text-content-primary'
                                             }`}
                                         >
                                             {isLinked && <Check size={12} className="inline mr-1.5" />}
@@ -254,14 +254,14 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                 })}
                             </div>
                             {habitSearch && searchedHabits.length === 0 && (
-                                <p className="text-xs text-neutral-500 py-2">
+                                <p className="text-xs text-content-muted py-2">
                                     No habits match &quot;{habitSearch}&quot;
                                 </p>
                             )}
                         </div>
                     )}
                     {filteredHabits.length === 0 && (
-                        <p className="text-xs text-neutral-500 bg-neutral-800/50 rounded-lg px-3 py-3">
+                        <p className="text-xs text-content-muted bg-surface-1/50 rounded-lg px-3 py-3">
                             No habits available{categoryId ? ' in this category' : ''}. Create habits first to link them to steps.
                         </p>
                     )}
@@ -269,11 +269,11 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
 
                 {/* Image */}
                 <div>
-                    <label className="block text-sm font-medium text-neutral-400 mb-2 flex items-center gap-1.5">
+                    <label className="block text-sm font-medium text-content-secondary mb-2 flex items-center gap-1.5">
                         <ImageIcon size={14} /> Step Image (Optional)
                     </label>
                     {step.imageUrl && (
-                        <div className="relative group w-full aspect-video bg-neutral-800 rounded-lg overflow-hidden border border-white/5 mb-2">
+                        <div className="relative group w-full aspect-video bg-surface-1 rounded-lg overflow-hidden border border-line-subtle mb-2">
                             <img
                                 src={step.imageUrl}
                                 alt="Step preview"
@@ -281,7 +281,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                             />
                             <button
                                 onClick={() => onChange({ imageUrl: undefined })}
-                                className="absolute top-2 right-2 p-1.5 bg-black/50 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/70"
+                                className="absolute top-2 right-2 p-1.5 bg-black/50 text-content-primary rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/70"
                                 title="Remove Image"
                             >
                                 <X size={14} />
@@ -293,7 +293,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                             type="button"
                             onClick={() => fileInputRef.current?.click()}
                             disabled={uploadingImage}
-                            className="flex items-center gap-2 px-4 py-2 bg-neutral-800 border border-white/10 rounded-lg text-sm text-neutral-300 hover:bg-neutral-700 transition-colors"
+                            className="flex items-center gap-2 px-4 py-2 bg-surface-1 border border-line-subtle rounded-lg text-sm text-content-secondary hover:bg-surface-2 transition-colors"
                         >
                             {uploadingImage ? (
                                 <Loader2 size={16} className="animate-spin text-emerald-500" />
@@ -312,30 +312,30 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                 e.target.value = '';
                             }}
                         />
-                        <span className="text-xs text-neutral-600">or</span>
+                        <span className="text-xs text-content-muted">or</span>
                         <input
                             type="text"
                             value={step.imageUrl || ''}
                             onChange={e => onChange({ imageUrl: e.target.value || undefined })}
                             placeholder="Paste image URL"
-                            className="flex-1 bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                            className="flex-1 bg-surface-1 border border-line-subtle rounded-lg px-3 py-2 text-sm text-content-primary focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                         />
                     </div>
                 </div>
 
                 {/* Tracking Fields */}
                 <div>
-                    <label className="block text-sm font-medium text-neutral-400 mb-2 flex items-center gap-1.5">
+                    <label className="block text-sm font-medium text-content-secondary mb-2 flex items-center gap-1.5">
                         <BarChart3 size={14} /> Tracking Fields (Optional)
                     </label>
-                    <p className="text-xs text-neutral-500 mb-3">
+                    <p className="text-xs text-content-muted mb-3">
                         Define fields to capture during execution (e.g., weight, reps, BPM).
                     </p>
                     <div className="space-y-2">
                         {(step.trackingFields || []).map((field: TrackingFieldDef) => (
                             <div
                                 key={field.id}
-                                className="flex items-center gap-2 bg-neutral-800 border border-white/10 rounded-lg p-3"
+                                className="flex items-center gap-2 bg-surface-1 border border-line-subtle rounded-lg p-3"
                             >
                                 <input
                                     type="text"
@@ -347,7 +347,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                         onChange({ trackingFields: updated });
                                     }}
                                     placeholder="Label (e.g., Weight)"
-                                    className="flex-1 bg-transparent text-sm text-white focus:outline-none placeholder-neutral-600"
+                                    className="flex-1 bg-transparent text-sm text-content-primary focus:outline-none placeholder-neutral-600"
                                 />
                                 <select
                                     value={field.type}
@@ -359,7 +359,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                         );
                                         onChange({ trackingFields: updated });
                                     }}
-                                    className="bg-neutral-900 border border-white/10 rounded px-2 py-1 text-xs text-neutral-300 focus:outline-none"
+                                    className="bg-surface-0 border border-line-subtle rounded px-2 py-1 text-xs text-content-secondary focus:outline-none"
                                 >
                                     <option value="number">Number</option>
                                     <option value="text">Text</option>
@@ -374,7 +374,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                         onChange({ trackingFields: updated });
                                     }}
                                     placeholder="Unit"
-                                    className="w-16 bg-transparent text-sm text-neutral-400 focus:outline-none placeholder-neutral-600"
+                                    className="w-16 bg-transparent text-sm text-content-secondary focus:outline-none placeholder-neutral-600"
                                 />
                                 <button
                                     type="button"
@@ -384,7 +384,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                         );
                                         onChange({ trackingFields: updated.length > 0 ? updated : undefined });
                                     }}
-                                    className="p-1 text-neutral-600 hover:text-red-400 transition-colors"
+                                    className="p-1 text-content-muted hover:text-red-400 transition-colors"
                                 >
                                     <X size={14} />
                                 </button>
@@ -402,7 +402,7 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                                     trackingFields: [...(step.trackingFields || []), newField],
                                 });
                             }}
-                            className="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-300 transition-colors py-2"
+                            className="flex items-center gap-1.5 text-sm text-content-muted hover:text-content-secondary transition-colors py-2"
                         >
                             <Plus size={14} /> Add tracking field
                         </button>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -60,16 +60,16 @@ const ToastItem = ({ toast, onDismiss }: { toast: Toast; onDismiss: (id: string)
             className={cn(
                 "pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-xl border shadow-lg backdrop-blur-sm",
                 "animate-in slide-in-from-right-5 fade-in duration-300 min-w-[260px] max-w-[380px]",
-                toast.type === 'success' && "bg-emerald-500/10 border-emerald-500/20 text-emerald-300",
-                toast.type === 'error' && "bg-red-500/10 border-red-500/20 text-red-300",
-                toast.type === 'info' && "bg-neutral-800 border-white/10 text-neutral-200",
+                toast.type === 'success' && "bg-accent-soft border-accent/20 text-accent-contrast",
+                toast.type === 'error' && "bg-danger-soft border-danger/30 text-danger-contrast",
+                toast.type === 'info' && "bg-surface-1 border-line-subtle text-content-primary",
             )}
         >
             <Icon size={18} className="flex-shrink-0" />
             <span className="text-sm font-medium flex-1">{toast.message}</span>
             <button
                 onClick={() => onDismiss(toast.id)}
-                className="flex-shrink-0 p-0.5 rounded hover:bg-white/10 transition-colors"
+                className="flex-shrink-0 p-0.5 rounded hover:bg-surface-2 transition-colors"
             >
                 <X size={14} />
             </button>

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -100,7 +100,7 @@ const HabitActionButtons = ({
                         e.stopPropagation();
                         onRunRoutine(linkedRoutines[0]);
                     }}
-                    className="p-1.5 rounded-lg hover:bg-neutral-800 text-emerald-500 hover:text-emerald-400 transition-colors"
+                    className="p-1.5 rounded-lg hover:bg-surface-1 text-emerald-500 hover:text-accent-contrast transition-colors"
                     title={`Run Routine: ${linkedRoutines[0].title}`}
                 >
                     <Play size={14} />
@@ -112,7 +112,7 @@ const HabitActionButtons = ({
                         e.stopPropagation();
                         onMoveToCategory();
                     }}
-                    className="p-1.5 rounded-lg hover:bg-neutral-800 text-neutral-500 hover:text-white transition-colors"
+                    className="p-1.5 rounded-lg hover:bg-surface-1 text-content-muted hover:text-content-primary transition-colors"
                     title="Move to Category"
                 >
                     <FolderInput size={14} />
@@ -124,7 +124,7 @@ const HabitActionButtons = ({
                         e.stopPropagation();
                         onAddToBundle();
                     }}
-                    className="p-1.5 rounded-lg hover:bg-neutral-800 text-neutral-500 hover:text-indigo-400 transition-colors"
+                    className="p-1.5 rounded-lg hover:bg-surface-1 text-content-muted hover:text-indigo-400 transition-colors"
                     title="Add to Bundle"
                 >
                     <Layers size={14} />
@@ -135,7 +135,7 @@ const HabitActionButtons = ({
                     e.stopPropagation();
                     onViewHistory();
                 }}
-                className="p-1.5 rounded-lg hover:bg-neutral-800 text-neutral-500 hover:text-white transition-colors"
+                className="p-1.5 rounded-lg hover:bg-surface-1 text-content-muted hover:text-content-primary transition-colors"
                 title="View History"
             >
                 <History size={14} />
@@ -145,7 +145,7 @@ const HabitActionButtons = ({
                     e.stopPropagation();
                     onEdit();
                 }}
-                className="p-1.5 rounded-lg hover:bg-neutral-800 text-neutral-500 hover:text-white transition-colors"
+                className="p-1.5 rounded-lg hover:bg-surface-1 text-content-muted hover:text-content-primary transition-colors"
                 title="Edit Habit"
             >
                 <Pencil size={14} />
@@ -169,7 +169,7 @@ const HabitActionButtons = ({
                     "p-1.5 rounded-lg transition-all",
                     deleteConfirmId === habit.id
                         ? "bg-red-500/20 text-red-400 opacity-100"
-                        : "hover:bg-neutral-800 text-neutral-500 hover:text-red-400"
+                        : "hover:bg-surface-1 text-content-muted hover:text-red-400"
                 )}
                 title={deleteConfirmId === habit.id ? "Click again to delete" : "Delete Habit"}
             >
@@ -261,14 +261,14 @@ const HabitRowContent = ({
             ref={setNodeRef}
             style={style}
             className={cn(
-                "flex border-b border-white/5 transition-colors group",
-                habit.isVirtual ? "bg-neutral-800/30" : "bg-neutral-900/50", // Difference for virtual
-                isDragging && "relative shadow-xl ring-1 ring-emerald-500/50 z-50 bg-neutral-900",
+                "flex border-b border-line-subtle transition-colors group",
+                habit.isVirtual ? "bg-surface-1/30" : "bg-surface-0/50", // Difference for virtual
+                isDragging && "relative shadow-xl ring-1 ring-focus/50 z-50 bg-surface-0",
             )}
             onContextMenu={(e) => onContextMenu(e, habit)}
         >
             <div
-                className="w-64 flex-shrink-0 p-4 border-r border-white/5 flex flex-col gap-1.5 transition-colors relative sticky left-0 z-20 bg-neutral-900 group-hover:bg-[#1a1a1a] after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10"
+                className="w-64 flex-shrink-0 p-4 border-r border-line-subtle flex flex-col gap-1.5 transition-colors relative sticky left-0 z-20 bg-surface-0 group-hover:bg-[#1a1a1a] after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10"
                 style={{ paddingLeft: `${16 + (depth * 24)}px` }} // Dynamic Indentation
             >
                 {/* Top row: drag handle + full habit name (no icons) */}
@@ -277,7 +277,7 @@ const HabitRowContent = ({
                         <button
                             {...attributes}
                             {...listeners}
-                            className="text-neutral-600 hover:text-neutral-400 cursor-grab active:cursor-grabbing p-1 -ml-2 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                            className="text-content-muted hover:text-content-secondary cursor-grab active:cursor-grabbing p-1 -ml-2 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
                             title="Drag to reorder"
                         >
                             <GripVertical size={16} />
@@ -286,7 +286,7 @@ const HabitRowContent = ({
                     <span
                         className={cn(
                             "font-medium transition-colors min-w-0 break-words line-clamp-2",
-                            (depth > 0 || habit.isVirtual) ? "text-neutral-400 italic text-sm" : "text-neutral-200"
+                            (depth > 0 || habit.isVirtual) ? "text-content-secondary italic text-sm" : "text-content-primary"
                         )}
                         title={habit.name}
                     >
@@ -338,7 +338,7 @@ const HabitRowContent = ({
                                 "w-12 h-1 rounded-full transition-all duration-300",
                                 isExpanded
                                     ? "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)]"
-                                    : "bg-neutral-700 hover:bg-blue-400"
+                                    : "bg-surface-2 hover:bg-blue-400"
                             )}
                         />
                     </div>
@@ -402,7 +402,7 @@ const HabitRowContent = ({
                     return (
                         <div
                             key={dateStr}
-                            className="w-16 flex-shrink-0 border-r border-white/5 flex items-center justify-center p-2"
+                            className="w-16 flex-shrink-0 border-r border-line-subtle flex items-center justify-center p-2"
                         >
                             <button
                                 onClick={habit.type === 'bundle' && habit.bundleType !== 'choice' ? handleBundleClick : (isInteractive ? (e) => handleCellClick(e, habit, dateStr, log) : undefined)}
@@ -415,16 +415,16 @@ const HabitRowContent = ({
                                 className={cn(
                                     "w-10 h-10 rounded-lg flex items-center justify-center transition-all duration-200 relative touch-manipulation",
                                     habit.type === 'bundle'
-                                        ? "bg-neutral-800 border border-white/5 hover:bg-neutral-700 text-neutral-200"
+                                        ? "bg-surface-1 border border-line-subtle hover:bg-surface-2 text-content-primary"
                                         : isFrozen
                                             ? "bg-sky-500/20 text-sky-400 border border-sky-500/30" // Frozen visual
                                             : isCompleted
-                                                ? "bg-emerald-500 text-neutral-900 shadow-[0_0_15px_rgba(16,185,129,0.4)] scale-90"
+                                                ? "bg-accent text-content-on-accent shadow-[0_0_15px_rgba(16,185,129,0.4)] scale-90"
                                                 : isPartial
-                                                    ? "bg-blue-500 text-neutral-900 shadow-[0_0_15px_rgba(59,130,246,0.4)] scale-95" // Partial
-                                                    : "bg-neutral-800/50 text-transparent hover:bg-neutral-800 hover:text-neutral-600 border border-white/5 hover:border-white/10",
+                                                    ? "bg-blue-500 text-content-on-accent shadow-[0_0_15px_rgba(59,130,246,0.4)] scale-95" // Partial
+                                                    : "bg-surface-1/50 text-transparent hover:bg-surface-1 hover:text-content-muted border border-line-subtle hover:border-line-subtle",
                                     !isInteractive && isCompleted && "opacity-80 cursor-default",
-                                    !isInteractive && "cursor-default hover:bg-neutral-800/50 hover:text-transparent",
+                                    !isInteractive && "cursor-default hover:bg-surface-1/50 hover:text-transparent",
                                     isDeleteMode && hasExistingEntry && "ring-1 ring-red-500/60"
                                 )}
                                 title={
@@ -441,7 +441,7 @@ const HabitRowContent = ({
                                     <>
                                         {/* Bundle Progress Background */}
                                         <div
-                                            className="absolute inset-0 bg-emerald-500/20 transition-all duration-500 pointer-events-none"
+                                            className="absolute inset-0 bg-accent-soft transition-all duration-500 pointer-events-none"
                                             style={{
                                                 height: `${getBundleStats(habit, logs, dateStr).percent}%`,
                                                 bottom: 0,
@@ -460,7 +460,7 @@ const HabitRowContent = ({
                                                         <span>{getBundleStats(habit, logs, dateStr).total}</span>
                                                     </>
                                                 ) : (
-                                                    <span className="text-neutral-600 opacity-0 hover:opacity-100 transition-opacity text-xs">+</span>
+                                                    <span className="text-content-muted opacity-0 hover:opacity-100 transition-opacity text-xs">+</span>
                                                 )
                                             )}
                                         </span>
@@ -1229,8 +1229,8 @@ export const TrackerGrid = ({
                     <div className="overflow-x-auto overscroll-x-contain [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
                         <div className="w-max min-w-full">
                             {/* Header */}
-                            <div className="sticky top-0 z-30 flex border-b border-white/5 bg-neutral-900 shadow-md">
-                                <div className="w-64 flex-shrink-0 p-4 font-medium text-emerald-400 border-r border-white/5 flex items-center justify-between bg-neutral-900 sticky left-0 z-40 group after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10">
+                            <div className="sticky top-0 z-30 flex border-b border-line-subtle bg-surface-0 shadow-md">
+                                <div className="w-64 flex-shrink-0 p-4 font-medium text-accent-contrast border-r border-line-subtle flex items-center justify-between bg-surface-0 sticky left-0 z-40 group after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10">
                                     <span>Daily Habits</span>
                                     <div className="flex items-center gap-1">
                                         <button
@@ -1239,7 +1239,7 @@ export const TrackerGrid = ({
                                                 "p-1.5 rounded-lg transition-colors",
                                                 deleteMode
                                                     ? "bg-red-500/20 text-red-400"
-                                                    : "hover:bg-neutral-800 text-neutral-500 hover:text-red-400"
+                                                    : "hover:bg-surface-1 text-content-muted hover:text-red-400"
                                             )}
                                             title={deleteMode ? 'Exit Delete Mode' : 'Enter Delete Mode (mobile-friendly)'}
                                         >
@@ -1247,19 +1247,19 @@ export const TrackerGrid = ({
                                         </button>
                                     </div>
                                 </div>
-                                <div className="flex bg-neutral-900">
+                                <div className="flex bg-surface-0">
                                     {dates.map((date) => (
                                         <div
                                             key={date.toISOString()}
                                             className={cn(
-                                                "w-16 flex-shrink-0 flex flex-col items-center justify-center p-2 border-r border-white/5 transition-colors",
-                                                isToday(date) ? "bg-emerald-500/10 text-emerald-400" : "text-neutral-500"
+                                                "w-16 flex-shrink-0 flex flex-col items-center justify-center p-2 border-r border-line-subtle transition-colors",
+                                                isToday(date) ? "bg-accent-soft text-accent-contrast" : "text-content-muted"
                                             )}
                                         >
                                             <span className="text-xs font-medium uppercase">{format(date, 'EEE')}</span>
                                             <span className={cn(
                                                 "text-lg font-bold w-8 h-8 flex items-center justify-center rounded-full mt-1",
-                                                isToday(date) && "bg-emerald-500 text-neutral-900"
+                                                isToday(date) && "bg-accent text-content-on-accent"
                                             )}>
                                                 {format(date, 'd')}
                                             </span>
@@ -1276,7 +1276,7 @@ export const TrackerGrid = ({
                             )}
                             <div className="flex-col">
                                 {loading ? (
-                                    <div className="flex items-center justify-center p-12 text-neutral-500 text-sm">Loading habits…</div>
+                                    <div className="flex items-center justify-center p-12 text-content-muted text-sm">Loading habits…</div>
                                 ) : dailyHabits.length > 0 ? (
                                     <SortableContext
                                         items={dailyHabits.map(h => h.id)}
@@ -1315,47 +1315,47 @@ export const TrackerGrid = ({
                                     <div className="sticky left-0 w-screen max-w-full flex flex-col items-center justify-center p-6 sm:p-8 text-center">
                                         <div className="max-w-sm mx-auto flex flex-col items-center">
                                         {/* The Rules — matching InfoModal style */}
-                                        <div className="w-full bg-emerald-500/5 border border-emerald-500/20 rounded-lg px-3 py-2.5 mb-5">
-                                            <p className="text-xs text-emerald-400 uppercase tracking-wide font-semibold mb-1.5">The Rules</p>
-                                            <ul className="space-y-0.5 text-sm text-neutral-300">
-                                                <li>Habits are <span className="text-emerald-400 font-medium">performed</span></li>
-                                                <li>Routines are <span className="text-emerald-400 font-medium">completed</span></li>
-                                                <li>Goals are <span className="text-emerald-400 font-medium">achieved</span></li>
+                                        <div className="w-full bg-emerald-500/5 border border-accent/20 rounded-lg px-3 py-2.5 mb-5">
+                                            <p className="text-xs text-accent-contrast uppercase tracking-wide font-semibold mb-1.5">The Rules</p>
+                                            <ul className="space-y-0.5 text-sm text-content-secondary">
+                                                <li>Habits are <span className="text-accent-contrast font-medium">performed</span></li>
+                                                <li>Routines are <span className="text-accent-contrast font-medium">completed</span></li>
+                                                <li>Goals are <span className="text-accent-contrast font-medium">achieved</span></li>
                                             </ul>
                                         </div>
 
                                         {/* Definitions — matching InfoModal structure */}
                                         <div className="w-full space-y-4 mb-6 text-left">
                                             <div className="pl-3 border-l-2 border-emerald-500/40">
-                                                <p className="text-sm text-neutral-200">
-                                                    <span className="font-bold text-emerald-400">Habit</span>
+                                                <p className="text-sm text-content-primary">
+                                                    <span className="font-bold text-accent-contrast">Habit</span>
                                                 </p>
-                                                <p className="text-sm text-neutral-400 mt-1">A repeated behavior performed over time. Each day, a habit is simply performed or not.</p>
+                                                <p className="text-sm text-content-secondary mt-1">A repeated behavior performed over time. Each day, a habit is simply performed or not.</p>
                                                 <div className="flex flex-wrap gap-1.5 mt-2">
                                                     {['Drink water', '10-minute walk', 'Read 5 pages'].map((ex) => (
-                                                        <span key={ex} className="px-2.5 py-0.5 text-xs text-neutral-400 bg-neutral-800/80 rounded-full border border-white/5">{ex}</span>
+                                                        <span key={ex} className="px-2.5 py-0.5 text-xs text-content-secondary bg-surface-1/80 rounded-full border border-line-subtle">{ex}</span>
                                                     ))}
                                                 </div>
                                             </div>
                                             <div className="pl-3 border-l-2 border-emerald-500/40">
-                                                <p className="text-sm text-neutral-200">
-                                                    <span className="font-bold text-emerald-400">Routine</span>
+                                                <p className="text-sm text-content-primary">
+                                                    <span className="font-bold text-accent-contrast">Routine</span>
                                                 </p>
-                                                <p className="text-sm text-neutral-400 mt-1">A group of habits performed together in a sequence.</p>
-                                                <p className="text-xs text-neutral-500 italic mt-1.5 pl-2">— "Morning Reset" — Stretch + Meditate + Review goals</p>
+                                                <p className="text-sm text-content-secondary mt-1">A group of habits performed together in a sequence.</p>
+                                                <p className="text-xs text-content-muted italic mt-1.5 pl-2">— "Morning Reset" — Stretch + Meditate + Review goals</p>
                                             </div>
                                             <div className="pl-3 border-l-2 border-emerald-500/40">
-                                                <p className="text-sm text-neutral-200">
-                                                    <span className="font-bold text-emerald-400">Goal</span>
+                                                <p className="text-sm text-content-primary">
+                                                    <span className="font-bold text-accent-contrast">Goal</span>
                                                 </p>
-                                                <p className="text-sm text-neutral-400 mt-1">An outcome achieved by consistently performing the habits that support it.</p>
-                                                <p className="text-xs text-neutral-500 italic mt-1.5 pl-2">— "Run a 10K" — supported by: Running habit</p>
+                                                <p className="text-sm text-content-secondary mt-1">An outcome achieved by consistently performing the habits that support it.</p>
+                                                <p className="text-xs text-content-muted italic mt-1.5 pl-2">— "Run a 10K" — supported by: Running habit</p>
                                             </div>
                                         </div>
 
                                         <button
                                             onClick={onAddHabit}
-                                            className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-medium rounded-lg transition-colors text-sm"
+                                            className="flex items-center gap-2 px-5 py-2.5 bg-accent hover:bg-accent-strong text-content-on-accent font-medium rounded-lg transition-colors text-sm"
                                         >
                                             Add Your First Habit
                                         </button>
@@ -1372,15 +1372,15 @@ export const TrackerGrid = ({
             {/* Delete Confirmation Modal */}
             {deleteConfirmId && (
                 <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-                    <div className="bg-neutral-900 border border-white/10 rounded-xl p-6 w-full max-w-sm shadow-xl">
-                        <h3 className="text-lg font-bold text-white mb-2">Delete Habit?</h3>
-                        <p className="text-neutral-400 mb-6 text-sm">
+                    <div className="bg-surface-0 border border-line-subtle rounded-xl p-6 w-full max-w-sm shadow-xl">
+                        <h3 className="text-lg font-bold text-content-primary mb-2">Delete Habit?</h3>
+                        <p className="text-content-secondary mb-6 text-sm">
                             Are you sure you want to delete this habit? This action cannot be undone and all history will be lost.
                         </p>
                         <div className="flex gap-3 justify-end">
                             <button
                                 onClick={() => setDeleteConfirmId(null)}
-                                className="px-4 py-2 text-sm font-medium text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+                                className="px-4 py-2 text-sm font-medium text-content-secondary hover:text-content-primary hover:bg-surface-2 rounded-lg transition-colors"
                             >
                                 Cancel
                             </button>
@@ -1391,7 +1391,7 @@ export const TrackerGrid = ({
                                         setDeleteConfirmId(null);
                                     }
                                 }}
-                                className="px-4 py-2 text-sm font-medium text-white bg-red-500/10 text-red-500 hover:bg-red-500/20 border border-red-500/20 rounded-lg transition-colors"
+                                className="px-4 py-2 text-sm font-medium text-content-primary bg-red-500/10 text-red-500 hover:bg-red-500/20 border border-red-500/20 rounded-lg transition-colors"
                             >
                                 Delete
                             </button>
@@ -1450,7 +1450,7 @@ export const TrackerGrid = ({
             {/* Context Menu */}
             {contextMenu && (
                 <div
-                    className="fixed z-50 bg-neutral-800 border border-white/10 rounded-lg shadow-xl p-1 min-w-[160px] animate-in fade-in zoom-in-95 duration-100"
+                    className="fixed z-50 bg-surface-1 border border-line-subtle rounded-lg shadow-xl p-1 min-w-[160px] animate-in fade-in zoom-in-95 duration-100"
                     style={{ top: contextMenu.y, left: contextMenu.x }}
                     onClick={(e) => e.stopPropagation()}
                 >
@@ -1461,7 +1461,7 @@ export const TrackerGrid = ({
 
                         return (
                             <div className="flex flex-col gap-1">
-                                <div className="px-2 py-1.5 text-xs font-semibold text-neutral-500 border-b border-white/5 mb-1">
+                                <div className="px-2 py-1.5 text-xs font-semibold text-content-muted border-b border-line-subtle mb-1">
                                     {habit.name}
                                 </div>
                                 {linked.map(routine => (
@@ -1471,7 +1471,7 @@ export const TrackerGrid = ({
                                             onRunRoutine?.(routine);
                                             setContextMenu(null);
                                         }}
-                                        className="flex items-center gap-2 px-2 py-1.5 text-sm text-emerald-400 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                        className="flex items-center gap-2 px-2 py-1.5 text-sm text-accent-contrast hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                     >
                                         <Play size={14} /> Start {routine.title}
                                     </button>
@@ -1482,7 +1482,7 @@ export const TrackerGrid = ({
                                         onEditHabit(habit);
                                         setContextMenu(null);
                                     }}
-                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-content-secondary hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                 >
                                     <Link2 size={14} /> {linked.length > 0 ? 'Edit Links...' : 'Link Routine...'}
                                 </button>
@@ -1492,7 +1492,7 @@ export const TrackerGrid = ({
                                         setCategoryPickerHabit(habit);
                                         setContextMenu(null);
                                     }}
-                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-content-secondary hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                 >
                                     <FolderInput size={14} /> Move to Category…
                                 </button>
@@ -1503,7 +1503,7 @@ export const TrackerGrid = ({
                                             setBundlePickerHabit(habit);
                                             setContextMenu(null);
                                         }}
-                                        className="flex items-center gap-2 px-2 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                        className="flex items-center gap-2 px-2 py-1.5 text-sm text-content-secondary hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                     >
                                         <Layers size={14} /> Add to Bundle…
                                     </button>
@@ -1515,7 +1515,7 @@ export const TrackerGrid = ({
                                             onConvertToBundle(habit);
                                             setContextMenu(null);
                                         }}
-                                        className="flex items-center gap-2 px-2 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                        className="flex items-center gap-2 px-2 py-1.5 text-sm text-content-secondary hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                     >
                                         <Layers size={14} /> Convert to Bundle…
                                     </button>
@@ -1526,7 +1526,7 @@ export const TrackerGrid = ({
                                         onViewHistory(habit);
                                         setContextMenu(null);
                                     }}
-                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-content-secondary hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                 >
                                     <History size={14} /> View History
                                 </button>
@@ -1536,7 +1536,7 @@ export const TrackerGrid = ({
                                         onEditHabit(habit);
                                         setContextMenu(null);
                                     }}
-                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded transition-colors text-left w-full"
+                                    className="flex items-center gap-2 px-2 py-1.5 text-sm text-content-secondary hover:bg-surface-2/50 rounded transition-colors text-left w-full"
                                 >
                                     <Pencil size={14} /> Edit Habit
                                 </button>

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -268,7 +268,7 @@ const HabitRowContent = ({
             onContextMenu={(e) => onContextMenu(e, habit)}
         >
             <div
-                className="w-64 flex-shrink-0 p-4 border-r border-line-subtle flex flex-col gap-1.5 transition-colors relative sticky left-0 z-20 bg-surface-0 group-hover:bg-[#1a1a1a] after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10"
+                className="w-64 flex-shrink-0 p-4 border-r border-line-subtle flex flex-col gap-1.5 transition-colors relative sticky left-0 z-20 bg-surface-0 group-hover:bg-surface-1 after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-surface-2"
                 style={{ paddingLeft: `${16 + (depth * 24)}px` }} // Dynamic Indentation
             >
                 {/* Top row: drag handle + full habit name (no icons) */}
@@ -456,7 +456,7 @@ const HabitRowContent = ({
                                                 getBundleStats(habit, logs, dateStr).completed > 0 ? (
                                                     <>
                                                         <span>{getBundleStats(habit, logs, dateStr).completed}</span>
-                                                        <span className="w-full h-[1px] bg-neutral-500/50 my-[1px]" />
+                                                        <span className="w-full h-[1px] bg-content-muted/50 my-[1px]" />
                                                         <span>{getBundleStats(habit, logs, dateStr).total}</span>
                                                     </>
                                                 ) : (
@@ -1225,12 +1225,12 @@ export const TrackerGrid = ({
                 collisionDetection={closestCenter}
                 onDragEnd={handleDragEnd}
             >
-                <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-neutral-700 scrollbar-track-transparent">
+                <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-line-strong scrollbar-track-transparent">
                     <div className="overflow-x-auto overscroll-x-contain [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
                         <div className="w-max min-w-full">
                             {/* Header */}
                             <div className="sticky top-0 z-30 flex border-b border-line-subtle bg-surface-0 shadow-md">
-                                <div className="w-64 flex-shrink-0 p-4 font-medium text-accent-contrast border-r border-line-subtle flex items-center justify-between bg-surface-0 sticky left-0 z-40 group after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10">
+                                <div className="w-64 flex-shrink-0 p-4 font-medium text-accent-contrast border-r border-line-subtle flex items-center justify-between bg-surface-0 sticky left-0 z-40 group after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-surface-2">
                                     <span>Daily Habits</span>
                                     <div className="flex items-center gap-1">
                                         <button

--- a/src/components/TrackingFieldInput.tsx
+++ b/src/components/TrackingFieldInput.tsx
@@ -10,7 +10,7 @@ interface TrackingFieldInputProps {
 export const TrackingFieldInput: React.FC<TrackingFieldInputProps> = ({ field, value, onChange }) => {
     return (
         <div className="flex items-center gap-3">
-            <label className="text-sm text-neutral-400 min-w-[80px] shrink-0">
+            <label className="text-sm text-content-secondary min-w-[80px] shrink-0">
                 {field.label}
             </label>
             <div className="flex-1 flex items-center gap-2">
@@ -28,7 +28,7 @@ export const TrackingFieldInput: React.FC<TrackingFieldInputProps> = ({ field, v
                             const num = parseFloat(raw);
                             onChange(isNaN(num) ? raw : num);
                         }}
-                        className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-emerald-500 placeholder-neutral-600 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        className="w-full bg-surface-0 border border-line-subtle rounded-lg px-3 py-2 text-content-primary text-sm focus:outline-none focus:border-emerald-500 placeholder-neutral-600 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                         placeholder={field.defaultValue !== undefined ? String(field.defaultValue) : '0'}
                     />
                 ) : (
@@ -36,12 +36,12 @@ export const TrackingFieldInput: React.FC<TrackingFieldInputProps> = ({ field, v
                         type="text"
                         value={value ?? ''}
                         onChange={e => onChange(e.target.value)}
-                        className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                        className="w-full bg-surface-0 border border-line-subtle rounded-lg px-3 py-2 text-content-primary text-sm focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                         placeholder={field.defaultValue !== undefined ? String(field.defaultValue) : ''}
                     />
                 )}
                 {field.unit && (
-                    <span className="text-xs text-neutral-500 shrink-0">{field.unit}</span>
+                    <span className="text-xs text-content-muted shrink-0">{field.unit}</span>
                 )}
             </div>
         </div>

--- a/src/components/VariantCard.tsx
+++ b/src/components/VariantCard.tsx
@@ -18,8 +18,8 @@ export const VariantCard: React.FC<VariantCardProps> = ({ variant, isSelected, o
             onClick={onClick}
             className={`w-full text-left p-4 rounded-xl border transition-all ${
                 isSelected
-                    ? 'border-emerald-500 bg-emerald-500/10 ring-1 ring-emerald-500/30'
-                    : 'border-white/10 bg-neutral-800/50 hover:border-white/20 hover:bg-neutral-800'
+                    ? 'border-emerald-500 bg-accent-soft ring-1 ring-focus/30'
+                    : 'border-line-subtle bg-surface-1/50 hover:border-line-strong hover:bg-surface-1'
             }`}
             role="option"
             aria-selected={isSelected}
@@ -27,7 +27,7 @@ export const VariantCard: React.FC<VariantCardProps> = ({ variant, isSelected, o
             <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                        <h4 className={`font-medium truncate ${isSelected ? 'text-emerald-400' : 'text-white'}`}>
+                        <h4 className={`font-medium truncate ${isSelected ? 'text-accent-contrast' : 'text-content-primary'}`}>
                             {variant.name}
                         </h4>
                         {variant.isAiGenerated && (
@@ -35,14 +35,14 @@ export const VariantCard: React.FC<VariantCardProps> = ({ variant, isSelected, o
                         )}
                     </div>
                     {variant.description && (
-                        <p className="text-xs text-neutral-500 mt-1 line-clamp-2">{variant.description}</p>
+                        <p className="text-xs text-content-muted mt-1 line-clamp-2">{variant.description}</p>
                     )}
                 </div>
                 <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
                     {onEdit && (
                         <button
                             onClick={(e) => { e.stopPropagation(); onEdit(); }}
-                            className="p-1 rounded text-neutral-500 hover:text-white hover:bg-neutral-700 transition-colors"
+                            className="p-1 rounded text-content-muted hover:text-content-primary hover:bg-surface-2 transition-colors"
                             aria-label={`Edit ${variant.name}`}
                             title="Edit variant"
                         >
@@ -50,7 +50,7 @@ export const VariantCard: React.FC<VariantCardProps> = ({ variant, isSelected, o
                         </button>
                     )}
                     <div className={`w-4 h-4 rounded-full border-2 ${
-                        isSelected ? 'border-emerald-500 bg-emerald-500' : 'border-neutral-600'
+                        isSelected ? 'border-emerald-500 bg-emerald-500' : 'border-line-strong'
                     }`}>
                         {isSelected && (
                             <div className="w-full h-full flex items-center justify-center">
@@ -60,7 +60,7 @@ export const VariantCard: React.FC<VariantCardProps> = ({ variant, isSelected, o
                     </div>
                 </div>
             </div>
-            <div className="flex items-center gap-3 mt-3 text-xs text-neutral-500">
+            <div className="flex items-center gap-3 mt-3 text-xs text-content-muted">
                 <span className="flex items-center gap-1">
                     <ListChecks size={12} />
                     {variant.steps.length} steps

--- a/src/components/VariantEditor.tsx
+++ b/src/components/VariantEditor.tsx
@@ -97,17 +97,17 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
             <div className="space-y-3">
                 <div className="flex gap-4">
                     <div className="flex-1">
-                        <label className="block text-xs font-medium text-neutral-500 mb-1">Variant Name</label>
+                        <label className="block text-xs font-medium text-content-muted mb-1">Variant Name</label>
                         <input
                             type="text"
                             value={variant.name}
                             onChange={e => updateVariantField({ name: e.target.value })}
-                            className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                            className="w-full bg-surface-0 border border-line-subtle rounded-lg px-3 py-2 text-content-primary focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                             placeholder="e.g., Quick, Standard, Deep"
                         />
                     </div>
                     <div className="w-28">
-                        <label className="block text-xs font-medium text-neutral-500 mb-1">Duration (min)</label>
+                        <label className="block text-xs font-medium text-content-muted mb-1">Duration (min)</label>
                         <input
                             type="number"
                             min="1"
@@ -126,7 +126,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                     updateVariantField({ estimatedDurationMinutes: 1 });
                                 }
                             }}
-                            className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                            className="w-full bg-surface-0 border border-line-subtle rounded-lg px-3 py-2 text-sm text-content-primary focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                             placeholder="15"
                         />
                     </div>
@@ -135,15 +135,15 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                     type="text"
                     value={variant.description || ''}
                     onChange={e => updateVariantField({ description: e.target.value || undefined })}
-                    className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-2 text-sm text-neutral-400 focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
+                    className="w-full bg-surface-0 border border-line-subtle rounded-lg px-3 py-2 text-sm text-content-secondary focus:outline-none focus:border-emerald-500 placeholder-neutral-600"
                     placeholder="Description (optional)"
                 />
             </div>
 
             {/* Steps Header */}
             <div className="flex items-center justify-between">
-                <label className="text-sm font-medium text-neutral-400">
-                    Steps {steps.length > 0 && <span className="text-neutral-600">({steps.length})</span>}
+                <label className="text-sm font-medium text-content-secondary">
+                    Steps {steps.length > 0 && <span className="text-content-muted">({steps.length})</span>}
                 </label>
             </div>
 
@@ -158,11 +158,11 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                     return (
                         <div
                             key={step.id}
-                            className="group bg-neutral-800/50 border border-white/5 rounded-xl overflow-hidden hover:border-white/10 transition-all"
+                            className="group bg-surface-1/50 border border-line-subtle rounded-xl overflow-hidden hover:border-line-subtle transition-all"
                         >
                             <div className="flex items-center gap-3 p-3">
                                 {/* Step number */}
-                                <div className="w-7 h-7 rounded-full bg-white/5 flex items-center justify-center text-xs text-neutral-500 flex-shrink-0">
+                                <div className="w-7 h-7 rounded-full bg-white/5 flex items-center justify-center text-xs text-content-muted flex-shrink-0">
                                     {index + 1}
                                 </div>
 
@@ -172,18 +172,18 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                     onClick={() => setEditingStepId(step.id)}
                                     className="flex-1 text-left min-w-0"
                                 >
-                                    <div className="font-medium text-white truncate text-sm">
-                                        {step.title || <span className="text-neutral-500 italic">Untitled Step</span>}
+                                    <div className="font-medium text-content-primary truncate text-sm">
+                                        {step.title || <span className="text-content-muted italic">Untitled Step</span>}
                                     </div>
                                     {/* Badges row */}
                                     <div className="flex items-center gap-2 mt-1 flex-wrap">
                                         {linkedHabit && (
-                                            <span className="inline-flex items-center gap-1 text-[11px] text-emerald-400 bg-emerald-500/10 rounded-full px-2 py-0.5">
+                                            <span className="inline-flex items-center gap-1 text-[11px] text-accent-contrast bg-accent-soft rounded-full px-2 py-0.5">
                                                 <Link2 size={10} /> {linkedHabit.name}
                                             </span>
                                         )}
                                         {hasTimer && (
-                                            <span className="inline-flex items-center gap-1 text-[11px] text-neutral-400 bg-white/5 rounded-full px-2 py-0.5">
+                                            <span className="inline-flex items-center gap-1 text-[11px] text-content-secondary bg-white/5 rounded-full px-2 py-0.5">
                                                 {step.timerMode === 'stopwatch' ? <Timer size={10} /> : <Clock size={10} />}
                                                 {step.timerMode === 'stopwatch'
                                                     ? 'Stopwatch'
@@ -193,7 +193,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                             </span>
                                         )}
                                         {step.trackingFields && step.trackingFields.length > 0 && (
-                                            <span className="inline-flex items-center gap-1 text-[11px] text-neutral-400 bg-white/5 rounded-full px-2 py-0.5">
+                                            <span className="inline-flex items-center gap-1 text-[11px] text-content-secondary bg-white/5 rounded-full px-2 py-0.5">
                                                 {step.trackingFields.length} field{step.trackingFields.length > 1 ? 's' : ''}
                                             </span>
                                         )}
@@ -205,7 +205,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                     <button
                                         type="button"
                                         onClick={() => moveStep(index, -1)}
-                                        className="p-1.5 text-neutral-500 hover:text-white transition-colors disabled:opacity-20"
+                                        className="p-1.5 text-content-muted hover:text-content-primary transition-colors disabled:opacity-20"
                                         title="Move Up"
                                         disabled={index === 0}
                                     >
@@ -214,7 +214,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                     <button
                                         type="button"
                                         onClick={() => moveStep(index, 1)}
-                                        className="p-1.5 text-neutral-500 hover:text-white transition-colors disabled:opacity-20"
+                                        className="p-1.5 text-content-muted hover:text-content-primary transition-colors disabled:opacity-20"
                                         title="Move Down"
                                         disabled={index === steps.length - 1}
                                     >
@@ -223,7 +223,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                                     <button
                                         type="button"
                                         onClick={() => removeStep(step.id)}
-                                        className="p-1.5 text-neutral-500 hover:text-red-400 transition-colors"
+                                        className="p-1.5 text-content-muted hover:text-red-400 transition-colors"
                                         title="Delete Step"
                                     >
                                         <Trash2 size={14} />
@@ -238,7 +238,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
                 <button
                     type="button"
                     onClick={addStep}
-                    className="w-full flex items-center justify-center gap-2 p-4 border-2 border-dashed border-neutral-700 hover:border-emerald-500/50 rounded-xl text-neutral-400 hover:text-emerald-400 transition-all"
+                    className="w-full flex items-center justify-center gap-2 p-4 border-2 border-dashed border-line-strong hover:border-emerald-500/50 rounded-xl text-content-secondary hover:text-accent-contrast transition-all"
                 >
                     <Plus size={18} />
                     <span className="text-sm font-medium">Add Step</span>
@@ -247,7 +247,7 @@ export const VariantEditor: React.FC<VariantEditorProps> = ({
 
             {/* Delete Variant */}
             {onDelete && (
-                <div className="pt-2 border-t border-white/5">
+                <div className="pt-2 border-t border-line-subtle">
                     <button
                         type="button"
                         onClick={onDelete}

--- a/src/components/WeeklyHabitCard.tsx
+++ b/src/components/WeeklyHabitCard.tsx
@@ -83,8 +83,8 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                     <div className={cn(
                         "w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all",
                         isCompleted
-                            ? "bg-emerald-500 border-emerald-500 text-neutral-900"
-                            : "border-line-strong hover:border-emerald-500/50"
+                            ? "bg-accent border-accent text-content-on-accent"
+                            : "border-line-strong hover:border-accent/50"
                     )}>
                         {isCompleted && <Check size={14} strokeWidth={3} />}
                     </div>
@@ -98,7 +98,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                                 className={cn(
                                     "w-3 h-8 rounded-full transition-all",
                                     i < currentCount
-                                        ? "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]"
+                                        ? "bg-accent shadow-[0_0_8px_rgba(16,185,129,0.4)]"
                                         : "bg-surface-1 border border-line-subtle"
                                 )}
                             />
@@ -144,7 +144,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
             className={cn(
                 "group relative flex flex-col gap-4 p-5 rounded-2xl border transition-all cursor-pointer select-none min-h-[160px]",
                 isCompleted
-                    ? "bg-surface-0/80 border-accent/30 hover:border-emerald-500/50"
+                    ? "bg-surface-0/80 border-accent/30 hover:border-accent/50"
                     : "bg-surface-0 border-line-subtle hover:bg-surface-1 hover:border-line-subtle"
             )}
         >
@@ -181,7 +181,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                     </button>
                     <button
                         onClick={(e) => { e.stopPropagation(); onDelete(habit); }}
-                        className="p-1.5 hover:bg-red-500/10 rounded-lg text-content-secondary hover:text-red-400"
+                        className="p-1.5 hover:bg-danger-soft rounded-lg text-content-secondary hover:text-danger-contrast"
                         title="Delete"
                     >
                         <Trash2 size={14} />

--- a/src/components/WeeklyHabitCard.tsx
+++ b/src/components/WeeklyHabitCard.tsx
@@ -84,7 +84,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                         "w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all",
                         isCompleted
                             ? "bg-emerald-500 border-emerald-500 text-neutral-900"
-                            : "border-neutral-600 hover:border-emerald-500/50"
+                            : "border-line-strong hover:border-emerald-500/50"
                     )}>
                         {isCompleted && <Check size={14} strokeWidth={3} />}
                     </div>
@@ -99,7 +99,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                                     "w-3 h-8 rounded-full transition-all",
                                     i < currentCount
                                         ? "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]"
-                                        : "bg-neutral-800 border border-white/10"
+                                        : "bg-surface-1 border border-line-subtle"
                                 )}
                             />
                         ))}
@@ -108,11 +108,11 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
             case 'quantity':
                 return (
                     <div className="w-full space-y-2">
-                        <div className="flex justify-between text-xs text-neutral-400">
+                        <div className="flex justify-between text-xs text-content-secondary">
                             <span>{currentCount} {habit.goal.unit}</span>
                             <span>{target} {habit.goal.unit}</span>
                         </div>
-                        <div className="w-full h-2 bg-neutral-800 rounded-full overflow-hidden">
+                        <div className="w-full h-2 bg-surface-1 rounded-full overflow-hidden">
                             <div
                                 className="h-full bg-emerald-500 transition-all duration-500"
                                 style={{ width: `${progressPercent}%` }}
@@ -124,7 +124,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
     };
 
     const getHelperText = () => {
-        if (isCompleted) return <span className="text-emerald-400">Done for the week!</span>;
+        if (isCompleted) return <span className="text-accent-contrast">Done for the week!</span>;
         switch (intentType) {
             case 'binary': return "Not done yet this week";
             case 'frequency': return `${currentCount} of ${target} sessions`;
@@ -144,15 +144,15 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
             className={cn(
                 "group relative flex flex-col gap-4 p-5 rounded-2xl border transition-all cursor-pointer select-none min-h-[160px]",
                 isCompleted
-                    ? "bg-neutral-900/80 border-emerald-500/30 hover:border-emerald-500/50"
-                    : "bg-neutral-900 border-white/5 hover:bg-neutral-800 hover:border-white/10"
+                    ? "bg-surface-0/80 border-accent/30 hover:border-emerald-500/50"
+                    : "bg-surface-0 border-line-subtle hover:bg-surface-1 hover:border-line-subtle"
             )}
         >
             <div className="flex justify-between items-start">
                 <div className="space-y-1">
                     <h4 className={cn(
                         "font-medium text-lg transition-colors line-clamp-2",
-                        isCompleted ? "text-emerald-400" : "text-neutral-200"
+                        isCompleted ? "text-accent-contrast" : "text-content-primary"
                     )}>
                         {habit.name}
                     </h4>
@@ -167,21 +167,21 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                 <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button
                         onClick={(e) => { e.stopPropagation(); onViewHistory(habit); }}
-                        className="p-1.5 hover:bg-white/10 rounded-lg text-neutral-400 hover:text-white"
+                        className="p-1.5 hover:bg-surface-2 rounded-lg text-content-secondary hover:text-content-primary"
                         title="History"
                     >
                         <History size={14} />
                     </button>
                     <button
                         onClick={(e) => { e.stopPropagation(); onEdit(habit); }}
-                        className="p-1.5 hover:bg-white/10 rounded-lg text-neutral-400 hover:text-white"
+                        className="p-1.5 hover:bg-surface-2 rounded-lg text-content-secondary hover:text-content-primary"
                         title="Edit"
                     >
                         <Edit2 size={14} />
                     </button>
                     <button
                         onClick={(e) => { e.stopPropagation(); onDelete(habit); }}
-                        className="p-1.5 hover:bg-red-500/10 rounded-lg text-neutral-400 hover:text-red-400"
+                        className="p-1.5 hover:bg-red-500/10 rounded-lg text-content-secondary hover:text-red-400"
                         title="Delete"
                     >
                         <Trash2 size={14} />
@@ -193,7 +193,7 @@ export const WeeklyHabitCard: React.FC<WeeklyHabitCardProps> = ({
                 {renderIndicator()}
             </div>
 
-            <div className="mt-2 flex justify-between items-center text-xs text-neutral-500 font-medium">
+            <div className="mt-2 flex justify-between items-center text-xs text-content-muted font-medium">
                 <div className="flex items-center gap-2">
                     {potentialEvidence && !isCompleted && (
                         <Zap size={12} className="text-purple-400 fill-purple-400 animate-pulse" />

--- a/src/components/WeeklyHabitEditModal.tsx
+++ b/src/components/WeeklyHabitEditModal.tsx
@@ -100,7 +100,7 @@ export const WeeklyHabitEditModal: React.FC<WeeklyHabitEditModalProps> = ({ habi
                                 type="time"
                                 value={time}
                                 onChange={(e) => setTime(e.target.value)}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white focus:border-emerald-500 focus:outline-none transition-colors"
+                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white focus:border-focus focus:outline-none transition-colors"
                             />
                         </div>
                         <div className="space-y-2">
@@ -113,7 +113,7 @@ export const WeeklyHabitEditModal: React.FC<WeeklyHabitEditModalProps> = ({ habi
                                 onChange={(e) => setDuration(Number(e.target.value))}
                                 min="5"
                                 step="5"
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white focus:border-emerald-500 focus:outline-none transition-colors"
+                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white focus:border-focus focus:outline-none transition-colors"
                             />
                         </div>
                     </div>
@@ -160,7 +160,7 @@ export const WeeklyHabitEditModal: React.FC<WeeklyHabitEditModalProps> = ({ habi
                     <button
                         onClick={handleSave}
                         disabled={isSaving}
-                        className="bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-bold py-2 px-6 rounded-xl transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="bg-emerald-500 hover:bg-accent-strong text-content-on-accent font-bold py-2 px-6 rounded-xl transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         {isSaving ? 'Saving...' : (
                             <>

--- a/src/components/YearHeatmapGrid.tsx
+++ b/src/components/YearHeatmapGrid.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useHabitStore } from '../store/HabitContext';
-import { getHeatmapColor } from '../utils/analytics';
+import { getHeatmapColor } from '../theme/heatmap';
+import { useTheme } from '../theme/ThemeContext';
+import { useThemeColors } from '../theme/useThemeColors';
 import { getBundleChildIds, isHabitComplete } from '../utils/habitUtils';
 import { eachDayOfInterval, subDays, format, getDay, startOfWeek, endOfWeek, isSameMonth } from 'date-fns';
 import { Tooltip } from 'react-tooltip';
@@ -12,6 +14,8 @@ interface YearHeatmapGridProps {
 
 export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ habits }) => {
     const { logs, extendLogWindow } = useHabitStore();
+    const { resolvedMode } = useTheme();
+    const themeColors = useThemeColors();
 
     // On mount, extend the log window to cover a full year if needed.
     // The initial load only fetches 90 days; the year heatmap needs 365.
@@ -135,13 +139,13 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
                 <div className="h-6" />
 
                 {/* Day Labels (Sun-Sat) */}
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">S</div>
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">M</div>
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">T</div>
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">W</div>
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">T</div>
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">F</div>
-                <div className="text-[10px] text-neutral-500 font-medium flex items-center justify-end pr-2">S</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">S</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">M</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">T</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">W</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">T</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">F</div>
+                <div className="text-[10px] text-content-muted font-medium flex items-center justify-end pr-2">S</div>
 
                 {/* Data Columns */}
                 {weeks.map((week, wIndex) => {
@@ -154,7 +158,7 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
                             {/* Row 0: Month Label Slot */}
                             <div className="h-6 relative">
                                 {label && (
-                                    <span className="absolute bottom-1 left-0 text-[10px] text-neutral-500 font-medium whitespace-nowrap z-10">
+                                    <span className="absolute bottom-1 left-0 text-[10px] text-content-muted font-medium whitespace-nowrap z-10">
                                         {label.text}
                                     </span>
                                 )}
@@ -166,7 +170,8 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
                                     key={day.date.toISOString()}
                                     data-tooltip-id="heatmap-tooltip"
                                     data-tooltip-content={`${format(day.date, 'MMM d, yyyy')}: ${day.count} completions across ${day.categoryCount} categories`}
-                                    className={`aspect-square w-full rounded-sm ${getHeatmapColor(day.intensity)} transition-all hover:ring-1 hover:ring-white/50`}
+                                    className="aspect-square w-full rounded-sm transition-all hover:ring-1 hover:ring-focus/50"
+                                    style={{ background: getHeatmapColor(day.intensity, resolvedMode) }}
                                 />
                             ))}
                         </React.Fragment>
@@ -177,7 +182,11 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
             <div className="mt-4">
                 <HeatmapLegend />
             </div>
-            <Tooltip id="heatmap-tooltip" className="z-50 !bg-neutral-800 !text-white !opacity-100 !rounded-lg !px-3 !py-1 !text-xs" />
+            <Tooltip
+                id="heatmap-tooltip"
+                className="z-50 !opacity-100 !rounded-lg !px-3 !py-1 !text-xs"
+                style={{ background: themeColors.chartTooltipBg, color: themeColors.contentPrimary, border: `1px solid ${themeColors.lineSubtle}` }}
+            />
         </div>
     );
 });

--- a/src/components/dashboard/DailyCheckInCard.tsx
+++ b/src/components/dashboard/DailyCheckInCard.tsx
@@ -9,7 +9,7 @@ interface DailyCheckInCardProps {
 }
 
 const METRIC_ICONS: Record<string, { icon: React.FC<{ size?: number; className?: string }>; color: string }> = {
-    energy: { icon: Battery, color: 'text-emerald-400' },
+    energy: { icon: Battery, color: 'text-accent-contrast' },
     calm: { icon: Droplets, color: 'text-sky-400' },
     stress: { icon: Droplets, color: 'text-rose-400' },
     focus: { icon: Brain, color: 'text-violet-400' },
@@ -68,11 +68,11 @@ export const DailyCheckInCard: React.FC<DailyCheckInCardProps> = ({ onOpenCheckI
         return (
             <button
                 onClick={onOpenCheckIn}
-                className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm text-left w-full hover:bg-neutral-800/50 transition-colors"
+                className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm text-left w-full hover:bg-surface-1/50 transition-colors"
             >
                 <div className="flex items-center gap-2 mb-2">
-                    <CheckCircle2 size={16} className="text-emerald-400" />
-                    <span className="text-xs font-medium text-emerald-400">{sessionLabel} check-in</span>
+                    <CheckCircle2 size={16} className="text-accent-contrast" />
+                    <span className="text-xs font-medium text-accent-contrast">{sessionLabel} check-in</span>
                 </div>
                 {summaryMetrics.length > 0 && (
                     <div className="flex flex-wrap gap-2">
@@ -82,11 +82,11 @@ export const DailyCheckInCard: React.FC<DailyCheckInCardProps> = ({ onOpenCheckI
                             return (
                                 <span
                                     key={label}
-                                    className="flex items-center gap-1 px-2 py-0.5 bg-neutral-800 rounded-md text-[11px] text-neutral-300"
+                                    className="flex items-center gap-1 px-2 py-0.5 bg-surface-1 rounded-md text-[11px] text-content-secondary"
                                 >
                                     {IconComp && <IconComp size={11} className={meta.color} />}
-                                    <span className="text-white font-medium">{value}</span>
-                                    <span className="text-neutral-600">/{max}</span>
+                                    <span className="text-content-primary font-medium">{value}</span>
+                                    <span className="text-content-muted">/{max}</span>
                                 </span>
                             );
                         })}
@@ -104,18 +104,18 @@ export const DailyCheckInCard: React.FC<DailyCheckInCardProps> = ({ onOpenCheckI
     return (
         <button
             onClick={onOpenCheckIn}
-            className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm text-left w-full hover:bg-neutral-800/50 transition-colors group"
+            className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm text-left w-full hover:bg-surface-1/50 transition-colors group"
         >
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                    <div className={`p-2 rounded-xl bg-neutral-800 ${iconColor}`}>
+                    <div className={`p-2 rounded-xl bg-surface-1 ${iconColor}`}>
                         <Icon size={20} />
                     </div>
                     <div>
-                        <p className="text-sm font-medium text-white">{ctaLabel}</p>
+                        <p className="text-sm font-medium text-content-primary">{ctaLabel}</p>
                     </div>
                 </div>
-                <ChevronRight size={16} className="text-neutral-600 group-hover:text-neutral-400 transition-colors" />
+                <ChevronRight size={16} className="text-content-muted group-hover:text-content-secondary transition-colors" />
             </div>
         </button>
     );

--- a/src/components/dashboard/DailyOverviewCard.tsx
+++ b/src/components/dashboard/DailyOverviewCard.tsx
@@ -25,7 +25,7 @@ const CompletionRing: React.FC<{ completed: number; total: number; size?: number
                 />
             </svg>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
-                <span className="text-lg font-bold text-white leading-none">{completed}/{total}</span>
+                <span className="text-lg font-bold text-content-primary leading-none">{completed}/{total}</span>
             </div>
         </div>
     );
@@ -42,9 +42,9 @@ export const DailyOverviewCard: React.FC = () => {
     );
 
     return (
-        <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm flex flex-col items-center justify-center">
+        <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm flex flex-col items-center justify-center">
             <CompletionRing completed={completedCount} total={totalCount} />
-            <span className="text-[11px] text-neutral-400 font-medium mt-1.5">Daily Habits</span>
+            <span className="text-[11px] text-content-secondary font-medium mt-1.5">Daily Habits</span>
         </div>
     );
 };

--- a/src/components/dashboard/JournalCard.tsx
+++ b/src/components/dashboard/JournalCard.tsx
@@ -6,29 +6,29 @@ interface JournalCardProps {
 
 export const JournalCard: React.FC<JournalCardProps> = ({ onNavigateToJournal }) => {
     return (
-        <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm">
-            <p className="text-xs font-medium text-neutral-400 mb-3">Journal</p>
+        <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm">
+            <p className="text-xs font-medium text-content-secondary mb-3">Journal</p>
             <div className="flex items-center justify-around">
                 <button
                     onClick={onNavigateToJournal}
-                    className="flex flex-col items-center gap-1.5 p-2 rounded-xl hover:bg-neutral-800/50 transition-colors min-w-[48px]"
+                    className="flex flex-col items-center gap-1.5 p-2 rounded-xl hover:bg-surface-1/50 transition-colors min-w-[48px]"
                 >
-                    <PenLine size={18} className="text-emerald-400" />
-                    <span className="text-[10px] text-neutral-500">Free</span>
+                    <PenLine size={18} className="text-accent-contrast" />
+                    <span className="text-[10px] text-content-muted">Free</span>
                 </button>
                 <button
                     onClick={onNavigateToJournal}
-                    className="flex flex-col items-center gap-1.5 p-2 rounded-xl hover:bg-neutral-800/50 transition-colors min-w-[48px]"
+                    className="flex flex-col items-center gap-1.5 p-2 rounded-xl hover:bg-surface-1/50 transition-colors min-w-[48px]"
                 >
-                    <LayoutTemplate size={18} className="text-emerald-400" />
-                    <span className="text-[10px] text-neutral-500">Template</span>
+                    <LayoutTemplate size={18} className="text-accent-contrast" />
+                    <span className="text-[10px] text-content-muted">Template</span>
                 </button>
                 <button
                     onClick={onNavigateToJournal}
-                    className="flex flex-col items-center gap-1.5 p-2 rounded-xl hover:bg-neutral-800/50 transition-colors min-w-[48px]"
+                    className="flex flex-col items-center gap-1.5 p-2 rounded-xl hover:bg-surface-1/50 transition-colors min-w-[48px]"
                 >
-                    <Clock size={18} className="text-emerald-400" />
-                    <span className="text-[10px] text-neutral-500">History</span>
+                    <Clock size={18} className="text-accent-contrast" />
+                    <span className="text-[10px] text-content-muted">History</span>
                 </button>
             </div>
         </div>

--- a/src/components/dashboard/PinnedRoutinesCard.tsx
+++ b/src/components/dashboard/PinnedRoutinesCard.tsx
@@ -35,8 +35,8 @@ const ICON_OPTIONS = [
 ] as const;
 
 const COLOR_OPTIONS = [
-    { key: 'neutral', class: 'bg-neutral-500', text: 'text-neutral-500' },
-    { key: 'emerald', class: 'bg-emerald-500', text: 'text-emerald-400' },
+    { key: 'neutral', class: 'bg-neutral-500', text: 'text-content-muted' },
+    { key: 'emerald', class: 'bg-emerald-500', text: 'text-accent-contrast' },
     { key: 'blue', class: 'bg-blue-500', text: 'text-blue-400' },
     { key: 'purple', class: 'bg-purple-500', text: 'text-purple-400' },
     { key: 'amber', class: 'bg-amber-500', text: 'text-amber-400' },
@@ -52,7 +52,7 @@ function getIconComponent(key?: string) {
 
 function getColorTextClass(key?: string) {
     const match = COLOR_OPTIONS.find(o => o.key === key);
-    return match?.text ?? 'text-neutral-500';
+    return match?.text ?? 'text-content-muted';
 }
 
 function readLocalStorageIds(): string[] {
@@ -157,11 +157,11 @@ const CustomizePopover: React.FC<{
     return (
         <div
             ref={ref}
-            className="absolute right-0 top-full mt-1 z-50 bg-neutral-800 border border-white/10 rounded-xl p-3 shadow-xl w-64"
+            className="absolute right-0 top-full mt-1 z-50 bg-surface-1 border border-line-subtle rounded-xl p-3 shadow-xl w-64"
         >
             {/* Colors */}
             <div className="mb-3">
-                <span className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium">Color</span>
+                <span className="text-[10px] uppercase tracking-wider text-content-muted font-medium">Color</span>
                 <div className="flex flex-wrap gap-2 mt-1.5">
                     {COLOR_OPTIONS.map(c => (
                         <button
@@ -177,7 +177,7 @@ const CustomizePopover: React.FC<{
 
             {/* Icons */}
             <div className="mb-3">
-                <span className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium">Icon</span>
+                <span className="text-[10px] uppercase tracking-wider text-content-muted font-medium">Icon</span>
                 <div className="grid grid-cols-8 gap-1.5 mt-1.5">
                     {ICON_OPTIONS.map(({ key, icon: Icon }) => (
                         <button
@@ -185,8 +185,8 @@ const CustomizePopover: React.FC<{
                             onClick={() => setSelectedIcon(key)}
                             className={`w-7 h-7 flex items-center justify-center rounded-md transition-all ${
                                 selectedIcon === key
-                                    ? 'bg-neutral-600 text-white'
-                                    : 'text-neutral-400 hover:bg-neutral-700 hover:text-white'
+                                    ? 'bg-surface-2 text-content-primary'
+                                    : 'text-content-secondary hover:bg-surface-2 hover:text-content-primary'
                             }`}
                             title={key}
                         >
@@ -202,8 +202,8 @@ const CustomizePopover: React.FC<{
                 disabled={!hasChanges || saving}
                 className={`w-full flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
                     hasChanges && !saving
-                        ? 'bg-emerald-500 text-white hover:bg-emerald-400'
-                        : 'bg-neutral-700 text-neutral-500 cursor-not-allowed'
+                        ? 'bg-emerald-500 text-content-primary hover:bg-accent-strong'
+                        : 'bg-surface-2 text-content-muted cursor-not-allowed'
                 }`}
             >
                 <Check size={12} />
@@ -266,24 +266,24 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
 
     if (pinnedRoutines.length === 0 && !showManage) {
         return (
-            <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm">
+            <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm">
                 <div className="flex items-center justify-between mb-3">
-                    <h3 className="text-sm font-semibold text-white">Pinned Routines</h3>
+                    <h3 className="text-sm font-semibold text-content-primary">Pinned Routines</h3>
                     <button
                         onClick={() => setShowManage(true)}
-                        className="text-[11px] text-emerald-400 hover:text-emerald-300 transition-colors"
+                        className="text-[11px] text-accent-contrast hover:text-accent-contrast transition-colors"
                     >
                         Manage
                     </button>
                 </div>
-                <p className="text-xs text-neutral-500">
+                <p className="text-xs text-content-muted">
                     Pin routines to see them here.
                     {onViewAllRoutines && (
                         <>
                             {' '}
                             <button
                                 onClick={onViewAllRoutines}
-                                className="text-emerald-500 hover:text-emerald-400 transition-colors"
+                                className="text-emerald-500 hover:text-accent-contrast transition-colors"
                             >
                                 View routines
                             </button>
@@ -295,23 +295,23 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
     }
 
     return (
-        <div className={`bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm${customizingId ? ' relative z-10' : ''}`}>
+        <div className={`bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm${customizingId ? ' relative z-10' : ''}`}>
             <div className="flex items-center justify-between mb-3">
-                <h3 className="text-sm font-semibold text-white">Pinned Routines</h3>
+                <h3 className="text-sm font-semibold text-content-primary">Pinned Routines</h3>
                 <div className="flex items-center gap-2">
                     <button
                         onClick={() => {
                             setShowManage(s => !s);
                             setCustomizingId(null);
                         }}
-                        className={`text-[11px] transition-colors ${showManage ? 'text-white' : 'text-emerald-400 hover:text-emerald-300'}`}
+                        className={`text-[11px] transition-colors ${showManage ? 'text-content-primary' : 'text-accent-contrast hover:text-accent-contrast'}`}
                     >
                         {showManage ? 'Done' : 'Manage'}
                     </button>
                     {onViewAllRoutines && (
                         <button
                             onClick={onViewAllRoutines}
-                            className="text-[11px] text-neutral-500 hover:text-white transition-colors"
+                            className="text-[11px] text-content-muted hover:text-content-primary transition-colors"
                         >
                             View all
                         </button>
@@ -325,20 +325,20 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
                         <div key={routine.id} className="relative flex items-center gap-2">
                             <button
                                 onClick={() => togglePin(routine.id)}
-                                className="flex items-center gap-3 flex-1 px-3 py-2.5 rounded-lg hover:bg-neutral-800/50 transition-colors text-left min-h-[44px]"
+                                className="flex items-center gap-3 flex-1 px-3 py-2.5 rounded-lg hover:bg-surface-1/50 transition-colors text-left min-h-[44px]"
                             >
                                 <Pin
                                     size={14}
-                                    className={isPinned(routine.id) ? 'text-emerald-400' : 'text-neutral-600'}
+                                    className={isPinned(routine.id) ? 'text-accent-contrast' : 'text-content-muted'}
                                     fill={isPinned(routine.id) ? 'currentColor' : 'none'}
                                 />
-                                <span className={`text-sm ${isPinned(routine.id) ? 'text-white' : 'text-neutral-400'}`}>
+                                <span className={`text-sm ${isPinned(routine.id) ? 'text-content-primary' : 'text-content-secondary'}`}>
                                     {routine.title}
                                 </span>
                             </button>
                             <button
                                 onClick={() => setCustomizingId(customizingId === routine.id ? null : routine.id)}
-                                className="p-2 rounded-md hover:bg-neutral-700 transition-colors text-neutral-500 hover:text-white flex-shrink-0"
+                                className="p-2 rounded-md hover:bg-surface-2 transition-colors text-content-muted hover:text-content-primary flex-shrink-0"
                                 title="Customize icon & color"
                             >
                                 <Palette size={14} />
@@ -361,7 +361,7 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
                         const IconComp = getIconComponent(routine.icon);
                         const colorClass = routine.color
                             ? getColorTextClass(routine.color)
-                            : (done ? 'text-emerald-400' : 'text-neutral-500');
+                            : (done ? 'text-accent-contrast' : 'text-content-muted');
                         const hasMultiple = isMultiVariant(routine);
                         const defaultVariant = resolveVariant(routine);
                         const resolvedSteps = defaultVariant?.steps || routine.steps || [];
@@ -380,15 +380,15 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
                             <button
                                 key={routine.id}
                                 onClick={handleClick}
-                                className="flex items-center justify-between w-full px-3 py-2.5 rounded-lg hover:bg-neutral-800/50 transition-colors min-h-[44px]"
+                                className="flex items-center justify-between w-full px-3 py-2.5 rounded-lg hover:bg-surface-1/50 transition-colors min-h-[44px]"
                             >
                                 <div className="flex items-center gap-3 min-w-0">
                                     {done ? (
-                                        <CheckCircle2 size={16} className="text-emerald-400 flex-shrink-0" />
+                                        <CheckCircle2 size={16} className="text-accent-contrast flex-shrink-0" />
                                     ) : (
                                         <IconComp size={14} className={`${colorClass} flex-shrink-0`} />
                                     )}
-                                    <span className={`text-sm truncate ${done ? 'text-neutral-500' : 'text-white'}`}>
+                                    <span className={`text-sm truncate ${done ? 'text-content-muted' : 'text-content-primary'}`}>
                                         {routine.title}
                                         {done && completionInfo.variantName && (
                                             <span className="text-emerald-500/60 ml-1">({completionInfo.variantName})</span>
@@ -396,7 +396,7 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
                                     </span>
                                 </div>
                                 <div className="flex items-center gap-2 flex-shrink-0 ml-3">
-                                    <span className="text-[11px] text-neutral-600">
+                                    <span className="text-[11px] text-content-muted">
                                         {resolvedSteps.length} steps
                                     </span>
                                     {hasMultiple && !done && (
@@ -406,9 +406,9 @@ export const PinnedRoutinesCard: React.FC<PinnedRoutinesCardProps> = ({
                                         </span>
                                     )}
                                     {done ? (
-                                        <span className="text-[11px] text-emerald-400 font-medium">Done</span>
+                                        <span className="text-[11px] text-accent-contrast font-medium">Done</span>
                                     ) : (
-                                        <ChevronRight size={14} className="text-neutral-600" />
+                                        <ChevronRight size={14} className="text-content-muted" />
                                     )}
                                 </div>
                             </button>

--- a/src/components/dashboard/SetupDashboard.tsx
+++ b/src/components/dashboard/SetupDashboard.tsx
@@ -78,7 +78,7 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
     <div className="flex flex-col gap-6 pb-8">
       {/* Welcome Header */}
       <div className="text-center pt-4">
-        <div className="w-12 h-12 mx-auto bg-gradient-to-br from-emerald-400 to-cyan-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-emerald-500/20">
+        <div className="w-12 h-12 mx-auto bg-gradient-to-br from-emerald-400 to-cyan-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-accent/20">
           <Sparkles size={24} className="text-content-primary" />
         </div>
         <h2 className="text-2xl font-bold text-content-primary mb-2">Welcome to HabitFlow</h2>
@@ -116,7 +116,7 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
       {firstIncomplete && (
         <button
           onClick={() => onNavigate(firstIncomplete.route)}
-          className="mx-auto px-8 py-3 bg-accent hover:bg-accent-strong text-neutral-900 font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-emerald-500/20"
+          className="mx-auto px-8 py-3 bg-accent hover:bg-accent-strong text-content-on-accent font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-accent/20"
         >
           {completedCount === 0 ? 'Start Setup' : 'Continue Setup'}
         </button>

--- a/src/components/dashboard/SetupDashboard.tsx
+++ b/src/components/dashboard/SetupDashboard.tsx
@@ -116,7 +116,7 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
       {firstIncomplete && (
         <button
           onClick={() => onNavigate(firstIncomplete.route)}
-          className="mx-auto px-8 py-3 bg-emerald-500 hover:bg-accent-strong text-neutral-900 font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-emerald-500/20"
+          className="mx-auto px-8 py-3 bg-accent hover:bg-accent-strong text-neutral-900 font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-emerald-500/20"
         >
           {completedCount === 0 ? 'Start Setup' : 'Continue Setup'}
         </button>

--- a/src/components/dashboard/SetupDashboard.tsx
+++ b/src/components/dashboard/SetupDashboard.tsx
@@ -79,10 +79,10 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
       {/* Welcome Header */}
       <div className="text-center pt-4">
         <div className="w-12 h-12 mx-auto bg-gradient-to-br from-emerald-400 to-cyan-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-emerald-500/20">
-          <Sparkles size={24} className="text-white" />
+          <Sparkles size={24} className="text-content-primary" />
         </div>
-        <h2 className="text-2xl font-bold text-white mb-2">Welcome to HabitFlow</h2>
-        <p className="text-neutral-400 text-sm">
+        <h2 className="text-2xl font-bold text-content-primary mb-2">Welcome to HabitFlow</h2>
+        <p className="text-content-secondary text-sm">
           Let's get you set up in a few quick steps.
         </p>
       </div>
@@ -94,19 +94,19 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
             <div
               key={i}
               className={`w-8 h-1 rounded-full transition-colors ${
-                step.completed ? 'bg-emerald-500' : 'bg-neutral-700'
+                step.completed ? 'bg-emerald-500' : 'bg-surface-2'
               }`}
             />
           ))}
         </div>
-        <span className="text-xs text-neutral-500 ml-2">{completedCount}/{steps.length}</span>
+        <span className="text-xs text-content-muted ml-2">{completedCount}/{steps.length}</span>
       </div>
 
       {/* Skip guide */}
       <div className="flex justify-center">
         <button
           onClick={onDismiss}
-          className="text-xs text-neutral-600 hover:text-neutral-400 transition-colors"
+          className="text-xs text-content-muted hover:text-content-secondary transition-colors"
         >
           Skip guide
         </button>
@@ -116,7 +116,7 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
       {firstIncomplete && (
         <button
           onClick={() => onNavigate(firstIncomplete.route)}
-          className="mx-auto px-8 py-3 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-emerald-500/20"
+          className="mx-auto px-8 py-3 bg-emerald-500 hover:bg-accent-strong text-neutral-900 font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-emerald-500/20"
         >
           {completedCount === 0 ? 'Start Setup' : 'Continue Setup'}
         </button>
@@ -132,37 +132,37 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
               onClick={() => onNavigate(step.route)}
               className={`w-full text-left p-4 rounded-xl border transition-all ${
                 step.completed
-                  ? 'bg-emerald-500/5 border-emerald-500/20'
-                  : 'bg-neutral-800/50 border-white/5 hover:border-white/10 hover:bg-neutral-800'
+                  ? 'bg-emerald-500/5 border-accent/20'
+                  : 'bg-surface-1/50 border-line-subtle hover:border-line-subtle hover:bg-surface-1'
               }`}
             >
               <div className="flex items-start gap-3">
                 <div className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5 ${
                   step.completed
-                    ? 'bg-emerald-500/20'
-                    : 'bg-neutral-700/50'
+                    ? 'bg-accent-soft'
+                    : 'bg-surface-2/50'
                 }`}>
                   {step.completed ? (
-                    <Check size={16} className="text-emerald-400" />
+                    <Check size={16} className="text-accent-contrast" />
                   ) : (
-                    <Icon size={16} className="text-neutral-400" />
+                    <Icon size={16} className="text-content-secondary" />
                   )}
                 </div>
 
                 <div className="flex-1 min-w-0">
                   <h3 className={`text-sm font-medium mb-0.5 ${
-                    step.completed ? 'text-emerald-300' : 'text-white'
+                    step.completed ? 'text-accent-contrast' : 'text-content-primary'
                   }`}>
                     {step.title}
                   </h3>
-                  <p className="text-xs text-neutral-500 mb-2">
+                  <p className="text-xs text-content-muted mb-2">
                     {step.description}
                   </p>
                   <div className="flex flex-wrap gap-1.5">
                     {step.examples.map((ex) => (
                       <span
                         key={ex}
-                        className="px-2 py-0.5 text-[11px] text-neutral-500 bg-neutral-800/60 rounded-full border border-white/5"
+                        className="px-2 py-0.5 text-[11px] text-content-muted bg-surface-1/60 rounded-full border border-line-subtle"
                       >
                         {ex}
                       </span>
@@ -178,9 +178,9 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
       {/* All done message */}
       {completedCount === steps.length && (
         <div className="text-center py-4">
-          <p className="text-emerald-400 text-sm font-medium mb-1">You're all set!</p>
-          <p className="text-neutral-500 text-xs">Your dashboard will fill in as you use HabitFlow.</p>
-          <p className="text-neutral-600 text-xs mt-1">You can reopen this guide anytime from Settings.</p>
+          <p className="text-accent-contrast text-sm font-medium mb-1">You're all set!</p>
+          <p className="text-content-muted text-xs">Your dashboard will fill in as you use HabitFlow.</p>
+          <p className="text-content-muted text-xs mt-1">You can reopen this guide anytime from Settings.</p>
         </div>
       )}
     </div>

--- a/src/components/dashboard/TasksCard.tsx
+++ b/src/components/dashboard/TasksCard.tsx
@@ -14,9 +14,9 @@ export const TasksCard: React.FC<TasksCardProps> = ({ onNavigateToTasks }) => {
 
     if (loading) {
         return (
-            <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm animate-pulse">
-                <div className="h-4 w-20 bg-neutral-800 rounded mb-2" />
-                <div className="h-3 w-16 bg-neutral-800 rounded" />
+            <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm animate-pulse">
+                <div className="h-4 w-20 bg-surface-1 rounded mb-2" />
+                <div className="h-3 w-16 bg-surface-1 rounded" />
             </div>
         );
     }
@@ -24,22 +24,22 @@ export const TasksCard: React.FC<TasksCardProps> = ({ onNavigateToTasks }) => {
     return (
         <button
             onClick={onNavigateToTasks}
-            className="bg-neutral-900/50 rounded-2xl border border-white/5 p-4 backdrop-blur-sm text-left w-full hover:bg-neutral-800/50 transition-colors group"
+            className="bg-surface-0/50 rounded-2xl border border-line-subtle p-4 backdrop-blur-sm text-left w-full hover:bg-surface-1/50 transition-colors group"
         >
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-xl bg-neutral-800 text-blue-400">
+                    <div className="p-2 rounded-xl bg-surface-1 text-blue-400">
                         <CheckSquare size={20} />
                     </div>
                     <div>
-                        <p className="text-sm font-medium text-white">
+                        <p className="text-sm font-medium text-content-primary">
                             {totalCount === 0
                                 ? 'Tasks'
                                 : `${completedCount}/${totalCount} tasks`}
                         </p>
                     </div>
                 </div>
-                <ChevronRight size={16} className="text-neutral-600 group-hover:text-neutral-400 transition-colors" />
+                <ChevronRight size={16} className="text-content-muted group-hover:text-content-secondary transition-colors" />
             </div>
         </button>
     );

--- a/src/components/dashboard/WeeklySummaryCard.tsx
+++ b/src/components/dashboard/WeeklySummaryCard.tsx
@@ -31,17 +31,17 @@ export const WeeklySummaryCard: React.FC = () => {
   }
 
   return (
-    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
+    <div className="bg-surface-0/50 rounded-2xl border border-line-subtle p-6 backdrop-blur-sm">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <Sparkles size={18} className="text-purple-400" />
-          <h3 className="text-lg font-semibold text-white">AI Weekly Summary</h3>
+          <h3 className="text-lg font-semibold text-content-primary">AI Weekly Summary</h3>
         </div>
         <div className="flex items-center gap-2">
           {summary && (
             <button
               onClick={() => setExpanded(!expanded)}
-              className="p-1.5 text-neutral-500 hover:text-white rounded-lg hover:bg-white/5 transition-colors"
+              className="p-1.5 text-content-muted hover:text-content-primary rounded-lg hover:bg-surface-2 transition-colors"
               aria-label={expanded ? 'Collapse' : 'Expand'}
             >
               {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
@@ -54,7 +54,7 @@ export const WeeklySummaryCard: React.FC = () => {
                 setPeriod(null);
                 setError(null);
               }}
-              className="p-1.5 text-neutral-500 hover:text-white rounded-lg hover:bg-white/5 transition-colors"
+              className="p-1.5 text-content-muted hover:text-content-primary rounded-lg hover:bg-surface-2 transition-colors"
               aria-label="Dismiss"
             >
               <X size={16} />
@@ -65,12 +65,12 @@ export const WeeklySummaryCard: React.FC = () => {
 
       {!summary && !loading && !error && (
         <div>
-          <p className="text-sm text-neutral-400 mb-4">
+          <p className="text-sm text-content-secondary mb-4">
             Generate a personalized summary of your past week's habits and journal entries.
           </p>
           <button
             onClick={handleGenerate}
-            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-purple-600/80 text-white hover:bg-purple-600 text-sm font-medium transition-colors"
+            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-purple-600/80 text-content-primary hover:bg-purple-600 text-sm font-medium transition-colors"
           >
             <Sparkles size={14} />
             Generate Weekly Summary
@@ -81,7 +81,7 @@ export const WeeklySummaryCard: React.FC = () => {
       {loading && (
         <div className="flex items-center gap-3 py-4">
           <Loader2 size={18} className="text-purple-400 animate-spin" />
-          <span className="text-sm text-neutral-400">Analyzing your week...</span>
+          <span className="text-sm text-content-secondary">Analyzing your week...</span>
         </div>
       )}
 
@@ -102,11 +102,11 @@ export const WeeklySummaryCard: React.FC = () => {
       {summary && expanded && (
         <div className="space-y-3">
           {period && (
-            <p className="text-[11px] text-neutral-500">
+            <p className="text-[11px] text-content-muted">
               {period.start} to {period.end}
             </p>
           )}
-          <div className="prose prose-sm prose-invert max-w-none text-neutral-300 leading-relaxed [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-white [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-white [&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-neutral-200 [&_strong]:text-white [&_ul]:space-y-1 [&_li]:text-sm">
+          <div className="prose prose-sm prose-invert max-w-none text-content-secondary leading-relaxed [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-content-primary [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-content-primary [&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-content-primary [&_strong]:text-content-primary [&_ul]:space-y-1 [&_li]:text-sm">
             {summary.split('\n').map((line, i) => {
               if (!line.trim()) return <br key={i} />;
               // Basic markdown rendering for bold and headers
@@ -121,7 +121,7 @@ export const WeeklySummaryCard: React.FC = () => {
               );
             })}
           </div>
-          <div className="pt-2 border-t border-white/5">
+          <div className="pt-2 border-t border-line-subtle">
             <button
               onClick={handleGenerate}
               className="text-xs text-purple-400 hover:text-purple-300 transition-colors"

--- a/src/components/day-view/DayCategorySection.tsx
+++ b/src/components/day-view/DayCategorySection.tsx
@@ -113,7 +113,7 @@ export const DayCategorySection = ({
                 {dragHandleProps && (
                     <div
                         {...dragHandleProps}
-                        className="p-1 cursor-grab active:cursor-grabbing text-neutral-600 hover:text-neutral-400 transition-colors touch-none"
+                        className="p-1 cursor-grab active:cursor-grabbing text-content-muted hover:text-content-secondary transition-colors touch-none"
                     >
                         <GripVertical size={18} />
                     </div>
@@ -146,13 +146,13 @@ export const DayCategorySection = ({
                 })()}
 
                 {allDone && (
-                    <span className="ml-auto flex items-center gap-1 text-xs text-emerald-500 font-medium bg-emerald-500/10 px-2 py-0.5 rounded-full">
+                    <span className="ml-auto flex items-center gap-1 text-xs text-emerald-500 font-medium bg-accent-soft px-2 py-0.5 rounded-full">
                         <CheckCircle2 size={12} />
                         All Done
                     </span>
                 )}
                 {!allDone && (
-                    <span className="ml-auto text-xs text-neutral-600">
+                    <span className="ml-auto text-xs text-content-muted">
                         {completedCount}/{habits.length}
                     </span>
                 )}

--- a/src/components/day-view/DayHabitRow.tsx
+++ b/src/components/day-view/DayHabitRow.tsx
@@ -71,8 +71,8 @@ export const DayHabitRow = ({
                     className={cn(
                         "flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all duration-300",
                         isCompleted
-                            ? "bg-emerald-500 border-emerald-500 text-neutral-900 scale-100"
-                            : "border-line-strong text-transparent hover:border-emerald-500/50 scale-95 hover:scale-100"
+                            ? "bg-accent border-accent text-content-on-accent scale-100"
+                            : "border-line-strong text-transparent hover:border-accent/50 scale-95 hover:scale-100"
                     )}
                 >
                     <Check size={14} strokeWidth={3} />

--- a/src/components/day-view/DayHabitRow.tsx
+++ b/src/components/day-view/DayHabitRow.tsx
@@ -50,7 +50,7 @@ export const DayHabitRow = ({
 
     return (
         <div
-            className="group relative flex flex-col bg-neutral-900/40 border border-white/5 rounded-xl transition-all hover:bg-neutral-800/40 hover:border-white/10 mb-2 overflow-hidden"
+            className="group relative flex flex-col bg-surface-0/40 border border-line-subtle rounded-xl transition-all hover:bg-surface-1/40 hover:border-line-subtle mb-2 overflow-hidden"
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
@@ -72,7 +72,7 @@ export const DayHabitRow = ({
                         "flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all duration-300",
                         isCompleted
                             ? "bg-emerald-500 border-emerald-500 text-neutral-900 scale-100"
-                            : "border-white/20 text-transparent hover:border-emerald-500/50 scale-95 hover:scale-100"
+                            : "border-line-strong text-transparent hover:border-emerald-500/50 scale-95 hover:scale-100"
                     )}
                 >
                     <Check size={14} strokeWidth={3} />
@@ -82,20 +82,20 @@ export const DayHabitRow = ({
                 <div className="flex-1 flex flex-col justify-center min-w-0">
                     <span className={cn(
                         "text-base font-medium truncate transition-colors",
-                        isCompleted ? "text-neutral-500 line-through decoration-white/20" : "text-neutral-200"
+                        isCompleted ? "text-content-muted line-through decoration-white/20" : "text-content-primary"
                     )}>
                         {habit.name}
                     </span>
 
                     {/* Metadata Row */}
-                    <div className="flex items-center gap-3 mt-0.5 text-xs text-neutral-500">
+                    <div className="flex items-center gap-3 mt-0.5 text-xs text-content-muted">
                         {/* Linked Goal Trophy */}
                         {habit.linkedGoalId && (
                             <Trophy size={12} className="flex-shrink-0 text-amber-500" />
                         )}
                         {/* Goal Indicator */}
                         {habit.goal && (
-                            <div className="flex items-center gap-1 hover:text-neutral-300 transition-colors cursor-help" title={`Goal: ${habit.goal.target ?? 1} ${habit.goal.unit ?? 'times'} (${habit.goal.frequency})`}>
+                            <div className="flex items-center gap-1 hover:text-content-secondary transition-colors cursor-help" title={`Goal: ${habit.goal.target ?? 1} ${habit.goal.unit ?? 'times'} (${habit.goal.frequency})`}>
                                 {habit.goal.type === 'number'
                                     ? <Hash size={12} className="text-sky-400" />
                                     : <Target size={12} className="text-emerald-500" />}
@@ -104,7 +104,7 @@ export const DayHabitRow = ({
 
                         {/* Time Estimate */}
                         <div
-                            className="flex items-center gap-1 hover:text-neutral-300 transition-colors cursor-pointer"
+                            className="flex items-center gap-1 hover:text-content-secondary transition-colors cursor-pointer"
                             onClick={() => setIsEditingTime(true)}
                         >
                             <Clock size={12} />
@@ -112,7 +112,7 @@ export const DayHabitRow = ({
                                 <input
                                     autoFocus
                                     type="number"
-                                    className="w-12 bg-neutral-800 text-white rounded px-1 py-0.5 text-xs border border-white/10 focus:outline-none focus:border-emerald-500"
+                                    className="w-12 bg-surface-1 text-content-primary rounded px-1 py-0.5 text-xs border border-line-subtle focus:outline-none focus:border-emerald-500"
                                     value={timeInput}
                                     onChange={(e) => setTimeInput(e.target.value)}
                                     onBlur={handleTimeSubmit}
@@ -134,8 +134,8 @@ export const DayHabitRow = ({
                     <button
                         onClick={() => onPin(habit.id)}
                         className={cn(
-                            "p-2 rounded-lg transition-colors hover:bg-white/10",
-                            habit.pinned ? "text-blue-400" : "text-neutral-500 hover:text-white"
+                            "p-2 rounded-lg transition-colors hover:bg-surface-2",
+                            habit.pinned ? "text-blue-400" : "text-content-muted hover:text-content-primary"
                         )}
                         title={habit.pinned ? "Unpin from Today's Focus" : "Pin to Today's Focus"}
                     >
@@ -144,7 +144,7 @@ export const DayHabitRow = ({
                     {isChecklistBundle && (
                         <button
                             onClick={() => setIsExpanded(!isExpanded)}
-                            className="p-2 rounded-lg text-neutral-500 hover:text-white hover:bg-white/10 transition-colors"
+                            className="p-2 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-2 transition-colors"
                         >
                             {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                         </button>
@@ -154,17 +154,17 @@ export const DayHabitRow = ({
 
             {/* Checklist Bundle Children */}
             {isChecklistBundle && isExpanded && subHabits && (
-                <div className="flex flex-col border-t border-white/5 bg-neutral-900/30">
+                <div className="flex flex-col border-t border-line-subtle bg-surface-0/30">
                     {subHabits.map(child => (
                         // Reusing simplified logic for children, or recursively render row? 
                         // For MVP simple rendering is safer.
-                        <div key={child.id} className="flex items-center gap-3 p-3 pl-12 border-b border-white/5 last:border-0 hover:bg-white/[0.02] transition-colors">
+                        <div key={child.id} className="flex items-center gap-3 p-3 pl-12 border-b border-line-subtle last:border-0 hover:bg-white/[0.02] transition-colors">
                             {/* Child actions would need to be passed down or handled via context in parent */}
-                            <span className="text-sm text-neutral-400">{child.name}</span>
+                            <span className="text-sm text-content-secondary">{child.name}</span>
                         </div>
                     ))}
                     {(!subHabits || subHabits.length === 0) && (
-                        <div className="p-3 pl-12 text-xs text-neutral-600 italic">No items in bundle</div>
+                        <div className="p-3 pl-12 text-xs text-content-muted italic">No items in bundle</div>
                     )}
                 </div>
             )}
@@ -179,8 +179,8 @@ export const DayHabitRow = ({
                             className={cn(
                                 "px-3 py-1.5 rounded-md text-xs font-medium border transition-all",
                                 selectedChoice === option.key
-                                    ? "bg-emerald-500/20 text-emerald-300 border-emerald-500/50"
-                                    : "bg-neutral-800 text-neutral-400 border-white/5 hover:border-white/20 hover:text-white"
+                                    ? "bg-accent-soft text-accent-contrast border-emerald-500/50"
+                                    : "bg-surface-1 text-content-secondary border-line-subtle hover:border-line-strong hover:text-content-primary"
                             )}
                         >
                             {option.label}

--- a/src/components/day-view/DayHabitRow.tsx
+++ b/src/components/day-view/DayHabitRow.tsx
@@ -112,7 +112,7 @@ export const DayHabitRow = ({
                                 <input
                                     autoFocus
                                     type="number"
-                                    className="w-12 bg-surface-1 text-content-primary rounded px-1 py-0.5 text-xs border border-line-subtle focus:outline-none focus:border-emerald-500"
+                                    className="w-12 bg-surface-1 text-content-primary rounded px-1 py-0.5 text-xs border border-line-subtle focus:outline-none focus:border-focus"
                                     value={timeInput}
                                     onChange={(e) => setTimeInput(e.target.value)}
                                     onBlur={handleTimeSubmit}
@@ -179,7 +179,7 @@ export const DayHabitRow = ({
                             className={cn(
                                 "px-3 py-1.5 rounded-md text-xs font-medium border transition-all",
                                 selectedChoice === option.key
-                                    ? "bg-accent-soft text-accent-contrast border-emerald-500/50"
+                                    ? "bg-accent-soft text-accent-contrast border-accent/50"
                                     : "bg-surface-1 text-content-secondary border-line-subtle hover:border-line-strong hover:text-content-primary"
                             )}
                         >

--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -284,7 +284,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
     // Show loading state while habits are being fetched
     if (loading) {
         return (
-            <div className="flex items-center justify-center p-12 text-neutral-500 text-sm">Loading habits…</div>
+            <div className="flex items-center justify-center p-12 text-content-muted text-sm">Loading habits…</div>
         );
     }
 
@@ -293,48 +293,48 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
         return (
             <div className="flex flex-col items-center justify-center p-6 sm:p-10 text-center">
                 {/* The Rules — matching InfoModal style */}
-                <div className="w-full max-w-sm bg-emerald-500/5 border border-emerald-500/20 rounded-lg px-3 py-2.5 mb-5">
-                    <p className="text-xs text-emerald-400 uppercase tracking-wide font-semibold mb-1.5">The Rules</p>
-                    <ul className="space-y-0.5 text-sm text-neutral-300">
-                        <li>Habits are <span className="text-emerald-400 font-medium">performed</span></li>
-                        <li>Routines are <span className="text-emerald-400 font-medium">completed</span></li>
-                        <li>Goals are <span className="text-emerald-400 font-medium">achieved</span></li>
+                <div className="w-full max-w-sm bg-emerald-500/5 border border-accent/20 rounded-lg px-3 py-2.5 mb-5">
+                    <p className="text-xs text-accent-contrast uppercase tracking-wide font-semibold mb-1.5">The Rules</p>
+                    <ul className="space-y-0.5 text-sm text-content-secondary">
+                        <li>Habits are <span className="text-accent-contrast font-medium">performed</span></li>
+                        <li>Routines are <span className="text-accent-contrast font-medium">completed</span></li>
+                        <li>Goals are <span className="text-accent-contrast font-medium">achieved</span></li>
                     </ul>
                 </div>
 
                 {/* Definitions — matching InfoModal structure */}
                 <div className="w-full max-w-sm space-y-4 mb-6 text-left">
                     <div className="pl-3 border-l-2 border-emerald-500/40">
-                        <p className="text-sm text-neutral-200">
-                            <span className="font-bold text-emerald-400">Habit</span>
+                        <p className="text-sm text-content-primary">
+                            <span className="font-bold text-accent-contrast">Habit</span>
                         </p>
-                        <p className="text-sm text-neutral-400 mt-1">A repeated behavior performed over time. Each day, a habit is simply performed or not.</p>
+                        <p className="text-sm text-content-secondary mt-1">A repeated behavior performed over time. Each day, a habit is simply performed or not.</p>
                         <div className="flex flex-wrap gap-1.5 mt-2">
                             {['Morning Walk', 'Drink Water', 'Read 5 pages', 'Stretch', 'Vitamins'].map((ex) => (
-                                <span key={ex} className="px-2.5 py-0.5 text-xs text-neutral-400 bg-neutral-800/80 rounded-full border border-white/5">{ex}</span>
+                                <span key={ex} className="px-2.5 py-0.5 text-xs text-content-secondary bg-surface-1/80 rounded-full border border-line-subtle">{ex}</span>
                             ))}
                         </div>
                     </div>
                     <div className="pl-3 border-l-2 border-emerald-500/40">
-                        <p className="text-sm text-neutral-200">
-                            <span className="font-bold text-emerald-400">Routine</span>
+                        <p className="text-sm text-content-primary">
+                            <span className="font-bold text-accent-contrast">Routine</span>
                         </p>
-                        <p className="text-sm text-neutral-400 mt-1">A group of habits performed together in a sequence.</p>
-                        <p className="text-xs text-neutral-500 italic mt-1.5 pl-2">— "Morning Reset" — Stretch + Meditate + Review goals</p>
+                        <p className="text-sm text-content-secondary mt-1">A group of habits performed together in a sequence.</p>
+                        <p className="text-xs text-content-muted italic mt-1.5 pl-2">— "Morning Reset" — Stretch + Meditate + Review goals</p>
                     </div>
                     <div className="pl-3 border-l-2 border-emerald-500/40">
-                        <p className="text-sm text-neutral-200">
-                            <span className="font-bold text-emerald-400">Goal</span>
+                        <p className="text-sm text-content-primary">
+                            <span className="font-bold text-accent-contrast">Goal</span>
                         </p>
-                        <p className="text-sm text-neutral-400 mt-1">An outcome achieved by consistently performing the habits that support it.</p>
-                        <p className="text-xs text-neutral-500 italic mt-1.5 pl-2">— "Run a 10K" — supported by: Running habit</p>
+                        <p className="text-sm text-content-secondary mt-1">An outcome achieved by consistently performing the habits that support it.</p>
+                        <p className="text-xs text-content-muted italic mt-1.5 pl-2">— "Run a 10K" — supported by: Running habit</p>
                     </div>
                 </div>
 
                 {onAddHabit && (
                     <button
                         onClick={onAddHabit}
-                        className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-white font-medium rounded-lg transition-colors"
+                        className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-accent-strong text-content-primary font-medium rounded-lg transition-colors"
                     >
                         <Plus size={18} />
                         Create Your First Habit
@@ -348,7 +348,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
         <div className="flex flex-col w-full max-w-6xl mx-auto pb-24 px-4 sm:px-6">
             {/* Header */}
             <div className="py-3 flex items-center justify-between">
-                <p className="text-neutral-400 font-medium">{displayDate}</p>
+                <p className="text-content-secondary font-medium">{displayDate}</p>
             </div>
 
             {/* Health Suggestions */}
@@ -357,7 +357,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
             {/* Loading State */}
             {dayViewLoading && (
                 <div className="flex items-center justify-center py-8">
-                    <p className="text-neutral-500">Loading...</p>
+                    <p className="text-content-muted">Loading...</p>
                 </div>
             )}
 

--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -304,7 +304,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
 
                 {/* Definitions — matching InfoModal structure */}
                 <div className="w-full max-w-sm space-y-4 mb-6 text-left">
-                    <div className="pl-3 border-l-2 border-emerald-500/40">
+                    <div className="pl-3 border-l-2 border-accent/40">
                         <p className="text-sm text-content-primary">
                             <span className="font-bold text-accent-contrast">Habit</span>
                         </p>
@@ -315,14 +315,14 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
                             ))}
                         </div>
                     </div>
-                    <div className="pl-3 border-l-2 border-emerald-500/40">
+                    <div className="pl-3 border-l-2 border-accent/40">
                         <p className="text-sm text-content-primary">
                             <span className="font-bold text-accent-contrast">Routine</span>
                         </p>
                         <p className="text-sm text-content-secondary mt-1">A group of habits performed together in a sequence.</p>
                         <p className="text-xs text-content-muted italic mt-1.5 pl-2">— "Morning Reset" — Stretch + Meditate + Review goals</p>
                     </div>
-                    <div className="pl-3 border-l-2 border-emerald-500/40">
+                    <div className="pl-3 border-l-2 border-accent/40">
                         <p className="text-sm text-content-primary">
                             <span className="font-bold text-accent-contrast">Goal</span>
                         </p>
@@ -334,7 +334,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
                 {onAddHabit && (
                     <button
                         onClick={onAddHabit}
-                        className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-accent-strong text-content-primary font-medium rounded-lg transition-colors"
+                        className="flex items-center gap-2 px-5 py-2.5 bg-accent hover:bg-accent-strong text-content-primary font-medium rounded-lg transition-colors"
                     >
                         <Plus size={18} />
                         Create Your First Habit

--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -233,7 +233,7 @@ export const HabitGridCell = ({
                                         "flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center transition-all duration-200",
                                         childDone
                                             ? "bg-indigo-500/20 border-indigo-500 text-indigo-400"
-                                            : "border-white/15 text-transparent hover:border-indigo-400/50"
+                                            : "border-line-strong text-transparent hover:border-indigo-400/50"
                                     )}
                                 >
                                     {childDone && <Check size={10} strokeWidth={3} />}
@@ -280,25 +280,25 @@ export const HabitGridCell = ({
             {/* EXPANDED CONTENT AREA */}
             {isExpanded && (
                 <div className="px-3 pb-3 pt-0 flex flex-col gap-3 animate-in fade-in slide-in-from-top-1 duration-200 cursor-default" onClick={e => e.stopPropagation()}>
-                    <div className="h-px w-full bg-white/5 mb-1" />
+                    <div className="h-px w-full bg-surface-1 mb-1" />
 
                     {/* Habit Metadata */}
                     {(habit.timeEstimate || habit.timesPerWeek || habit.nonNegotiable || (isQuantity && habitStatus) || habit.assignedDays) && (
                         <div className="flex flex-wrap gap-2">
                             {habit.timeEstimate && (
-                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-surface-1 px-2 py-0.5 rounded-full">
                                     <Clock size={10} />
                                     {habit.timeEstimate}m
                                 </span>
                             )}
                             {isQuantity && habitStatus && (
-                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-surface-1 px-2 py-0.5 rounded-full">
                                     <Target size={10} />
                                     {habitStatus.currentValue}/{habitStatus.targetValue} {habit.goal?.unit || ''}
                                 </span>
                             )}
                             {habit.timesPerWeek != null && habit.timesPerWeek > 0 && (
-                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-surface-1 px-2 py-0.5 rounded-full">
                                     <Repeat size={10} />
                                     {habit.timesPerWeek}x/week
                                 </span>
@@ -310,7 +310,7 @@ export const HabitGridCell = ({
                                 </span>
                             )}
                             {habit.assignedDays && habit.assignedDays.length > 0 && habit.assignedDays.length < 7 && (
-                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-surface-1 px-2 py-0.5 rounded-full">
                                     <Calendar size={10} />
                                     {habit.assignedDays.map(d => ['Su','Mo','Tu','We','Th','Fr','Sa'][d]).join(', ')}
                                 </span>

--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -116,7 +116,7 @@ export const HabitGridCell = ({
             );
         }
         if (habit.goal) return <CheckCheck size={12} className="text-emerald-500" />;
-        if (habit.timeEstimate) return <span className="text-[10px] text-neutral-500 font-medium">{habit.timeEstimate}m</span>;
+        if (habit.timeEstimate) return <span className="text-[10px] text-content-muted font-medium">{habit.timeEstimate}m</span>;
         return null;
     };
 
@@ -140,15 +140,15 @@ export const HabitGridCell = ({
                     className={cn(
                         "flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all duration-300 relative",
                         isCompleted
-                            ? "bg-emerald-500/10 border-emerald-500 text-emerald-500"
-                            : "border-white/20 text-transparent hover:border-emerald-500/50"
+                            ? "bg-accent-soft border-emerald-500 text-emerald-500"
+                            : "border-line-strong text-transparent hover:border-emerald-500/50"
                     )}
                     title={`${habitStatus.currentValue}/${habitStatus.targetValue} ${habit.goal?.unit ?? ''}`}
                 >
                     {isCompleted ? (
                         <Check size={12} strokeWidth={3} />
                     ) : pct > 0 ? (
-                        <span className="text-[8px] font-bold text-neutral-400">{Math.round(pct)}%</span>
+                        <span className="text-[8px] font-bold text-content-secondary">{Math.round(pct)}%</span>
                     ) : null}
                 </button>
             );
@@ -160,8 +160,8 @@ export const HabitGridCell = ({
                 className={cn(
                     "flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center transition-all duration-300",
                     isCompleted
-                        ? "bg-emerald-500/10 border-emerald-500 text-emerald-500"
-                        : "border-white/20 text-transparent hover:border-emerald-500/50"
+                        ? "bg-accent-soft border-emerald-500 text-emerald-500"
+                        : "border-line-strong text-transparent hover:border-emerald-500/50"
                 )}
             >
                 {isCompleted && <Check size={12} strokeWidth={3} />}
@@ -174,8 +174,8 @@ export const HabitGridCell = ({
             className={cn(
                 "relative flex flex-col rounded-lg border transition-all duration-300 overflow-hidden",
                 isExpanded
-                    ? "bg-neutral-800 border-white/10 shadow-lg scale-[1.02] z-10"
-                    : "bg-neutral-900/40 border-white/5 hover:bg-neutral-800/60 hover:border-white/10",
+                    ? "bg-surface-1 border-line-subtle shadow-lg scale-[1.02] z-10"
+                    : "bg-surface-0/40 border-line-subtle hover:bg-surface-1/60 hover:border-line-subtle",
                 // Claim extra grid rows for bundles with sub-habits
                 hasSubHabits && !isExpanded && "row-span-2"
             )}
@@ -191,7 +191,7 @@ export const HabitGridCell = ({
                 {/* Name - Center */}
                 <span className={cn(
                     "flex-1 text-sm font-medium truncate select-none transition-colors",
-                    isCompleted ? "text-neutral-500 line-through decoration-white/20" : "text-neutral-300"
+                    isCompleted ? "text-content-muted line-through decoration-white/20" : "text-content-secondary"
                 )}>
                     {habit.name}
                 </span>
@@ -216,7 +216,7 @@ export const HabitGridCell = ({
 
             {/* BUNDLE SUB-HABITS (Always Visible for bundles) */}
             {isChecklistBundle && hasSubHabits && (
-                <div className="flex flex-col border-t border-white/5">
+                <div className="flex flex-col border-t border-line-subtle">
                     {subHabits!.map(child => {
                         const childDone = subHabitStatuses?.get(child.id) ?? false;
                         return (
@@ -240,7 +240,7 @@ export const HabitGridCell = ({
                                 </button>
                                 <span className={cn(
                                     "text-xs truncate transition-colors flex items-center gap-1",
-                                    childDone ? "text-neutral-600 line-through" : "text-neutral-400"
+                                    childDone ? "text-content-muted line-through" : "text-content-secondary"
                                 )}>
                                     {child.name}
                                     {child.linkedGoalId && <Trophy size={10} className="flex-shrink-0 text-amber-500" />}
@@ -264,7 +264,7 @@ export const HabitGridCell = ({
                                 "px-2 py-1 rounded text-[10px] font-medium border transition-all",
                                 selectedChoices?.has(option.id)
                                     ? "bg-amber-500/20 text-amber-300 border-amber-500/50"
-                                    : "bg-neutral-800 text-neutral-400 border-white/5 hover:border-white/20 hover:text-white"
+                                    : "bg-surface-1 text-content-secondary border-line-subtle hover:border-line-strong hover:text-content-primary"
                             )}
                         >
                             {option.name}
@@ -286,19 +286,19 @@ export const HabitGridCell = ({
                     {(habit.timeEstimate || habit.timesPerWeek || habit.nonNegotiable || (isQuantity && habitStatus) || habit.assignedDays) && (
                         <div className="flex flex-wrap gap-2">
                             {habit.timeEstimate && (
-                                <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
                                     <Clock size={10} />
                                     {habit.timeEstimate}m
                                 </span>
                             )}
                             {isQuantity && habitStatus && (
-                                <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
                                     <Target size={10} />
                                     {habitStatus.currentValue}/{habitStatus.targetValue} {habit.goal?.unit || ''}
                                 </span>
                             )}
                             {habit.timesPerWeek != null && habit.timesPerWeek > 0 && (
-                                <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
                                     <Repeat size={10} />
                                     {habit.timesPerWeek}x/week
                                 </span>
@@ -310,7 +310,7 @@ export const HabitGridCell = ({
                                 </span>
                             )}
                             {habit.assignedDays && habit.assignedDays.length > 0 && habit.assignedDays.length < 7 && (
-                                <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
+                                <span className="flex items-center gap-1 text-[10px] text-content-muted bg-white/5 px-2 py-0.5 rounded-full">
                                     <Calendar size={10} />
                                     {habit.assignedDays.map(d => ['Su','Mo','Tu','We','Th','Fr','Sa'][d]).join(', ')}
                                 </span>
@@ -323,7 +323,7 @@ export const HabitGridCell = ({
                         {onAddToBundle && habit.type !== 'bundle' && !habit.bundleParentId && (
                             <button
                                 onClick={() => onAddToBundle(habit)}
-                                className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                                className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-content-muted hover:text-content-secondary hover:bg-surface-2"
                             >
                                 <Layers size={12} />
                                 <span>Bundle</span>
@@ -332,7 +332,7 @@ export const HabitGridCell = ({
                         {onMoveToCategory && (
                             <button
                                 onClick={() => onMoveToCategory(habit)}
-                                className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                                className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors text-xs text-content-muted hover:text-content-secondary hover:bg-surface-2"
                             >
                                 <FolderInput size={12} />
                                 <span>Move</span>
@@ -341,7 +341,7 @@ export const HabitGridCell = ({
                         {onViewHistory && (
                             <button
                                 onClick={() => onViewHistory(habit)}
-                                className="p-1.5 rounded-md transition-colors text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                                className="p-1.5 rounded-md transition-colors text-content-muted hover:text-content-secondary hover:bg-surface-2"
                                 title="View History"
                             >
                                 <History size={12} />
@@ -350,7 +350,7 @@ export const HabitGridCell = ({
                         {onEditHabit && (
                             <button
                                 onClick={() => onEditHabit(habit)}
-                                className="p-1.5 rounded-md transition-colors text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                                className="p-1.5 rounded-md transition-colors text-content-muted hover:text-content-secondary hover:bg-surface-2"
                                 title="Edit Habit"
                             >
                                 <Pencil size={12} />
@@ -362,7 +362,7 @@ export const HabitGridCell = ({
                                 "p-1.5 rounded-md transition-colors",
                                 habit.pinned
                                     ? "bg-blue-500/10 text-blue-400 hover:bg-blue-500/20"
-                                    : "text-neutral-500 hover:text-neutral-300 hover:bg-white/5"
+                                    : "text-content-muted hover:text-content-secondary hover:bg-surface-2"
                             )}
                             title={habit.pinned ? 'Unpin' : 'Pin to Focus'}
                         >
@@ -375,7 +375,7 @@ export const HabitGridCell = ({
                                         await onDeleteHabit(habit.id);
                                     }
                                 }}
-                                className="p-1.5 rounded-md transition-colors text-neutral-500 hover:text-red-400 hover:bg-white/5"
+                                className="p-1.5 rounded-md transition-colors text-content-muted hover:text-red-400 hover:bg-surface-2"
                                 title="Delete Habit"
                             >
                                 <Trash2 size={12} />

--- a/src/components/day-view/PinnedHabitsStrip.tsx
+++ b/src/components/day-view/PinnedHabitsStrip.tsx
@@ -18,7 +18,7 @@ export const PinnedHabitsStrip = ({ habits, onUnpin, onToggle, checkStatus }: Pi
 
     return (
         <div className="w-full mb-8 animate-in fade-in slide-in-from-top-4 duration-500">
-            <h2 className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-3 px-1 flex items-center gap-2">
+            <h2 className="text-xs font-bold text-content-muted uppercase tracking-wider mb-3 px-1 flex items-center gap-2">
                 <Flame size={12} className="text-orange-500" />
                 Today's Focus
             </h2>

--- a/src/components/day-view/ScheduleView.tsx
+++ b/src/components/day-view/ScheduleView.tsx
@@ -249,20 +249,20 @@ export const ScheduleView = () => {
             <div className="py-3 flex items-center justify-between">
                 <button
                     onClick={() => setWeekOffset(w => w - 1)}
-                    className="p-1 text-neutral-400 hover:text-white transition-colors"
+                    className="p-1 text-content-secondary hover:text-content-primary transition-colors"
                     aria-label="Previous week"
                 >
                     <ChevronLeft size={20} />
                 </button>
                 <button
                     onClick={() => setWeekOffset(0)}
-                    className="text-neutral-400 font-medium text-sm hover:text-white transition-colors"
+                    className="text-content-secondary font-medium text-sm hover:text-content-primary transition-colors"
                 >
                     {weekOffset === 0 ? 'This Week' : `${format(weekStart, 'MMM d')} – ${format(endOfWeek(weekStart, { weekStartsOn: 1 }), 'MMM d')}`}
                 </button>
                 <button
                     onClick={() => setWeekOffset(w => w + 1)}
-                    className="p-1 text-neutral-400 hover:text-white transition-colors"
+                    className="p-1 text-content-secondary hover:text-content-primary transition-colors"
                     aria-label="Next week"
                 >
                     <ChevronRight size={20} />
@@ -282,14 +282,14 @@ export const ScheduleView = () => {
                             onClick={() => setSelectedDayIndex(i)}
                             className={`flex flex-col items-center py-2 px-1 rounded-lg transition-all text-xs ${
                                 isSelected
-                                    ? 'bg-emerald-500/20 border border-emerald-500/50 text-emerald-400'
+                                    ? 'bg-accent-soft border border-emerald-500/50 text-accent-contrast'
                                     : isToday
-                                        ? 'bg-neutral-800 border border-white/10 text-white'
-                                        : 'bg-neutral-800/50 border border-transparent text-neutral-400 hover:bg-neutral-800'
+                                        ? 'bg-surface-1 border border-line-subtle text-content-primary'
+                                        : 'bg-surface-1/50 border border-transparent text-content-secondary hover:bg-surface-1'
                             }`}
                         >
                             <span className="font-medium">{dayNames[i]}</span>
-                            <span className={`text-lg font-semibold ${isSelected ? 'text-emerald-400' : ''}`}>
+                            <span className={`text-lg font-semibold ${isSelected ? 'text-accent-contrast' : ''}`}>
                                 {format(day, 'd')}
                             </span>
                         </button>
@@ -299,7 +299,7 @@ export const ScheduleView = () => {
 
             {dayViewLoading && (
                 <div className="flex items-center justify-center py-8">
-                    <p className="text-neutral-500">Loading...</p>
+                    <p className="text-content-muted">Loading...</p>
                 </div>
             )}
 
@@ -316,10 +316,10 @@ export const ScheduleView = () => {
                         renderCategoryGroups(scheduledGrouped)
                     ) : (
                         <div className="flex flex-col items-center justify-center p-6 text-center">
-                            <div className="w-12 h-12 bg-neutral-800 rounded-full flex items-center justify-center mb-3">
-                                <Calendar size={24} className="text-neutral-500" />
+                            <div className="w-12 h-12 bg-surface-1 rounded-full flex items-center justify-center mb-3">
+                                <Calendar size={24} className="text-content-muted" />
                             </div>
-                            <p className="text-sm text-neutral-500">
+                            <p className="text-sm text-content-muted">
                                 No scheduled habits for {format(selectedDate, 'EEEE')}
                             </p>
                         </div>
@@ -330,11 +330,11 @@ export const ScheduleView = () => {
                         <div className="mt-2">
                             <button
                                 onClick={() => setShowDailyHabits(!showDailyHabits)}
-                                className="flex items-center gap-2 w-full py-2 px-3 rounded-lg bg-neutral-800/50 border border-white/5 text-neutral-400 hover:text-white transition-colors"
+                                className="flex items-center gap-2 w-full py-2 px-3 rounded-lg bg-surface-1/50 border border-line-subtle text-content-secondary hover:text-content-primary transition-colors"
                             >
                                 {showDailyHabits ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
                                 <span className="text-sm font-medium">Daily Habits</span>
-                                <span className="text-xs text-neutral-500 ml-auto">{dailyHabits.length}</span>
+                                <span className="text-xs text-content-muted ml-auto">{dailyHabits.length}</span>
                             </button>
                             {showDailyHabits && (
                                 <div className="mt-2 flex flex-col gap-2">

--- a/src/components/goals/CreateGoalTrackModal.tsx
+++ b/src/components/goals/CreateGoalTrackModal.tsx
@@ -55,45 +55,45 @@ export const CreateGoalTrackModal: React.FC<CreateGoalTrackModalProps> = ({
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl shadow-2xl">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl shadow-2xl">
                 {/* Header */}
-                <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
-                    <h2 className="text-lg font-semibold text-white">Create Goal Track</h2>
+                <div className="flex items-center justify-between px-5 py-4 border-b border-line-subtle">
+                    <h2 className="text-lg font-semibold text-content-primary">Create Goal Track</h2>
                     <button
                         onClick={onClose}
                         disabled={isSubmitting}
-                        className="p-2 rounded-lg hover:bg-neutral-800 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center"
+                        className="p-2 rounded-lg hover:bg-surface-1 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center"
                     >
-                        <X size={18} className="text-neutral-400" />
+                        <X size={18} className="text-content-secondary" />
                     </button>
                 </div>
 
                 {/* Body */}
                 <form onSubmit={handleSubmit} className="p-5 space-y-4">
                     {error && (
-                        <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
+                        <div className="p-3 bg-danger-soft border border-danger/30 rounded-lg text-sm text-danger-contrast">
                             {error}
                         </div>
                     )}
 
                     <div>
-                        <label className="block text-sm font-medium text-neutral-300 mb-1.5">Track Name</label>
+                        <label className="block text-sm font-medium text-content-secondary mb-1.5">Track Name</label>
                         <input
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
                             placeholder="e.g., Certification Path"
-                            className="w-full px-3 py-2.5 bg-neutral-800 border border-white/10 rounded-lg text-white text-sm placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                            className="w-full px-3 py-2.5 bg-surface-1 border border-line-subtle rounded-lg text-content-primary text-sm placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-focus"
                             autoFocus
                         />
                     </div>
 
                     <div>
-                        <label className="block text-sm font-medium text-neutral-300 mb-1.5">Category</label>
+                        <label className="block text-sm font-medium text-content-secondary mb-1.5">Category</label>
                         <select
                             value={categoryId}
                             onChange={(e) => setCategoryId(e.target.value)}
-                            className="w-full px-3 py-2.5 bg-neutral-800 border border-white/10 rounded-lg text-white text-sm focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                            className="w-full px-3 py-2.5 bg-surface-1 border border-line-subtle rounded-lg text-content-primary text-sm focus:outline-none focus:ring-1 focus:ring-focus"
                         >
                             <option value="">Select category...</option>
                             {categories.map(cat => (
@@ -103,13 +103,13 @@ export const CreateGoalTrackModal: React.FC<CreateGoalTrackModalProps> = ({
                     </div>
 
                     <div>
-                        <label className="block text-sm font-medium text-neutral-300 mb-1.5">Description (optional)</label>
+                        <label className="block text-sm font-medium text-content-secondary mb-1.5">Description (optional)</label>
                         <textarea
                             value={description}
                             onChange={(e) => setDescription(e.target.value)}
                             placeholder="What is this track about?"
                             rows={2}
-                            className="w-full px-3 py-2.5 bg-neutral-800 border border-white/10 rounded-lg text-white text-sm placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 resize-none"
+                            className="w-full px-3 py-2.5 bg-surface-1 border border-line-subtle rounded-lg text-content-primary text-sm placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-focus resize-none"
                         />
                     </div>
 
@@ -119,14 +119,14 @@ export const CreateGoalTrackModal: React.FC<CreateGoalTrackModalProps> = ({
                             type="button"
                             onClick={onClose}
                             disabled={isSubmitting}
-                            className="px-4 py-2 text-sm font-medium text-white bg-neutral-700 hover:bg-neutral-600 rounded-lg transition-colors"
+                            className="px-4 py-2 text-sm font-medium text-content-primary bg-surface-2 hover:bg-surface-2 rounded-lg transition-colors"
                         >
                             Cancel
                         </button>
                         <button
                             type="submit"
                             disabled={isSubmitting || !name.trim() || !categoryId}
-                            className="px-4 py-2 text-sm font-medium text-neutral-900 bg-emerald-500 hover:bg-emerald-400 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="px-4 py-2 text-sm font-medium text-content-on-accent bg-accent hover:bg-accent-strong rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             {isSubmitting ? 'Creating...' : 'Create Track'}
                         </button>

--- a/src/components/goals/DeleteGoalConfirmModal.tsx
+++ b/src/components/goals/DeleteGoalConfirmModal.tsx
@@ -41,13 +41,13 @@ export const DeleteGoalConfirmModal: React.FC<DeleteGoalConfirmModalProps> = ({
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+            <div className="w-full max-w-md bg-surface-0 border border-line-subtle rounded-2xl p-6 shadow-2xl">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Delete Goal</h3>
+                    <h3 className="text-xl font-bold text-content-primary">Delete Goal</h3>
                     <button
                         onClick={handleCancel}
                         disabled={isDeleting}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors disabled:opacity-50 -mr-2"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50 -mr-2"
                         aria-label="Close"
                     >
                         <X size={20} />
@@ -60,24 +60,24 @@ export const DeleteGoalConfirmModal: React.FC<DeleteGoalConfirmModalProps> = ({
                         <AlertTriangle className="text-amber-400 flex-shrink-0 mt-0.5" size={20} />
                         <div className="flex-1">
                             <div className="text-amber-400 font-medium mb-1">Confirm Deletion</div>
-                            <div className="text-white text-sm">
+                            <div className="text-content-primary text-sm">
                                 Delete this goal? This will not delete underlying habits or habit logs, but the goal and its progress will be removed.
                             </div>
                         </div>
                     </div>
 
                     {/* Goal Title */}
-                    <div className="p-3 bg-neutral-800/50 rounded-lg">
-                        <div className="text-neutral-400 text-xs mb-1">Goal</div>
-                        <div className="text-white text-sm font-medium">{goalTitle}</div>
+                    <div className="p-3 bg-surface-1/50 rounded-lg">
+                        <div className="text-content-secondary text-xs mb-1">Goal</div>
+                        <div className="text-content-primary text-sm font-medium">{goalTitle}</div>
                     </div>
 
                     {/* Error Display */}
                     {error && (
-                        <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg flex items-start gap-3">
-                            <AlertTriangle className="text-red-400 flex-shrink-0 mt-0.5" size={16} />
+                        <div className="p-3 bg-danger-soft border border-danger/50 rounded-lg flex items-start gap-3">
+                            <AlertTriangle className="text-danger-contrast flex-shrink-0 mt-0.5" size={16} />
                             <div className="flex-1">
-                                <div className="text-red-400 text-sm">{error}</div>
+                                <div className="text-danger-contrast text-sm">{error}</div>
                             </div>
                         </div>
                     )}
@@ -88,7 +88,7 @@ export const DeleteGoalConfirmModal: React.FC<DeleteGoalConfirmModalProps> = ({
                             type="button"
                             onClick={handleCancel}
                             disabled={isDeleting}
-                            className="flex-1 px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="flex-1 px-4 py-2 bg-surface-2 hover:bg-surface-2 text-content-primary rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             Cancel
                         </button>
@@ -96,7 +96,7 @@ export const DeleteGoalConfirmModal: React.FC<DeleteGoalConfirmModalProps> = ({
                             type="button"
                             onClick={handleConfirm}
                             disabled={isDeleting}
-                            className="flex-1 px-4 py-2 bg-red-500 hover:bg-red-400 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                            className="flex-1 px-4 py-2 bg-danger hover:bg-danger/80 text-content-primary font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                         >
                             {isDeleting ? (
                                 <>

--- a/src/components/goals/EditGoalModal.tsx
+++ b/src/components/goals/EditGoalModal.tsx
@@ -174,14 +174,14 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-2xl bg-neutral-900 border border-white/10 rounded-2xl flex flex-col max-h-[75dvh] shadow-2xl">
+            <div className="w-full max-w-2xl bg-surface-0 border border-line-subtle rounded-2xl flex flex-col max-h-[75dvh] shadow-2xl">
                 {/* Header */}
-                <div className="flex items-center justify-between p-6 border-b border-white/10">
-                    <h3 className="text-xl font-bold text-white">Edit Goal</h3>
+                <div className="flex items-center justify-between p-6 border-b border-line-subtle">
+                    <h3 className="text-xl font-bold text-content-primary">Edit Goal</h3>
                     <button
                         onClick={onClose}
                         disabled={isSubmitting}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors disabled:opacity-50 -mr-2"
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50 -mr-2"
                         aria-label="Close"
                     >
                         <X size={20} />
@@ -193,10 +193,10 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                     <form id="edit-goal-form" onSubmit={handleSubmit} className="space-y-6">
                         {/* Error Display */}
                         {error && (
-                            <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg flex items-start gap-3">
-                                <AlertCircle className="text-red-400 flex-shrink-0 mt-0.5" size={16} />
+                            <div className="p-3 bg-danger-soft border border-danger/50 rounded-lg flex items-start gap-3">
+                                <AlertCircle className="text-danger-contrast flex-shrink-0 mt-0.5" size={16} />
                                 <div className="flex-1">
-                                    <div className="text-red-400 text-sm">{error}</div>
+                                    <div className="text-danger-contrast text-sm">{error}</div>
                                 </div>
                             </div>
                         )}
@@ -204,14 +204,14 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                         {/* Category Selection */}
                         <div className="space-y-3">
                             <div className="flex justify-between items-center">
-                                <label className="block text-sm font-medium text-neutral-300">
-                                    Category <span className="text-neutral-500 font-normal">(Optional, for Skill Tree)</span>
+                                <label className="block text-sm font-medium text-content-secondary">
+                                    Category <span className="text-content-muted font-normal">(Optional, for Skill Tree)</span>
                                 </label>
                                 {!isCreatingCategory && (
                                     <button
                                         type="button"
                                         onClick={() => setIsCreatingCategory(true)}
-                                        className="text-xs text-emerald-400 hover:text-emerald-300 flex items-center gap-1"
+                                        className="text-xs text-accent-contrast hover:text-accent-contrast flex items-center gap-1"
                                     >
                                         <Plus size={12} />
                                         New Category
@@ -226,7 +226,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                         value={newCategoryName}
                                         onChange={(e) => setNewCategoryName(e.target.value)}
                                         placeholder="New category name..."
-                                        className="flex-1 bg-neutral-900 border border-emerald-500/50 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-1 focus:ring-emerald-500/50"
+                                        className="flex-1 bg-surface-0 border border-accent/50 rounded-xl px-4 py-3 text-content-primary focus:outline-none focus:ring-1 focus:ring-focus/50"
                                         autoFocus
                                         onKeyDown={(e) => {
                                             if (e.key === 'Enter') {
@@ -239,7 +239,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                         type="button"
                                         onClick={handleCreateCategory}
                                         disabled={!newCategoryName.trim() || isSubmittingCategory}
-                                        className="bg-emerald-500 hover:bg-emerald-400 text-neutral-900 px-4 rounded-xl font-medium transition-colors disabled:opacity-50"
+                                        className="bg-accent hover:bg-accent-strong text-content-on-accent px-4 rounded-xl font-medium transition-colors disabled:opacity-50"
                                     >
                                         {isSubmittingCategory ? '...' : 'Save'}
                                     </button>
@@ -249,7 +249,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                             setIsCreatingCategory(false);
                                             setNewCategoryName('');
                                         }}
-                                        className="bg-neutral-800 hover:bg-neutral-700 text-neutral-400 px-3 rounded-xl transition-colors"
+                                        className="bg-surface-1 hover:bg-surface-2 text-content-secondary px-3 rounded-xl transition-colors"
                                     >
                                         <X size={20} />
                                     </button>
@@ -265,7 +265,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                                 setCategoryId(e.target.value);
                                             }
                                         }}
-                                        className="w-full bg-neutral-800 border border-white/10 rounded-lg pl-10 pr-4 py-3 text-white appearance-none focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 transition-all"
+                                        className="w-full bg-surface-1 border border-line-subtle rounded-lg pl-10 pr-4 py-3 text-content-primary appearance-none focus:outline-none focus:border-focus focus:ring-1 focus:ring-focus transition-all"
                                     >
                                         <option value="">Select a Category...</option>
                                         {categories.map(cat => (
@@ -274,7 +274,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                         <option disabled>──────────</option>
                                         <option value="new">+ Create New Category</option>
                                     </select>
-                                    <div className="absolute left-3 top-3.5 text-neutral-500 pointer-events-none">
+                                    <div className="absolute left-3 top-3.5 text-content-muted pointer-events-none">
                                         <Folder size={20} />
                                     </div>
                                 </div>
@@ -283,27 +283,27 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
 
                         {/* Title */}
                         <div>
-                            <label className="block text-sm font-medium text-neutral-300 mb-2">
+                            <label className="block text-sm font-medium text-content-secondary mb-2">
                                 Goal Title
                             </label>
                             <input
                                 type="text"
                                 value={title}
                                 onChange={(e) => setTitle(e.target.value)}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                 placeholder="e.g., Read 50 Books"
                             />
                         </div>
 
                         {/* Description (Notes) */}
                         <div>
-                            <label className="block text-sm font-medium text-neutral-300 mb-2">
+                            <label className="block text-sm font-medium text-content-secondary mb-2">
                                 Description
                             </label>
                             <textarea
                                 value={description}
                                 onChange={(e) => setDescription(e.target.value)}
-                                className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500 min-h-[80px]"
+                                className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus min-h-[80px]"
                                 placeholder="Why is this goal important?"
                             />
                         </div>
@@ -314,7 +314,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                             {goal.type !== 'onetime' && (
                                 <>
                                     <div>
-                                        <label className="block text-sm font-medium text-neutral-300 mb-2">
+                                        <label className="block text-sm font-medium text-content-secondary mb-2">
                                             Target Value
                                         </label>
                                         <input
@@ -332,7 +332,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                                 }
                                                 setTargetValue(newVal);
                                             }}
-                                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                             min="1"
                                             step="any"
                                         />
@@ -340,14 +340,14 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
 
                                     {/* Unit */}
                                     <div>
-                                        <label className="block text-sm font-medium text-neutral-300 mb-2">
+                                        <label className="block text-sm font-medium text-content-secondary mb-2">
                                             Unit Label
                                         </label>
                                         <input
                                             type="text"
                                             value={unit}
                                             onChange={(e) => setUnit(e.target.value)}
-                                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                            className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                             placeholder="e.g., books, miles"
                                         />
                                     </div>
@@ -356,14 +356,14 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
 
                             {/* Deadline */}
                             <div className={goal.type === 'onetime' ? "sm:col-span-2" : "sm:col-span-2"}>
-                                <label className="block text-sm font-medium text-neutral-300 mb-2">
+                                <label className="block text-sm font-medium text-content-secondary mb-2">
                                     {goal.type === 'onetime' ? 'Event Date (Optional)' : 'Deadline (Optional)'}
                                 </label>
                                 <input
                                     type="date"
                                     value={deadline}
                                     onChange={(e) => setDeadline(e.target.value)}
-                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                    className="w-full bg-surface-1 border border-line-subtle rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:border-focus"
                                 />
                             </div>
                         </div>
@@ -372,13 +372,13 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                         {/* Habit Selector */}
                         <div>
                             <div className="flex items-center justify-between mb-4">
-                                <label className="block text-sm font-medium text-neutral-300">
+                                <label className="block text-sm font-medium text-content-secondary">
                                     Linked Habits
                                 </label>
                                 <button
                                     type="button"
                                     onClick={() => setIsAddHabitOpen(true)}
-                                    className="text-xs text-emerald-400 hover:text-emerald-300 font-medium flex items-center gap-1"
+                                    className="text-xs text-accent-contrast hover:text-accent-contrast font-medium flex items-center gap-1"
                                 >
                                     <Plus size={12} />
                                     Create new habit
@@ -388,19 +388,19 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                             {/* Filter Bar */}
                             <div className="flex gap-2 mb-3">
                                 <div className="relative flex-1">
-                                    <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500" />
+                                    <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-content-muted" />
                                     <input
                                         type="text"
                                         value={habitSearch}
                                         onChange={(e) => setHabitSearch(e.target.value)}
                                         placeholder="Search habits..."
-                                        className="w-full bg-neutral-800/50 border border-white/10 rounded-lg pl-9 pr-3 py-2 text-sm text-white focus:outline-none focus:border-white/20"
+                                        className="w-full bg-surface-1/50 border border-line-subtle rounded-lg pl-9 pr-3 py-2 text-sm text-content-primary focus:outline-none focus:border-line-strong"
                                     />
                                     {habitSearch && (
                                         <button
                                             type="button"
                                             onClick={() => setHabitSearch('')}
-                                            className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-white"
+                                            className="absolute right-2 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-primary"
                                         >
                                             <X size={14} />
                                         </button>
@@ -411,8 +411,8 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                         type="button"
                                         onClick={() => setFilterByGoalCategory(!filterByGoalCategory)}
                                         className={`px-3 py-2 rounded-lg border text-xs font-medium flex items-center gap-2 transition-colors ${filterByGoalCategory
-                                                ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
-                                                : 'bg-neutral-800/50 border-white/10 text-neutral-400 hover:bg-neutral-800'
+                                                ? 'bg-accent-soft border-accent/50 text-accent-contrast'
+                                                : 'bg-surface-1/50 border-line-subtle text-content-secondary hover:bg-surface-1'
                                             }`}
                                         title="Only show habits in this goal's category"
                                     >
@@ -422,14 +422,14 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                 )}
                             </div>
 
-                            <p className="text-neutral-400 text-xs mb-3">
+                            <p className="text-content-secondary text-xs mb-3">
                                 {displayedHabits.length} habit{displayedHabits.length !== 1 ? 's' : ''} available
                                 {filterByGoalCategory && categoryId && ' (filtered by category)'}
                             </p>
 
-                            <div className="space-y-2 max-h-60 overflow-y-auto border border-white/5 rounded-lg p-2 bg-neutral-800/20">
+                            <div className="space-y-2 max-h-60 overflow-y-auto border border-line-subtle rounded-lg p-2 bg-surface-1/20">
                                 {displayedHabits.length === 0 ? (
-                                    <div className="text-neutral-500 text-sm p-4 text-center flex flex-col items-center gap-2">
+                                    <div className="text-content-muted text-sm p-4 text-center flex flex-col items-center gap-2">
                                         <Search size={24} className="opacity-20" />
                                         <p>No habits found matching your filters.</p>
                                         {(habitSearch || filterByGoalCategory) && (
@@ -439,7 +439,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                                     setHabitSearch('');
                                                     setFilterByGoalCategory(false);
                                                 }}
-                                                className="text-emerald-400 text-xs hover:underline"
+                                                className="text-accent-contrast text-xs hover:underline"
                                             >
                                                 Clear all filters
                                             </button>
@@ -451,23 +451,23 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                                             key={habit.id}
                                             onClick={() => toggleHabitSelection(habit.id)}
                                             className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer border transition-all ${selectedHabitIds.includes(habit.id)
-                                                ? 'bg-emerald-500/10 border-emerald-500/50'
-                                                : 'bg-neutral-800/50 border-transparent hover:bg-neutral-800'
+                                                ? 'bg-accent-soft border-accent/50'
+                                                : 'bg-surface-1/50 border-transparent hover:bg-surface-1'
                                                 }`}
                                         >
                                             <div className={`w-5 h-5 rounded-full border flex items-center justify-center flex-shrink-0 transition-colors ${selectedHabitIds.includes(habit.id)
-                                                ? 'bg-emerald-500 border-emerald-500'
+                                                ? 'bg-accent border-accent'
                                                 : 'border-neutral-500'
                                                 }`}>
-                                                {selectedHabitIds.includes(habit.id) && <Plus size={14} className="text-neutral-900" />}
+                                                {selectedHabitIds.includes(habit.id) && <Plus size={14} className="text-content-on-accent" />}
                                             </div>
                                             <div className="flex-1">
-                                                <div className="text-white text-sm font-medium">{habit.name}</div>
-                                                <div className="text-neutral-400 text-xs">{habit.goal.frequency} • {habit.goal.target} {habit.goal.unit}</div>
+                                                <div className="text-content-primary text-sm font-medium">{habit.name}</div>
+                                                <div className="text-content-secondary text-xs">{habit.goal.frequency} • {habit.goal.target} {habit.goal.unit}</div>
                                             </div>
                                             {/* Category Tag (Visual confirmation) */}
                                             {categories.find(c => c.id === habit.categoryId) && (
-                                                <div className="text-[10px] px-2 py-0.5 rounded bg-neutral-700 text-neutral-300">
+                                                <div className="text-[10px] px-2 py-0.5 rounded bg-surface-2 text-content-secondary">
                                                     {categories.find(c => c.id === habit.categoryId)?.name}
                                                 </div>
                                             )}
@@ -480,13 +480,13 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                 </div>
 
                 {/* Footer */}
-                <div className="p-6 border-t border-white/10 bg-neutral-900/50 rounded-b-2xl">
+                <div className="p-6 border-t border-line-subtle bg-surface-0/50 rounded-b-2xl">
                     <div className="flex items-center gap-3">
                         <button
                             type="button"
                             onClick={onClose}
                             disabled={isSubmitting}
-                            className="flex-1 px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50"
+                            className="flex-1 px-4 py-2 bg-surface-2 hover:bg-surface-2 text-content-primary rounded-lg transition-colors disabled:opacity-50"
                         >
                             Cancel
                         </button>
@@ -494,7 +494,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                             type="submit"
                             form="edit-goal-form"
                             disabled={isSubmitting}
-                            className="flex-1 px-4 py-2 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-medium rounded-lg transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+                            className="flex-1 px-4 py-2 bg-accent hover:bg-accent-strong text-content-on-accent font-medium rounded-lg transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
                         >
                             {isSubmitting ? (
                                 <>

--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -215,17 +215,17 @@ export const GoalCard: React.FC<GoalCardProps> = ({
 
                                 {/* Numerical Progress and Metadata Row */}
                                 <div className="flex items-center gap-3 flex-wrap text-sm">
-                                    <span className="text-neutral-300 font-medium">
+                                    <span className="text-content-secondary font-medium">
                                         {progressText}
                                     </span>
-                                    <span className="text-emerald-400 font-medium">
+                                    <span className="text-accent-contrast font-medium">
                                         {progress.percent}%
                                     </span>
                                     <span className={goalMetadataClasses}>
                                         {linkedHabits.length} {linkedHabits.length === 1 ? 'habit' : 'habits'}
                                     </span>
                                     {goal.deadline && (
-                                        <span className="px-2 py-0.5 bg-neutral-700/50 text-neutral-300 rounded text-xs">
+                                        <span className="px-2 py-0.5 bg-surface-2/50 text-content-secondary rounded text-xs">
                                             Due {formatDeadline(goal.deadline)}
                                         </span>
                                     )}
@@ -240,7 +240,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                             </div>
 
                             {/* Chevron Icon */}
-                            <ChevronRight className="text-neutral-400 flex-shrink-0 mt-1" size={20} />
+                            <ChevronRight className="text-content-secondary flex-shrink-0 mt-1" size={20} />
                         </div>
                     </div>
                 )}
@@ -249,7 +249,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                 {isExpanded && (
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-3 flex-1 min-w-0">
-                            <ChevronDown className="text-neutral-400 flex-shrink-0" size={20} />
+                            <ChevronDown className="text-content-secondary flex-shrink-0" size={20} />
                             <div className="flex-1 min-w-0">
                                 <h3 className={`${goalTitleClasses} truncate`}>
                                     {goal.title}
@@ -261,11 +261,11 @@ export const GoalCard: React.FC<GoalCardProps> = ({
             </button>
 
             {isExpanded && (
-                <div className="px-4 pb-4 pt-4 border-t border-white/5 bg-neutral-900/30 animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="px-4 pb-4 pt-4 border-t border-line-subtle bg-surface-0/30 animate-in fade-in slide-in-from-top-2 duration-200">
                     <div className="space-y-6">
                         {/* Linked Habits List */}
                         <div>
-                            <div className="text-neutral-400 text-sm font-medium mb-2">Linked Habits</div>
+                            <div className="text-content-secondary text-sm font-medium mb-2">Linked Habits</div>
                             {linkedHabits.length === 0 ? (
                                 <div className={goalSubtitleClasses}>No habits linked</div>
                             ) : (
@@ -273,22 +273,22 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                                     {linkedHabits.map((habit) => (
                                         <div
                                             key={habit.id}
-                                            className="flex items-center gap-3 p-2 bg-neutral-800/50 rounded-lg"
+                                            className="flex items-center gap-3 p-2 bg-surface-1/50 rounded-lg"
                                         >
                                             {/* Habit Icon Placeholder */}
                                             {habit.goal.unit && (
-                                                <div className="w-8 h-8 bg-emerald-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
-                                                    <span className="text-emerald-400 text-xs font-medium">
+                                                <div className="w-8 h-8 bg-accent-soft rounded-lg flex items-center justify-center flex-shrink-0">
+                                                    <span className="text-accent-contrast text-xs font-medium">
                                                         {habit.goal.unit.charAt(0).toUpperCase()}
                                                     </span>
                                                 </div>
                                             )}
                                             <div className="flex-1 min-w-0">
-                                                <div className="text-white text-sm font-medium truncate">
+                                                <div className="text-content-primary text-sm font-medium truncate">
                                                     {habit.name}
                                                 </div>
                                                 {habit.goal.unit && (
-                                                    <div className="text-neutral-400 text-xs">
+                                                    <div className="text-content-secondary text-xs">
                                                         {habit.goal.type === 'number' ? 'Quantified' : 'Binary'} • {habit.goal.unit}
                                                     </div>
                                                 )}
@@ -311,21 +311,21 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                                             <div
                                                 key={milestone.percent}
                                                 className={`flex items-center justify-between p-2 rounded-lg transition-colors ${milestone.reached
-                                                    ? 'bg-emerald-500/10 border border-emerald-500/30'
-                                                    : 'bg-neutral-800/50 border border-white/10'
+                                                    ? 'bg-accent-soft border border-accent/30'
+                                                    : 'bg-surface-1/50 border border-line-subtle'
                                                     }`}
                                             >
                                                 <div className="flex items-center gap-3">
                                                     {milestone.reached ? (
-                                                        <Check className="text-emerald-400 flex-shrink-0" size={16} />
+                                                        <Check className="text-accent-contrast flex-shrink-0" size={16} />
                                                     ) : (
-                                                        <div className="w-4 h-4 rounded-full border-2 border-neutral-600 flex-shrink-0" />
+                                                        <div className="w-4 h-4 rounded-full border-2 border-line-strong flex-shrink-0" />
                                                     )}
                                                     <div>
-                                                        <div className="text-white text-sm font-medium">
+                                                        <div className="text-content-primary text-sm font-medium">
                                                             {milestone.percent}% • {milestone.label}
                                                         </div>
-                                                        <div className="text-neutral-400 text-xs">
+                                                        <div className="text-content-secondary text-xs">
                                                             {milestoneValue}
                                                         </div>
                                                     </div>
@@ -340,7 +340,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                         {/* Sparkline Placeholder */}
                         <div>
                             <div className={`${goalSubtitleClasses} font-medium mb-2`}>Last 7 Days</div>
-                            <div className="flex items-end gap-1 h-16 bg-neutral-800/50 rounded-lg p-2">
+                            <div className="flex items-end gap-1 h-16 bg-surface-1/50 rounded-lg p-2">
                                 {progress.lastSevenDays.map((day) => {
                                     const heightPercent = (day.value / maxSparklineValue) * 100;
                                     return (
@@ -352,11 +352,11 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                                             <div
                                                 className={`w-full rounded-t transition-all ${day.hasProgress
                                                     ? 'bg-emerald-500'
-                                                    : 'bg-neutral-600'
+                                                    : 'bg-surface-2'
                                                     }`}
                                                 style={{ height: `${Math.max(4, heightPercent)}%` }}
                                             />
-                                            <div className="text-[8px] text-neutral-500 leading-tight">
+                                            <div className="text-[8px] text-content-muted leading-tight">
                                                 {(() => {
                                                     try {
                                                         return format(parseISO(day.date), 'd');
@@ -372,14 +372,14 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                         </div>
 
                         {/* Actions */}
-                        <div className="flex flex-wrap gap-2 pt-2 border-t border-white/5">
+                        <div className="flex flex-wrap gap-2 pt-2 border-t border-line-subtle">
                             {onViewDetails && (
                                 <button
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         onViewDetails(goal.id);
                                     }}
-                                    className="flex items-center gap-2 px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 text-white text-sm rounded-lg transition-colors"
+                                    className="flex items-center gap-2 px-3 py-1.5 bg-surface-2 hover:bg-surface-2 text-content-primary text-sm rounded-lg transition-colors"
                                 >
                                     <ExternalLink size={14} />
                                     View full goal details
@@ -391,7 +391,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
                                         e.stopPropagation();
                                         onEdit(goal.id);
                                     }}
-                                    className="flex items-center gap-2 px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 text-white text-sm rounded-lg transition-colors"
+                                    className="flex items-center gap-2 px-3 py-1.5 bg-surface-2 hover:bg-surface-2 text-content-primary text-sm rounded-lg transition-colors"
                                 >
                                     <Edit size={14} />
                                     Edit goal
@@ -401,9 +401,9 @@ export const GoalCard: React.FC<GoalCardProps> = ({
 
                         {/* Notes */}
                         {goal.notes && (
-                            <div className="pt-2 border-t border-white/5">
-                                <div className="text-neutral-400 text-sm font-medium mb-1">Notes</div>
-                                <div className="text-white text-sm">{goal.notes}</div>
+                            <div className="pt-2 border-t border-line-subtle">
+                                <div className="text-content-secondary text-sm font-medium mb-1">Notes</div>
+                                <div className="text-content-primary text-sm">{goal.notes}</div>
                             </div>
                         )}
                     </div>

--- a/src/components/goals/GoalCumulativeChart.tsx
+++ b/src/components/goals/GoalCumulativeChart.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { format, parseISO, isValid, subDays } from 'date-fns';
+import { useThemeColors } from '../../theme/useThemeColors';
 
 interface GoalCumulativeChartProps {
     data: Array<{
@@ -20,9 +21,11 @@ interface ChartPoint {
 
 export const GoalCumulativeChart: React.FC<GoalCumulativeChartProps> = ({
     data,
-    color = "#10b981", // emerald-500
+    color,
     unit = ""
 }) => {
+    const themeColors = useThemeColors();
+    const lineColor = color ?? themeColors.accent;
     const chartData = useMemo<ChartPoint[]>(() => {
         // Sort by date ascending to ensure proper line graph
         const sorted: ChartPoint[] = [...data]
@@ -52,14 +55,14 @@ export const GoalCumulativeChart: React.FC<GoalCumulativeChartProps> = ({
 
     if (data.length === 0) {
         return (
-            <div className="flex items-center justify-center h-64 bg-neutral-900/30 rounded-lg border border-white/5">
-                <p className="text-neutral-500 text-sm">No progress data available yet.</p>
+            <div className="flex items-center justify-center h-64 bg-surface-1/60 rounded-lg border border-line-subtle">
+                <p className="text-content-muted text-sm">No progress data available yet.</p>
             </div>
         );
     }
 
     return (
-        <div className="w-full h-64 bg-neutral-900/30 rounded-lg border border-white/5 p-4">
+        <div className="w-full h-64 bg-surface-1/60 rounded-lg border border-line-subtle p-4">
             <ResponsiveContainer width="100%" height="100%">
                 <AreaChart
                     data={chartData}
@@ -67,22 +70,22 @@ export const GoalCumulativeChart: React.FC<GoalCumulativeChartProps> = ({
                 >
                     <defs>
                         <linearGradient id="colorValueCumulative" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="5%" stopColor={color} stopOpacity={0.3} />
-                            <stop offset="95%" stopColor={color} stopOpacity={0} />
+                            <stop offset="5%" stopColor={lineColor} stopOpacity={0.3} />
+                            <stop offset="95%" stopColor={lineColor} stopOpacity={0} />
                         </linearGradient>
                     </defs>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" vertical={false} />
+                    <CartesianGrid strokeDasharray="3 3" stroke={themeColors.chartGrid} vertical={false} />
                     <XAxis
                         dataKey="date"
                         tickFormatter={formatXAxis}
-                        stroke="#737373"
+                        stroke={themeColors.chartAxis}
                         fontSize={12}
                         tickLine={false}
                         axisLine={false}
                         minTickGap={30}
                     />
                     <YAxis
-                        stroke="#737373"
+                        stroke={themeColors.chartAxis}
                         fontSize={12}
                         tickLine={false}
                         axisLine={false}
@@ -90,13 +93,13 @@ export const GoalCumulativeChart: React.FC<GoalCumulativeChartProps> = ({
                     />
                     <Tooltip
                         contentStyle={{
-                            backgroundColor: '#171717',
-                            borderColor: '#262626',
-                            color: '#e5e5e5',
+                            backgroundColor: themeColors.chartTooltipBg,
+                            borderColor: themeColors.lineSubtle,
+                            color: themeColors.contentPrimary,
                             borderRadius: '8px',
                             fontSize: '12px'
                         }}
-                        itemStyle={{ color: color }}
+                        itemStyle={{ color: lineColor }}
                         formatter={(value: number, _name, item) => {
                             // Suppress tooltip content for the synthetic leading buffer point
                             if (item && (item.payload as ChartPoint)?.synthetic) {
@@ -109,7 +112,7 @@ export const GoalCumulativeChart: React.FC<GoalCumulativeChartProps> = ({
                     <Area
                         type="monotone"
                         dataKey="value"
-                        stroke={color}
+                        stroke={lineColor}
                         fillOpacity={1}
                         fill="url(#colorValueCumulative)"
                         strokeWidth={2}
@@ -125,8 +128,8 @@ export const GoalCumulativeChart: React.FC<GoalCumulativeChartProps> = ({
                                     cx={cx}
                                     cy={cy}
                                     r={4}
-                                    fill={color}
-                                    stroke="#0A0A0A"
+                                    fill={lineColor}
+                                    stroke={themeColors.surface1}
                                     strokeWidth={1.5}
                                 />
                             );

--- a/src/components/goals/GoalEntryList.tsx
+++ b/src/components/goals/GoalEntryList.tsx
@@ -22,11 +22,11 @@ export const GoalEntryList: React.FC<GoalEntryListProps> = ({ entries }) => {
     if (entries.length === 0) {
         return (
             <div className="flex flex-col items-center justify-center py-12 text-center">
-                <div className="w-12 h-12 bg-neutral-800 rounded-full flex items-center justify-center mb-4">
-                    <Activity className="text-neutral-500" size={24} />
+                <div className="w-12 h-12 bg-surface-1 rounded-full flex items-center justify-center mb-4">
+                    <Activity className="text-content-muted" size={24} />
                 </div>
-                <p className="text-neutral-400 font-medium">No activity yet</p>
-                <p className="text-neutral-500 text-sm mt-1">
+                <p className="text-content-secondary font-medium">No activity yet</p>
+                <p className="text-content-muted text-sm mt-1">
                     Progress will appear here as you complete linked habits.
                 </p>
             </div>
@@ -38,20 +38,20 @@ export const GoalEntryList: React.FC<GoalEntryListProps> = ({ entries }) => {
             {sortedEntries.map((entry) => (
                 <div
                     key={entry.id}
-                    className="flex items-center justify-between p-3 bg-neutral-900/30 border border-white/5 rounded-lg hover:bg-neutral-900/50 transition-colors"
+                    className="flex items-center justify-between p-3 bg-surface-0/30 border border-line-subtle rounded-lg hover:bg-surface-0/50 transition-colors"
                 >
                     <div className="flex items-center gap-3">
-                        <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${entry.source === 'habit' ? 'bg-emerald-500/10 text-emerald-500' : 'bg-blue-500/10 text-blue-500'}`}>
+                        <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${entry.source === 'habit' ? 'bg-accent-soft text-emerald-500' : 'bg-blue-500/10 text-blue-500'}`}>
                             {entry.source === 'habit' ? <Activity size={14} /> : <Database size={14} />}
                         </div>
                         <div>
-                            <div className="text-white text-sm font-medium">
+                            <div className="text-content-primary text-sm font-medium">
                                 {format(parseISO(entry.date), 'MMM d, yyyy')}
                             </div>
-                            <div className="text-neutral-400 text-xs flex items-center gap-1.5">
+                            <div className="text-content-secondary text-xs flex items-center gap-1.5">
                                 {entry.source === 'habit' ? (
                                     <>
-                                        <span className="bg-emerald-500/10 text-emerald-400 text-[10px] px-1.5 py-0.5 rounded">Linked Habit</span>
+                                        <span className="bg-accent-soft text-accent-contrast text-[10px] px-1.5 py-0.5 rounded">Linked Habit</span>
                                         <span>{entry.habitName}</span>
                                     </>
                                 ) : (
@@ -61,8 +61,8 @@ export const GoalEntryList: React.FC<GoalEntryListProps> = ({ entries }) => {
                         </div>
                     </div>
                     <div className="text-right">
-                        <div className="text-white font-medium">
-                            +{Number.isInteger(entry.value) ? entry.value : entry.value.toFixed(1)} <span className="text-neutral-500 text-xs font-normal">{entry.unit}</span>
+                        <div className="text-content-primary font-medium">
+                            +{Number.isInteger(entry.value) ? entry.value : entry.value.toFixed(1)} <span className="text-content-muted text-xs font-normal">{entry.unit}</span>
                         </div>
                     </div>
                 </div>

--- a/src/components/goals/GoalGridCard.tsx
+++ b/src/components/goals/GoalGridCard.tsx
@@ -34,19 +34,19 @@ const CompactGoalCard: React.FC<GoalGridCardProps> = ({
 
     return (
         <div
-            className={`group flex items-center gap-2 bg-neutral-900/50 hover:bg-neutral-800/80 border rounded-xl px-3 py-2.5 transition-all cursor-pointer ${
+            className={`group flex items-center gap-2 bg-surface-0/50 hover:bg-surface-1/80 border rounded-xl px-3 py-2.5 transition-all cursor-pointer ${
                 isCompleted
-                    ? 'border-emerald-500/30'
+                    ? 'border-accent/30'
                     : progress.inactivityWarning
                         ? 'border-amber-500/40'
-                        : 'border-white/5 hover:border-white/10'
+                        : 'border-line-subtle hover:border-line-subtle'
             } ${isDragging ? 'opacity-50 shadow-2xl' : ''}`}
             onClick={() => onViewDetails(goal.id)}
         >
             {/* Drag handle */}
             <div
                 {...dragHandleProps}
-                className="flex-shrink-0 text-neutral-600 hover:text-neutral-400 cursor-grab active:cursor-grabbing touch-none"
+                className="flex-shrink-0 text-content-muted hover:text-content-secondary cursor-grab active:cursor-grabbing touch-none"
                 onClick={(e) => e.stopPropagation()}
             >
                 <GripVertical size={16} />
@@ -55,15 +55,15 @@ const CompactGoalCard: React.FC<GoalGridCardProps> = ({
             {/* Status icon */}
             <div className="flex-shrink-0">
                 {isCompleted ? (
-                    <div className="w-5 h-5 rounded-full bg-emerald-500/20 flex items-center justify-center">
-                        <Check size={12} className="text-emerald-400" />
+                    <div className="w-5 h-5 rounded-full bg-accent-soft flex items-center justify-center">
+                        <Check size={12} className="text-accent-contrast" />
                     </div>
                 ) : goal.type === 'onetime' ? (
-                    <div className="w-5 h-5 rounded-full border border-neutral-600 flex items-center justify-center">
-                        <div className="w-2 h-2 rounded-full bg-neutral-600" />
+                    <div className="w-5 h-5 rounded-full border border-line-strong flex items-center justify-center">
+                        <div className="w-2 h-2 rounded-full bg-surface-2" />
                     </div>
                 ) : (
-                    <div className="w-5 h-5 rounded-full border border-emerald-500/40 flex items-center justify-center">
+                    <div className="w-5 h-5 rounded-full border border-accent/40 flex items-center justify-center">
                         <div className="w-2 h-2 rounded-full bg-emerald-500/60" />
                     </div>
                 )}
@@ -71,7 +71,7 @@ const CompactGoalCard: React.FC<GoalGridCardProps> = ({
 
             {/* Title */}
             <span className={`flex-1 text-sm font-medium truncate ${
-                isCompleted ? 'text-neutral-500 line-through' : 'text-neutral-100'
+                isCompleted ? 'text-content-muted line-through' : 'text-content-primary'
             }`}>
                 {goal.title}
             </span>
@@ -80,7 +80,7 @@ const CompactGoalCard: React.FC<GoalGridCardProps> = ({
             <div className="flex items-center gap-2 flex-shrink-0">
                 {/* Deadline */}
                 {deadlineLabel && !isCompleted && (
-                    <span className="flex items-center gap-1 text-xs text-neutral-500">
+                    <span className="flex items-center gap-1 text-xs text-content-muted">
                         <Clock size={11} />
                         {deadlineLabel}
                     </span>
@@ -100,7 +100,7 @@ const CompactGoalCard: React.FC<GoalGridCardProps> = ({
                         e.stopPropagation();
                         onEdit(goal.id);
                     }}
-                    className="p-1 text-neutral-600 hover:text-white hover:bg-white/10 rounded-md transition-colors opacity-0 group-hover:opacity-100"
+                    className="p-1 text-content-muted hover:text-content-primary hover:bg-surface-2 rounded-md transition-colors opacity-0 group-hover:opacity-100"
                     title="Edit Goal"
                 >
                     <Edit size={14} />
@@ -129,12 +129,12 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
 
     return (
         <div
-            className={`group relative flex flex-col bg-neutral-900/50 hover:bg-neutral-800/80 border rounded-xl transition-all overflow-hidden cursor-pointer ${
+            className={`group relative flex flex-col bg-surface-0/50 hover:bg-surface-1/80 border rounded-xl transition-all overflow-hidden cursor-pointer ${
                 isCompleted
-                    ? 'border-emerald-500/30'
+                    ? 'border-accent/30'
                     : progress.inactivityWarning
                         ? 'border-amber-500/40'
-                        : 'border-white/5 hover:border-white/10'
+                        : 'border-line-subtle hover:border-line-subtle'
             } ${isDragging ? 'opacity-50 shadow-2xl' : ''}`}
             onClick={() => onViewDetails(goal.id)}
         >
@@ -143,17 +143,17 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
                 {/* Drag handle */}
                 <div
                     {...dragHandleProps}
-                    className="flex-shrink-0 mt-0.5 text-neutral-600 hover:text-neutral-400 cursor-grab active:cursor-grabbing touch-none"
+                    className="flex-shrink-0 mt-0.5 text-content-muted hover:text-content-secondary cursor-grab active:cursor-grabbing touch-none"
                     onClick={(e) => e.stopPropagation()}
                 >
                     <GripVertical size={16} />
                 </div>
 
                 <div className="flex-1 min-w-0">
-                    <h3 className="font-semibold text-neutral-100 truncate text-sm leading-tight">
+                    <h3 className="font-semibold text-content-primary truncate text-sm leading-tight">
                         {goal.title}
                     </h3>
-                    <div className="text-xs text-neutral-500 mt-0.5">
+                    <div className="text-xs text-content-muted mt-0.5">
                         {goal.targetValue} {goal.unit} total
                         {goal.deadline && (
                             <span> · by {new Date(goal.deadline + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>
@@ -167,7 +167,7 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
                         e.stopPropagation();
                         onEdit(goal.id);
                     }}
-                    className="flex-shrink-0 p-1 text-neutral-600 hover:text-white hover:bg-white/10 rounded-md transition-colors opacity-0 group-hover:opacity-100"
+                    className="flex-shrink-0 p-1 text-content-muted hover:text-content-primary hover:bg-surface-2 rounded-md transition-colors opacity-0 group-hover:opacity-100"
                     title="Edit Goal"
                 >
                     <Edit size={14} />
@@ -178,11 +178,11 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
             <div className="px-3 pb-3">
                 {isLowTarget ? (
                     <div className="w-full py-1">
-                        <div className="relative h-2.5 w-full bg-neutral-800 rounded-full overflow-hidden">
+                        <div className="relative h-2.5 w-full bg-surface-1 rounded-full overflow-hidden">
                             <div
                                 className={`h-full rounded-full transition-all duration-500 ease-out ${
                                     progress.percent >= 100
-                                        ? 'bg-emerald-500 shadow-[0_0_10px_rgba(16,185,129,0.3)]'
+                                        ? 'bg-accent shadow-[0_0_10px_rgba(16,185,129,0.3)]'
                                         : 'bg-emerald-500'
                                 }`}
                                 style={{ width: `${Math.min(100, progress.percent)}%` }}
@@ -190,12 +190,12 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
                             {Array.from({ length: target - 1 }, (_, i) => (
                                 <div
                                     key={i}
-                                    className="absolute top-0 h-full w-px bg-neutral-700"
+                                    className="absolute top-0 h-full w-px bg-surface-2"
                                     style={{ left: `${((i + 1) / target) * 100}%` }}
                                 />
                             ))}
                         </div>
-                        <div className="mt-1 text-xs text-neutral-400 font-medium text-center tabular-nums">
+                        <div className="mt-1 text-xs text-content-secondary font-medium text-center tabular-nums">
                             {progress.currentValue} / {target} {goal.unit || ''}
                         </div>
                     </div>
@@ -207,17 +207,17 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
                             targetValue={target}
                         />
                         <div className="mt-1.5">
-                            <div className="h-1.5 w-full bg-neutral-800 rounded-full overflow-hidden">
+                            <div className="h-1.5 w-full bg-surface-1 rounded-full overflow-hidden">
                                 <div
                                     className={`h-full rounded-full transition-all duration-500 ease-out ${
                                         progress.percent >= 100
-                                            ? 'bg-emerald-500 shadow-[0_0_10px_rgba(16,185,129,0.3)]'
+                                            ? 'bg-accent shadow-[0_0_10px_rgba(16,185,129,0.3)]'
                                             : 'bg-emerald-500'
                                     }`}
                                     style={{ width: `${Math.min(100, progress.percent)}%` }}
                                 />
                             </div>
-                            <div className="mt-1 text-xs text-neutral-400 font-medium text-center tabular-nums">
+                            <div className="mt-1 text-xs text-content-secondary font-medium text-center tabular-nums">
                                 {progress.currentValue} / {target} {goal.unit || ''}
                             </div>
                         </div>

--- a/src/components/goals/GoalPulseCard.tsx
+++ b/src/components/goals/GoalPulseCard.tsx
@@ -54,22 +54,22 @@ export const GoalPulseCard: React.FC<GoalPulseCardProps> = ({ goalWithProgress, 
     // Determine if goal should have subtle emphasis (has deadline and is upcoming)
     const hasUpcomingDeadline = deadlineInfo !== null;
     const emphasisClass = hasUpcomingDeadline
-        ? 'border-emerald-500/20 bg-neutral-900/60'
-        : 'border-white/5 bg-neutral-900/50';
+        ? 'border-accent/20 bg-surface-0/60'
+        : 'border-line-subtle bg-surface-0/50';
 
     return (
         <button
             onClick={onClick}
-            className={`group w-full text-left ${emphasisClass} hover:bg-neutral-800 border hover:border-white/10 rounded-xl p-3 transition-all duration-200 cursor-pointer flex flex-col justify-between h-full`}
+            className={`group w-full text-left ${emphasisClass} hover:bg-surface-1 border hover:border-line-subtle rounded-xl p-3 transition-all duration-200 cursor-pointer flex flex-col justify-between h-full`}
         >
             <div className="flex items-start justify-between w-full mb-2">
                 <div className="flex-1 min-w-0 pr-2">
-                    <h4 className="text-sm font-medium text-neutral-200 group-hover:text-white truncate">
+                    <h4 className="text-sm font-medium text-content-primary group-hover:text-content-primary truncate">
                         {goal.title}
                     </h4>
                     {/* Optional "Upcoming" / "Preparing" label */}
                     {deadlineInfo && (
-                        <div className="text-[10px] text-emerald-400/80 font-medium mt-0.5">
+                        <div className="text-[10px] text-accent-contrast/80 font-medium mt-0.5">
                             {deadlineInfo.label}
                         </div>
                     )}
@@ -77,11 +77,11 @@ export const GoalPulseCard: React.FC<GoalPulseCardProps> = ({ goalWithProgress, 
 
                 {/* One-Time Goal Status / Cumulative Value */}
                 {isCumulative ? (
-                    <span className="text-xs font-mono text-neutral-500 group-hover:text-neutral-400 whitespace-nowrap">
+                    <span className="text-xs font-mono text-content-muted group-hover:text-content-secondary whitespace-nowrap">
                         {Math.round(progress.percent)}%
                     </span>
                 ) : (
-                    <span className="text-[10px] uppercase tracking-wide font-medium text-neutral-500 bg-neutral-800/50 px-1.5 py-0.5 rounded border border-white/5">
+                    <span className="text-[10px] uppercase tracking-wide font-medium text-content-muted bg-surface-1/50 px-1.5 py-0.5 rounded border border-line-subtle">
                         {deadlineLabel}
                     </span>
                 )}
@@ -89,7 +89,7 @@ export const GoalPulseCard: React.FC<GoalPulseCardProps> = ({ goalWithProgress, 
 
             {/* Progress Bar (Only for Cumulative) */}
             {isCumulative && (
-                <div className="w-full h-1 bg-neutral-800 rounded-full overflow-hidden">
+                <div className="w-full h-1 bg-surface-1 rounded-full overflow-hidden">
                     <div
                         className="h-full bg-emerald-500/80 transition-all duration-500"
                         style={{ width: `${Math.min(100, progress.percent)}%` }}
@@ -99,7 +99,7 @@ export const GoalPulseCard: React.FC<GoalPulseCardProps> = ({ goalWithProgress, 
 
             {/* One-Time Goal Extra Context (Optional, keep minimal) */}
             {!isCumulative && (
-                <div className="text-xs text-neutral-600 truncate">
+                <div className="text-xs text-content-muted truncate">
                     {goal.completedAt ? 'Completed' : 'One-time goal'}
                 </div>
             )}

--- a/src/components/goals/GoalSharedComponents.tsx
+++ b/src/components/goals/GoalSharedComponents.tsx
@@ -17,7 +17,7 @@ import { AlertTriangle } from 'lucide-react';
  * Consistent styling:
  * - Height: 2 (8px) for compact views, 4 (16px) for detail views
  * - Border radius: rounded-full
- * - Background: bg-neutral-700
+ * - Background: bg-surface-2
  * - Fill: bg-emerald-500
  */
 interface ProgressBarProps {
@@ -40,7 +40,7 @@ export const GoalProgressBar: React.FC<ProgressBarProps> = ({
     const cappedPercent = Math.min(100, Math.max(0, percent));
 
     return (
-        <div className={`w-full ${heightClass} bg-neutral-700 rounded-full overflow-hidden ${className}`}>
+        <div className={`w-full ${heightClass} bg-surface-2 rounded-full overflow-hidden ${className}`}>
             <div
                 className={`h-full bg-emerald-500 transition-all duration-300`}
                 style={{ width: `${cappedPercent}%` }}
@@ -69,7 +69,7 @@ export const GoalStatusChip: React.FC<StatusChipProps> = ({
 
     const statusClasses = {
         active: 'bg-blue-500/20 text-blue-400 border border-blue-500/30',
-        completed: 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30',
+        completed: 'bg-accent-soft text-accent-contrast border border-accent/30',
         warning: 'bg-amber-500/20 text-amber-400 border border-amber-500/30',
     }[status];
 
@@ -105,7 +105,7 @@ export const GoalMilestoneDots: React.FC<MilestoneDotsProps> = ({
                         key={threshold}
                         className={`w-1.5 h-1.5 rounded-full transition-colors ${isFilled
                                 ? 'bg-emerald-500'
-                                : 'bg-neutral-600'
+                                : 'bg-surface-2'
                             }`}
                         title={`${threshold}%`}
                     />
@@ -144,18 +144,18 @@ export const GoalInactivityWarningBadge: React.FC<InactivityWarningBadgeProps> =
  * 
  * Consistent border radius, shadows, and spacing.
  */
-export const goalCardBaseClasses = 'bg-neutral-800/50 border border-white/10 rounded-lg overflow-hidden transition-all';
+export const goalCardBaseClasses = 'bg-surface-1/50 border border-line-subtle rounded-lg overflow-hidden transition-all';
 export const goalCardPaddingClasses = 'p-4 sm:p-5';
-export const goalCardHoverClasses = 'hover:bg-neutral-800/70';
+export const goalCardHoverClasses = 'hover:bg-surface-1/70';
 
 /**
  * Shared goal title styling.
  */
-export const goalTitleClasses = 'text-lg font-semibold text-white';
-export const goalTitleCompactClasses = 'font-semibold text-white';
+export const goalTitleClasses = 'text-lg font-semibold text-content-primary';
+export const goalTitleCompactClasses = 'font-semibold text-content-primary';
 
 /**
  * Shared goal subtitle/metadata styling.
  */
-export const goalSubtitleClasses = 'text-sm text-neutral-400';
-export const goalMetadataClasses = 'text-xs text-neutral-500';
+export const goalSubtitleClasses = 'text-sm text-content-secondary';
+export const goalMetadataClasses = 'text-xs text-content-muted';

--- a/src/components/goals/GoalTrackSection.tsx
+++ b/src/components/goals/GoalTrackSection.tsx
@@ -33,17 +33,17 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
 
     return (
         <div
-            className={`bg-neutral-800/30 border border-white/5 rounded-lg overflow-hidden mb-2 ${
+            className={`bg-surface-1/30 border border-line-subtle rounded-lg overflow-hidden mb-2 ${
                 isDragging ? 'opacity-50 shadow-2xl' : ''
             }`}
         >
             {/* Track Header */}
-            <div className="flex items-center gap-1 pl-2 pr-0 hover:bg-neutral-800/50 transition-colors">
+            <div className="flex items-center gap-1 pl-2 pr-0 hover:bg-surface-1/50 transition-colors">
                 {/* Drag handle */}
                 {dragHandleProps && (
                     <div
                         {...dragHandleProps}
-                        className="flex-shrink-0 text-neutral-600 hover:text-neutral-400 cursor-grab active:cursor-grabbing touch-none py-2.5"
+                        className="flex-shrink-0 text-content-muted hover:text-content-secondary cursor-grab active:cursor-grabbing touch-none py-2.5"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <GripVertical size={16} />
@@ -53,23 +53,23 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
                     onClick={() => onViewTrack?.(track.id)}
                     className="flex-1 flex items-center gap-2.5 px-2 py-2.5 text-left"
                 >
-                <Route size={15} className="text-emerald-400 flex-shrink-0" />
+                <Route size={15} className="text-accent-contrast flex-shrink-0" />
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                        <span className="text-sm font-semibold text-white truncate">{track.name}</span>
-                        <span className="text-xs text-neutral-500 flex-shrink-0">
+                        <span className="text-sm font-semibold text-content-primary truncate">{track.name}</span>
+                        <span className="text-xs text-content-muted flex-shrink-0">
                             {completedCount}/{totalCount}
                         </span>
                     </div>
                     {/* Mini progress bar */}
-                    <div className="mt-1 h-1 bg-neutral-700 rounded-full overflow-hidden">
+                    <div className="mt-1 h-1 bg-surface-2 rounded-full overflow-hidden">
                         <div
                             className="h-full bg-emerald-500 rounded-full transition-all duration-300"
                             style={{ width: `${progressPercent}%` }}
                         />
                     </div>
                 </div>
-                <ChevronRight size={14} className="text-neutral-500 flex-shrink-0" />
+                <ChevronRight size={14} className="text-content-muted flex-shrink-0" />
                 </button>
             </div>
 
@@ -87,22 +87,22 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
                             onClick={() => onViewGoal?.(goal.id)}
                             className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-left transition-colors ${
                                 isLocked
-                                    ? 'opacity-60 hover:bg-neutral-800/50 hover:opacity-100'
+                                    ? 'opacity-60 hover:bg-surface-1/50 hover:opacity-100'
                                     : isActive
-                                    ? 'bg-emerald-500/5 border border-emerald-500/20 hover:bg-emerald-500/10'
+                                    ? 'bg-emerald-500/5 border border-accent/20 hover:bg-accent-strong/10'
                                     : isCompleted
-                                    ? 'hover:bg-neutral-800/50'
-                                    : 'hover:bg-neutral-800/50'
+                                    ? 'hover:bg-surface-1/50'
+                                    : 'hover:bg-surface-1/50'
                             }`}
                         >
                             {/* State indicator */}
                             <div className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
                                 {isCompleted ? (
-                                    <div className="w-4.5 h-4.5 rounded-full bg-emerald-500/20 flex items-center justify-center">
-                                        <Check size={11} className="text-emerald-400" />
+                                    <div className="w-4.5 h-4.5 rounded-full bg-accent-soft flex items-center justify-center">
+                                        <Check size={11} className="text-accent-contrast" />
                                     </div>
                                 ) : isLocked ? (
-                                    <Lock size={12} className="text-neutral-600" />
+                                    <Lock size={12} className="text-content-muted" />
                                 ) : (
                                     <div className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
                                 )}
@@ -111,21 +111,21 @@ export const GoalTrackSection: React.FC<GoalTrackSectionProps> = ({
                             {/* Goal info */}
                             <div className="flex-1 min-w-0">
                                 <div className={`text-sm truncate ${
-                                    isCompleted ? 'text-neutral-500 line-through' :
-                                    isLocked ? 'text-neutral-500' :
-                                    'text-white font-medium'
+                                    isCompleted ? 'text-content-muted line-through' :
+                                    isLocked ? 'text-content-muted' :
+                                    'text-content-primary font-medium'
                                 }`}>
                                     {goal.title}
                                 </div>
                                 {isActive && gwp && goal.type === 'cumulative' && gwp.progress.percent > 0 && (
-                                    <div className="text-xs text-neutral-400 mt-0.5">
+                                    <div className="text-xs text-content-secondary mt-0.5">
                                         {gwp.progress.percent}% complete
                                     </div>
                                 )}
                             </div>
 
                             {/* Step indicator */}
-                            <span className="text-[10px] text-neutral-600 flex-shrink-0">
+                            <span className="text-[10px] text-content-muted flex-shrink-0">
                                 {index + 1}/{totalCount}
                             </span>
                         </button>

--- a/src/components/goals/GoalTrendChart.tsx
+++ b/src/components/goals/GoalTrendChart.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts';
 import { format, parseISO, isValid, eachDayOfInterval, isAfter, subDays, addDays, differenceInDays } from 'date-fns';
+import { useThemeColors } from '../../theme/useThemeColors';
 
 interface GoalTrendChartProps {
     data: Array<{
@@ -26,9 +27,11 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
     deadline,
     targetValue,
     firstEntryDate,
-    color = "#10b981", // emerald-500
+    color,
     unit = ""
 }) => {
+    const themeColors = useThemeColors();
+    const accent = color ?? themeColors.accent;
     const { chartData, currentActual, forecastDateStr } = useMemo(() => {
         // 1. Determine the effective chart start: first entry minus a 2-day
         // buffer if we have one, else fall back to the goal's startDate.
@@ -137,8 +140,8 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
 
     if (!isValid(parseISO(startDate)) || !isValid(parseISO(deadline))) {
         return (
-            <div className="flex items-center justify-center h-64 bg-neutral-900/30 rounded-lg border border-white/5">
-                <p className="text-neutral-500 text-sm">Invalid date configuration.</p>
+            <div className="flex items-center justify-center h-64 bg-surface-1/60 rounded-lg border border-line-subtle">
+                <p className="text-content-muted text-sm">Invalid date configuration.</p>
             </div>
         );
     }
@@ -146,9 +149,9 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
     return (
         <div className="w-full space-y-3">
             {requiredPace !== null && (
-                <div className="text-sm text-neutral-400">
+                <div className="text-sm text-content-secondary">
                     Required pace:{' '}
-                    <span className="text-white font-medium">
+                    <span className="text-content-primary font-medium">
                         {requiredPace.toFixed(1)} {unit}
                     </span>{' '}
                     / week
@@ -156,17 +159,17 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
             )}
             <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
                 <div className="flex items-center gap-1.5">
-                    <span className="inline-block w-4 border-t border-neutral-500" />
-                    <span className="text-neutral-400">Deadline {format(parseISO(deadline), 'MMM d')}</span>
+                    <span className="inline-block w-4 border-t border-content-muted" />
+                    <span className="text-content-secondary">Deadline {format(parseISO(deadline), 'MMM d')}</span>
                 </div>
                 {forecastDateStr && (
                     <div className="flex items-center gap-1.5">
-                        <span className="inline-block w-4 border-t border-dashed border-emerald-500" />
-                        <span className="text-emerald-500">Forecast {format(parseISO(forecastDateStr), 'MMM d')}</span>
+                        <span className="inline-block w-4 border-t border-dashed" style={{ borderColor: accent }} />
+                        <span style={{ color: accent }}>Forecast {format(parseISO(forecastDateStr), 'MMM d')}</span>
                     </div>
                 )}
             </div>
-            <div className="w-full h-80 bg-neutral-900/30 rounded-lg border border-white/5 p-4">
+            <div className="w-full h-80 bg-surface-1/60 rounded-lg border border-line-subtle p-4">
             <ResponsiveContainer width="100%" height="100%">
                 <ComposedChart
                     data={chartData}
@@ -174,22 +177,22 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
                 >
                     <defs>
                         <linearGradient id="colorActual" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="5%" stopColor={color} stopOpacity={0.3} />
-                            <stop offset="95%" stopColor={color} stopOpacity={0} />
+                            <stop offset="5%" stopColor={accent} stopOpacity={0.3} />
+                            <stop offset="95%" stopColor={accent} stopOpacity={0} />
                         </linearGradient>
                     </defs>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" vertical={false} />
+                    <CartesianGrid strokeDasharray="3 3" stroke={themeColors.chartGrid} vertical={false} />
                     <XAxis
                         dataKey="date"
                         tickFormatter={formatXAxis}
-                        stroke="#737373"
+                        stroke={themeColors.chartAxis}
                         fontSize={12}
                         tickLine={false}
                         axisLine={false}
                         minTickGap={30}
                     />
                     <YAxis
-                        stroke="#737373"
+                        stroke={themeColors.chartAxis}
                         fontSize={12}
                         tickLine={false}
                         axisLine={false}
@@ -197,9 +200,9 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
                     />
                     <Tooltip
                         contentStyle={{
-                            backgroundColor: '#171717',
-                            borderColor: '#262626',
-                            color: '#e5e5e5',
+                            backgroundColor: themeColors.chartTooltipBg,
+                            borderColor: themeColors.lineSubtle,
+                            color: themeColors.contentPrimary,
                             borderRadius: '8px',
                             fontSize: '12px'
                         }}
@@ -215,7 +218,7 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
                     <Line
                         type="monotone"
                         dataKey="ideal"
-                        stroke="#525252" // Neutral-600
+                        stroke={themeColors.contentMuted}
                         strokeDasharray="5 5"
                         dot={false}
                         strokeWidth={2}
@@ -226,7 +229,7 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
                     <Area
                         type="monotone"
                         dataKey="actual"
-                        stroke={color}
+                        stroke={accent}
                         fillOpacity={1}
                         fill="url(#colorActual)"
                         strokeWidth={2}
@@ -237,7 +240,7 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
                     {/* Deadline vertical marker */}
                     <ReferenceLine
                         x={deadline}
-                        stroke="#737373" // neutral-500
+                        stroke={themeColors.contentMuted}
                         strokeWidth={1}
                     />
 
@@ -245,7 +248,7 @@ export const GoalTrendChart: React.FC<GoalTrendChartProps> = ({
                     {forecastDateStr && (
                         <ReferenceLine
                             x={forecastDateStr}
-                            stroke="#10b981" // emerald-500
+                            stroke={accent}
                             strokeWidth={1.5}
                             strokeDasharray="4 4"
                         />

--- a/src/components/goals/GoalWeeklySummary.tsx
+++ b/src/components/goals/GoalWeeklySummary.tsx
@@ -40,20 +40,20 @@ export const GoalWeeklySummary: React.FC<GoalWeeklySummaryProps> = ({ entries, u
 
     return (
         <div className="mt-6 space-y-3">
-            <h3 className="text-neutral-400 text-xs font-medium uppercase tracking-wider">Weekly Contribution</h3>
+            <h3 className="text-content-secondary text-xs font-medium uppercase tracking-wider">Weekly Contribution</h3>
             <div className="space-y-2">
                 {weeklyData.map((week, index) => (
                     <div key={index} className="flex items-center gap-3">
-                        <div className="w-20 text-xs text-neutral-500 font-medium text-right shrink-0">
+                        <div className="w-20 text-xs text-content-muted font-medium text-right shrink-0">
                             {week.label}
                         </div>
-                        <div className="flex-1 h-6 bg-neutral-800/50 rounded-md overflow-hidden flex items-center p-0.5">
+                        <div className="flex-1 h-6 bg-surface-1/50 rounded-md overflow-hidden flex items-center p-0.5">
                             <div
-                                className={`h-full rounded-sm transition-all duration-500 ${week.isCurrentWeek ? 'bg-emerald-500/80' : 'bg-neutral-600/50'}`}
+                                className={`h-full rounded-sm transition-all duration-500 ${week.isCurrentWeek ? 'bg-emerald-500/80' : 'bg-surface-2/50'}`}
                                 style={{ width: `${(week.value / maxValue) * 100}%`, minWidth: week.value > 0 ? '4px' : '0' }}
                             />
                         </div>
-                        <div className="w-16 text-xs text-neutral-300 font-medium shrink-0">
+                        <div className="w-16 text-xs text-content-secondary font-medium shrink-0">
                             {Number.isInteger(week.value) ? week.value : week.value.toFixed(1)} {unit}
                         </div>
                     </div>

--- a/src/components/goals/InactivityCoachingPopup.tsx
+++ b/src/components/goals/InactivityCoachingPopup.tsx
@@ -61,17 +61,17 @@ export const InactivityCoachingPopup: React.FC<InactivityCoachingPopupProps> = (
             style={{ top: position.top, left: position.left }}
         >
             <div className="fixed inset-0" onClick={onClose} />
-            <div className="relative bg-neutral-800 border border-amber-500/30 rounded-xl p-4 shadow-xl w-80 animate-in fade-in zoom-in-95 duration-200" onClick={(e) => e.stopPropagation()}>
+            <div className="relative bg-surface-1 border border-amber-500/30 rounded-xl p-4 shadow-xl w-80 animate-in fade-in zoom-in-95 duration-200" onClick={(e) => e.stopPropagation()}>
                 <button
                     onClick={onClose}
-                    className="absolute top-3 right-3 text-neutral-400 hover:text-white transition-colors"
+                    className="absolute top-3 right-3 text-content-secondary hover:text-content-primary transition-colors"
                 >
                     <X size={16} />
                 </button>
 
                 <div className="space-y-3">
                     <div>
-                        <h3 className="text-white font-semibold text-sm mb-1">
+                        <h3 className="text-content-primary font-semibold text-sm mb-1">
                             Progress compounds — even a small action today moves you forward.
                         </h3>
                     </div>
@@ -80,7 +80,7 @@ export const InactivityCoachingPopup: React.FC<InactivityCoachingPopupProps> = (
                         <div className="text-amber-400 text-sm font-medium mb-1">
                             Try this:
                         </div>
-                        <div className="text-white text-sm">
+                        <div className="text-content-primary text-sm">
                             {suggestion}
                         </div>
                     </div>

--- a/src/components/goals/MiniHeatmap.tsx
+++ b/src/components/goals/MiniHeatmap.tsx
@@ -65,7 +65,7 @@ export const MiniHeatmap: React.FC<MiniHeatmapProps> = ({ data }) => {
                             title={tooltipText}
                         >
                             {!String(day.date).startsWith('empty') && (
-                                <div className="hidden group-hover/cell:block absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-neutral-900 border border-white/10 text-[10px] text-white rounded whitespace-nowrap z-10 pointer-events-none shadow-xl">
+                                <div className="hidden group-hover/cell:block absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-surface-0 border border-line-subtle text-[10px] text-content-primary rounded whitespace-nowrap z-10 pointer-events-none shadow-xl">
                                     {day.date} • {day.value}
                                 </div>
                             )}

--- a/src/components/goals/MiniHeatmap.tsx
+++ b/src/components/goals/MiniHeatmap.tsx
@@ -44,7 +44,7 @@ export const MiniHeatmap: React.FC<MiniHeatmapProps> = ({ data }) => {
         <div className="flex flex-col gap-1 w-full">
             <div className="grid grid-cols-7 gap-1 w-full relative">
                 {displayData.map((day, idx) => {
-                    let bgClass = "bg-white/5";
+                    let bgClass = "bg-surface-1";
                     if (day.hasProgress) {
                         bgClass = "bg-emerald-500";
                     }

--- a/src/components/goals/ScheduleCalendar.tsx
+++ b/src/components/goals/ScheduleCalendar.tsx
@@ -47,17 +47,17 @@ export const ScheduleCalendar: React.FC<ScheduleCalendarProps> = ({
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => onMonthChange(subMonths(currentMonth, 1))}
-          className="p-1.5 rounded-lg hover:bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+          className="p-1.5 rounded-lg hover:bg-surface-1 text-content-secondary hover:text-content-primary transition-colors"
           aria-label="Previous month"
         >
           <ChevronLeft size={20} />
         </button>
-        <h3 className="text-lg font-semibold text-white">
+        <h3 className="text-lg font-semibold text-content-primary">
           {format(currentMonth, 'MMMM yyyy')}
         </h3>
         <button
           onClick={() => onMonthChange(addMonths(currentMonth, 1))}
-          className="p-1.5 rounded-lg hover:bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+          className="p-1.5 rounded-lg hover:bg-surface-1 text-content-secondary hover:text-content-primary transition-colors"
           aria-label="Next month"
         >
           <ChevronRight size={20} />
@@ -67,14 +67,14 @@ export const ScheduleCalendar: React.FC<ScheduleCalendarProps> = ({
       {/* Day Names Header */}
       <div className="grid grid-cols-7 gap-px mb-1">
         {DAY_NAMES.map(name => (
-          <div key={name} className="text-center text-xs font-medium text-neutral-500 py-1.5">
+          <div key={name} className="text-center text-xs font-medium text-content-muted py-1.5">
             {name}
           </div>
         ))}
       </div>
 
       {/* Calendar Grid */}
-      <div className="grid grid-cols-7 gap-px bg-neutral-800/30 rounded-lg overflow-hidden">
+      <div className="grid grid-cols-7 gap-px bg-surface-1/30 rounded-lg overflow-hidden">
         {calendarDays.map(day => {
           const dateKey = format(day, 'yyyy-MM-dd');
           const dayEvents = events.get(dateKey) || [];
@@ -93,15 +93,15 @@ export const ScheduleCalendar: React.FC<ScheduleCalendarProps> = ({
               className={`
                 relative min-h-[3.25rem] sm:min-h-[3.75rem] p-1 sm:p-1.5 flex flex-col items-center
                 transition-colors
-                ${inMonth ? 'bg-neutral-900/60' : 'bg-neutral-900/20'}
+                ${inMonth ? 'bg-surface-0/60' : 'bg-surface-0/20'}
                 ${isSelected ? 'ring-2 ring-emerald-500/60 ring-inset' : ''}
-                ${dayEvents.length > 0 && inMonth ? 'hover:bg-neutral-800/80 cursor-pointer' : 'hover:bg-neutral-800/40'}
+                ${dayEvents.length > 0 && inMonth ? 'hover:bg-surface-1/80 cursor-pointer' : 'hover:bg-surface-1/40'}
               `}
             >
               {/* Day Number */}
               <span className={`
                 text-xs sm:text-sm font-medium leading-none
-                ${!inMonth ? 'text-neutral-700' : today ? 'text-emerald-400 font-bold' : 'text-neutral-300'}
+                ${!inMonth ? 'text-neutral-700' : today ? 'text-accent-contrast font-bold' : 'text-content-secondary'}
               `}>
                 {format(day, 'd')}
               </span>
@@ -110,7 +110,7 @@ export const ScheduleCalendar: React.FC<ScheduleCalendarProps> = ({
               {dayEvents.length > 0 && inMonth && (
                 <div className="flex items-center gap-0.5 mt-1 flex-wrap justify-center">
                   {showOverflow ? (
-                    <span className="text-[10px] font-semibold text-neutral-300 bg-neutral-700 rounded-full px-1.5 py-0.5 leading-none">
+                    <span className="text-[10px] font-semibold text-content-secondary bg-surface-2 rounded-full px-1.5 py-0.5 leading-none">
                       {dayEvents.length}
                     </span>
                   ) : (

--- a/src/components/tasks/AddTaskInput.tsx
+++ b/src/components/tasks/AddTaskInput.tsx
@@ -46,9 +46,9 @@ export const AddTaskInput: React.FC<AddTaskInputProps> = ({
                 disabled={isSubmitting}
                 enterKeyHint="done"
                 className="
-          w-full bg-neutral-900 border border-neutral-800 rounded-lg py-2.5 pl-9 pr-10
-          text-base sm:text-sm text-neutral-200 placeholder-neutral-500
-          focus:outline-none focus:border-neutral-600 focus:bg-neutral-800
+          w-full bg-surface-0 border border-line-subtle rounded-lg py-2.5 pl-9 pr-10
+          text-base sm:text-sm text-content-primary placeholder-neutral-500
+          focus:outline-none focus:border-line-strong focus:bg-surface-1
           transition-all duration-200
         "
             />
@@ -56,7 +56,7 @@ export const AddTaskInput: React.FC<AddTaskInputProps> = ({
                 <button
                     type="submit"
                     disabled={isSubmitting}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md text-emerald-400 hover:bg-emerald-500/20 transition-colors disabled:opacity-50"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md text-accent-contrast hover:bg-accent-strong/20 transition-colors disabled:opacity-50"
                 >
                     <Check size={16} />
                 </button>

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -41,8 +41,8 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
                 className={`
           flex-shrink-0 w-5 h-5 rounded border flex items-center justify-center transition-colors
           ${isCompleted
-                        ? 'bg-emerald-500/20 border-emerald-500 text-emerald-500'
-                        : 'border-neutral-700 hover:border-neutral-500 text-transparent'
+                        ? 'bg-accent-soft border-emerald-500 text-emerald-500'
+                        : 'border-line-strong hover:border-neutral-500 text-transparent'
                     }
         `}
             >
@@ -51,7 +51,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
 
             {/* Title */}
             <span
-                className={`flex-grow text-sm font-light text-neutral-200 transition-all ${isCompleted ? 'line-through text-neutral-500' : ''}`}
+                className={`flex-grow text-sm font-light text-content-primary transition-all ${isCompleted ? 'line-through text-content-muted' : ''}`}
             >
                 {task.title}
             </span>
@@ -61,7 +61,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
                 {task.listPlacement === 'inbox' && !isCompleted && (
                     <button
                         onClick={handleMoveToToday}
-                        className="p-1.5 text-neutral-500 hover:text-emerald-400 hover:bg-emerald-500/10 rounded transition-colors"
+                        className="p-1.5 text-content-muted hover:text-accent-contrast hover:bg-accent-strong/10 rounded transition-colors"
                         title="Move to Today"
                     >
                         <ArrowRight size={14} />
@@ -71,7 +71,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
                 {task.listPlacement === 'today' && !isCompleted && (
                     <button
                         onClick={handleMoveToInbox}
-                        className="p-1.5 text-neutral-500 hover:text-amber-400 hover:bg-amber-500/10 rounded transition-colors"
+                        className="p-1.5 text-content-muted hover:text-amber-400 hover:bg-amber-500/10 rounded transition-colors"
                         title="Move to Inbox"
                     >
                         <ArrowLeft size={14} />
@@ -80,7 +80,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
 
                 <button
                     onClick={handleDetail}
-                    className="p-1.5 text-neutral-500 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                    className="p-1.5 text-content-muted hover:text-danger-contrast hover:bg-danger-soft rounded transition-colors"
                     title="Delete"
                     disabled={isDeleting}
                 >

--- a/src/index.css
+++ b/src/index.css
@@ -2,19 +2,117 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Theme tokens — semantic design system.
+ *
+ * These CSS variables are the source of truth for Tailwind's semantic aliases
+ * (bg-surface-1, text-content-muted, etc.). The Tailwind config resolves those
+ * aliases via `rgb(var(--x) / <alpha-value>)`, so opacity modifiers work too:
+ * `bg-surface-1/80`, `border-line-subtle/50`.
+ *
+ * Values are kept in sync with src/theme/palette.ts. That TS module is the
+ * single canonical source; this block is the pre-hydration fallback so the
+ * first paint is never unstyled. If you edit these values, update palette.ts
+ * to match — a runtime check in cssVars.ts will overwrite these anyway.
+ *
+ * Values must be space-separated RGB triplets (e.g. `255 255 255`), NOT
+ * comma-separated or `rgb(...)` — otherwise the `<alpha-value>` pattern
+ * silently breaks.
+ */
+
+/* Light theme — default when no class is present. */
 :root {
+  --surface-0: 250 250 250;
+  --surface-1: 255 255 255;
+  --surface-2: 245 245 245;
+
+  --content-primary: 23 23 23;
+  --content-secondary: 82 82 82;
+  --content-muted: 115 115 115;
+  --content-on-accent: 255 255 255;
+
+  --line-subtle: 229 229 229;
+  --line-strong: 212 212 212;
+
+  --accent: 16 185 129;
+  --accent-strong: 5 150 105;
+  --accent-soft: 236 253 245;
+  --accent-contrast: 4 120 87;
+
+  --warning: 217 119 6;
+  --warning-soft: 254 243 199;
+  --warning-contrast: 180 83 9;
+
+  --danger: 220 38 38;
+  --danger-soft: 254 226 226;
+  --danger-contrast: 185 28 28;
+
+  --focus-ring: 37 99 235;
+
+  --chart-grid: 229 229 229;
+  --chart-axis: 115 115 115;
+  --chart-tooltip-bg: 255 255 255;
+
+  --heatmap-0: 245 245 245;
+  --heatmap-1: 209 250 229;
+  --heatmap-2: 110 231 183;
+  --heatmap-3: 16 185 129;
+  --heatmap-4: 4 120 87;
+
+  /* base typography — applied regardless of theme */
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
+
+  color: rgb(var(--content-primary));
+  background-color: rgb(var(--surface-0));
+}
+
+/* Dark theme — activated by class="dark" on <html>. */
+.dark {
+  --surface-0: 23 23 23;
+  --surface-1: 38 38 38;
+  --surface-2: 64 64 64;
+
+  --content-primary: 255 255 255;
+  --content-secondary: 212 212 212;
+  --content-muted: 163 163 163;
+  --content-on-accent: 10 10 10;
+
+  --line-subtle: 42 42 42;
+  --line-strong: 64 64 64;
+
+  --accent: 16 185 129;
+  --accent-strong: 52 211 153;
+  --accent-soft: 10 46 35;
+  --accent-contrast: 52 211 153;
+
+  --warning: 245 158 11;
+  --warning-soft: 58 42 10;
+  --warning-contrast: 251 191 36;
+
+  --danger: 251 113 133;
+  --danger-soft: 58 13 20;
+  --danger-contrast: 253 164 175;
+
+  --focus-ring: 16 185 129;
+
+  --chart-grid: 64 64 64;
+  --chart-axis: 163 163 163;
+  --chart-tooltip-bg: 38 38 38;
+
+  --heatmap-0: 38 38 38;
+  --heatmap-1: 6 78 59;
+  --heatmap-2: 4 120 87;
+  --heatmap-3: 16 185 129;
+  --heatmap-4: 110 231 183;
+
+  color-scheme: dark;
 }
 
 body {
@@ -22,6 +120,80 @@ body {
   min-width: 320px;
   min-height: 100vh;
   min-height: 100dvh;
+  color: rgb(var(--content-primary));
+  background-color: rgb(var(--surface-0));
+}
+
+/*
+ * Shared component helpers.
+ *
+ * These sit in @layer components so Tailwind utilities still override them
+ * (per the cascade). They exist to stop the same ~12-word Tailwind string
+ * from being duplicated across every card / button / input in the app.
+ *
+ * Use these as the default; use inline Tailwind when a component legitimately
+ * needs to deviate.
+ */
+@layer components {
+  .hf-card {
+    @apply rounded-xl border border-line-subtle bg-surface-1;
+  }
+  .hf-card-hover {
+    @apply hover:bg-surface-2 transition-colors;
+  }
+  .hf-modal-panel {
+    @apply rounded-xl border border-line-subtle bg-surface-1 shadow-xl;
+  }
+  .hf-divider {
+    @apply border-t border-line-subtle;
+  }
+  .hf-input {
+    @apply rounded-lg bg-surface-1 border border-line-strong
+           text-content-primary placeholder:text-content-muted
+           focus:outline-none focus:ring-2 focus:ring-focus/50 focus:border-focus;
+  }
+  .hf-btn-primary {
+    @apply inline-flex items-center justify-center gap-2
+           rounded-lg px-4 py-2 font-medium
+           bg-accent text-content-on-accent hover:bg-accent-strong
+           transition-colors focus:outline-none focus:ring-2 focus:ring-focus/50
+           disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+  .hf-btn-secondary {
+    @apply inline-flex items-center justify-center gap-2
+           rounded-lg px-4 py-2 font-medium
+           bg-accent-soft text-accent-contrast border border-line-subtle
+           hover:bg-surface-2 transition-colors
+           focus:outline-none focus:ring-2 focus:ring-focus/50;
+  }
+  .hf-btn-ghost {
+    @apply inline-flex items-center justify-center
+           rounded-lg p-2
+           text-content-secondary hover:text-content-primary hover:bg-surface-2
+           transition-colors focus:outline-none focus:ring-2 focus:ring-focus/50;
+  }
+  .hf-btn-danger {
+    @apply inline-flex items-center justify-center gap-2
+           rounded-lg px-4 py-2 font-medium
+           bg-danger-soft text-danger-contrast border border-line-subtle
+           hover:bg-surface-2 transition-colors
+           focus:outline-none focus:ring-2 focus:ring-focus/50;
+  }
+  .hf-chip {
+    @apply inline-flex items-center gap-1.5
+           rounded-full px-3 py-1 text-xs
+           bg-surface-2 text-content-secondary border border-line-subtle;
+  }
+  .hf-tab {
+    @apply pb-3 px-3 text-sm font-medium transition-colors relative
+           text-content-muted hover:text-content-secondary;
+  }
+  .hf-tab-active {
+    @apply text-accent-contrast;
+  }
+  .hf-tab-underline {
+    @apply absolute bottom-0 left-0 right-0 h-0.5 bg-accent rounded-t-full;
+  }
 }
 
 @layer utilities {
@@ -46,7 +218,7 @@ body {
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
-  
+
   @keyframes gold-burst {
     0% {
       transform: scale(0.95);
@@ -61,7 +233,7 @@ body {
       box-shadow: 0 0 0 0 rgba(234, 179, 8, 0);
     }
   }
-  
+
   .animate-gold-burst {
     animation: gold-burst 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
@@ -73,5 +245,10 @@ body {
 
   .animate-wiggle {
     animation: wiggle 0.3s ease-in-out infinite;
+  }
+
+  /* Suppress transitions briefly during theme swap to avoid animation flashes */
+  [data-theme-switching] * {
+    transition: none !important;
   }
 }

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -338,7 +338,7 @@ export async function fetchDashboardPrefs(): Promise<DashboardPrefs> {
   return response.dashboardPrefs;
 }
 
-export async function updateDashboardPrefs(patch: Partial<Pick<DashboardPrefs, 'pinnedRoutineIds' | 'pinnedGoalIds' | 'pinnedJournalTemplateIds' | 'checkinExtraMetricKeys' | 'hideStreaks'>>): Promise<DashboardPrefs> {
+export async function updateDashboardPrefs(patch: Partial<Pick<DashboardPrefs, 'pinnedRoutineIds' | 'pinnedGoalIds' | 'pinnedJournalTemplateIds' | 'checkinExtraMetricKeys' | 'hideStreaks' | 'themeMode'>>): Promise<DashboardPrefs> {
   const response = await apiRequest<{ dashboardPrefs: DashboardPrefs }>('/dashboardPrefs', {
     method: 'PUT',
     body: JSON.stringify(patch),

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -663,6 +663,15 @@ export interface DashboardPrefs {
     /** When true, streak/flame indicators are hidden across the UI */
     hideStreaks?: boolean;
 
+    /**
+     * Appearance: user's chosen theme mode.
+     * - 'light' / 'dark': explicit choice, persists across devices.
+     * - 'system': follow the device's prefers-color-scheme at runtime.
+     * Undefined means the user has never set a preference; the client
+     * falls back to the product default (currently 'dark').
+     */
+    themeMode?: 'light' | 'dark' | 'system';
+
     /** ISO 8601 timestamp */
     updatedAt: string;
 }

--- a/src/pages/JournalPage.tsx
+++ b/src/pages/JournalPage.tsx
@@ -50,12 +50,12 @@ export function JournalPage() {
 
             {/* Tab Navigation (Hidden when editing an existing entry to focus) */}
             {!isEditingExisting && (
-                <div className="flex gap-4 border-b border-white/5 mb-4">
+                <div className="flex gap-4 border-b border-line-subtle mb-4">
                     {tabs.map(({ id, label, icon: Icon }) => (
                         <button
                             key={id}
                             onClick={() => setActiveTab(id)}
-                            className={`pb-3 px-3 text-sm font-medium transition-colors relative ${activeTab === id ? 'text-emerald-400' : 'text-white/40 hover:text-white/60'}`}
+                            className={`pb-3 px-3 text-sm font-medium transition-colors relative ${activeTab === id ? 'text-accent-contrast' : 'text-content-primary/40 hover:text-content-primary/60'}`}
                         >
                             <div className="flex items-center gap-2">
                                 <Icon size={16} />

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -7,7 +7,7 @@ export const TasksPage: React.FC = () => {
     const { tasks, loading, error } = useTasks();
 
     if (loading) return (
-        <div className="flex items-center justify-center h-full text-neutral-500 animate-pulse">
+        <div className="flex items-center justify-center h-full text-content-muted animate-pulse">
             Loading tasks...
         </div>
     );
@@ -41,22 +41,22 @@ export const TasksPage: React.FC = () => {
     return (
         <div className="flex flex-col h-full gap-6">
             {/* Description - sits like a definition under the Tasks header */}
-            <p className="text-neutral-500 text-sm -mt-3">
+            <p className="text-content-muted text-sm -mt-3">
                 A one-time action with a clear finish. Once completed, it's done.
             </p>
 
             <div className="flex flex-col md:flex-row h-full gap-6">
 
                 {/* TODAY COLUMN */}
-                <div className="flex-1 flex flex-col min-w-0 bg-neutral-900/30 rounded-xl border border-neutral-800/50 overflow-hidden">
-                    <div className="p-4 border-b border-neutral-800/50 bg-neutral-900/50 flex items-baseline justify-between">
+                <div className="flex-1 flex flex-col min-w-0 bg-surface-0/30 rounded-xl border border-line-subtle/50 overflow-hidden">
+                    <div className="p-4 border-b border-line-subtle/50 bg-surface-0/50 flex items-baseline justify-between">
                         <h2 className="text-lg font-medium text-emerald-500/90">Today</h2>
                         {todayTasks.filter(t => t.status !== 'completed').length > 0 && (
-                            <span className="text-xs text-neutral-600 font-mono">{todayTasks.filter(t => t.status !== 'completed').length} active</span>
+                            <span className="text-xs text-content-muted font-mono">{todayTasks.filter(t => t.status !== 'completed').length} active</span>
                         )}
                     </div>
 
-                    <div className="p-4 bg-neutral-900/20 border-b border-neutral-800/30">
+                    <div className="p-4 bg-surface-0/20 border-b border-line-subtle/30">
                         <AddTaskInput defaultPlacement="today" placeholder="Add directly to today..." />
                     </div>
 
@@ -67,10 +67,10 @@ export const TasksPage: React.FC = () => {
                             ))}
                             {sortedToday.length === 0 && (
                                 <div className="py-8 text-center">
-                                    <p className="text-neutral-500 text-sm mb-3">Commit what matters for today.</p>
+                                    <p className="text-content-muted text-sm mb-3">Commit what matters for today.</p>
                                     <div className="flex flex-wrap justify-center gap-1.5">
                                         {['Email recruiter', 'Refill prescription', 'Schedule workout'].map((ex) => (
-                                            <span key={ex} className="px-2.5 py-1 text-[11px] text-neutral-600 bg-neutral-800/50 rounded-full border border-white/5">
+                                            <span key={ex} className="px-2.5 py-1 text-[11px] text-content-muted bg-surface-1/50 rounded-full border border-line-subtle">
                                                 {ex}
                                             </span>
                                         ))}
@@ -82,15 +82,15 @@ export const TasksPage: React.FC = () => {
                 </div>
 
                 {/* INBOX COLUMN */}
-                <div className="flex-1 flex flex-col min-w-0 bg-neutral-900/30 rounded-xl border border-neutral-800/50 overflow-hidden">
-                    <div className="p-4 border-b border-neutral-800/50 bg-neutral-900/50 flex items-baseline justify-between">
-                        <h2 className="text-lg font-medium text-neutral-300">Inbox</h2>
+                <div className="flex-1 flex flex-col min-w-0 bg-surface-0/30 rounded-xl border border-line-subtle/50 overflow-hidden">
+                    <div className="p-4 border-b border-line-subtle/50 bg-surface-0/50 flex items-baseline justify-between">
+                        <h2 className="text-lg font-medium text-content-secondary">Inbox</h2>
                         {inboxTasks.filter(t => t.status !== 'completed').length > 0 && (
-                            <span className="text-xs text-neutral-600 font-mono">{inboxTasks.filter(t => t.status !== 'completed').length} pending</span>
+                            <span className="text-xs text-content-muted font-mono">{inboxTasks.filter(t => t.status !== 'completed').length} pending</span>
                         )}
                     </div>
 
-                    <div className="p-4 bg-neutral-900/20 border-b border-neutral-800/30">
+                    <div className="p-4 bg-surface-0/20 border-b border-line-subtle/30">
                         <AddTaskInput defaultPlacement="inbox" placeholder="Capture to inbox..." />
                     </div>
 
@@ -101,10 +101,10 @@ export const TasksPage: React.FC = () => {
                             ))}
                             {sortedInbox.length === 0 && (
                                 <div className="py-8 text-center">
-                                    <p className="text-neutral-500 text-sm mb-3">Capture what's on your mind.</p>
+                                    <p className="text-content-muted text-sm mb-3">Capture what's on your mind.</p>
                                     <div className="flex flex-wrap justify-center gap-1.5">
                                         {['Call landlord', 'Buy groceries', 'Send invoice'].map((ex) => (
-                                            <span key={ex} className="px-2.5 py-1 text-[11px] text-neutral-600 bg-neutral-800/50 rounded-full border border-white/5">
+                                            <span key={ex} className="px-2.5 py-1 text-[11px] text-content-muted bg-surface-1/50 rounded-full border border-line-subtle">
                                                 {ex}
                                             </span>
                                         ))}
@@ -116,7 +116,7 @@ export const TasksPage: React.FC = () => {
                 </div>
 
             </div>
-            <div className="text-center text-xs text-neutral-600 pb-2">
+            <div className="text-center text-xs text-content-muted pb-2">
                 Tasks reset visually at midnight, but remain in your list until completed or deleted.
             </div>
         </div>

--- a/src/pages/goals/GoalCompletedPage.tsx
+++ b/src/pages/goals/GoalCompletedPage.tsx
@@ -84,7 +84,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
             <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
                 <div className="flex flex-col items-center gap-4 py-12">
                     <Loader2 className="text-emerald-500 animate-spin" size={32} />
-                    <div className="text-neutral-400 text-sm">Loading...</div>
+                    <div className="text-content-secondary text-sm">Loading...</div>
                 </div>
             </div>
         );
@@ -93,7 +93,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
     if (!goal) {
         return (
             <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-                <div className="text-center py-12 text-neutral-500">
+                <div className="text-center py-12 text-content-muted">
                     <p>Goal not found</p>
                 </div>
             </div>
@@ -145,7 +145,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                             <CelebratoryBadgeIcon goalId={goalId} badgeImageUrl={goal.badgeImageUrl} size={64} />
                         </div>
                         <Sparkles
-                            className="absolute -top-4 -right-4 text-emerald-400 animate-pulse"
+                            className="absolute -top-4 -right-4 text-accent-contrast animate-pulse"
                             size={40}
                         />
                         <Sparkles
@@ -157,10 +157,10 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                 </div>
 
                 {/* Celebration Message */}
-                <h1 className="text-4xl sm:text-5xl font-bold text-white mb-4 animate-fade-in">
+                <h1 className="text-4xl sm:text-5xl font-bold text-content-primary mb-4 animate-fade-in">
                     You completed your goal!
                 </h1>
-                <h2 className="text-2xl sm:text-3xl font-semibold text-emerald-400 mb-8">
+                <h2 className="text-2xl sm:text-3xl font-semibold text-accent-contrast mb-8">
                     {goal.title}
                 </h2>
 
@@ -168,32 +168,32 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                 <div className="max-w-lg mx-auto mb-10 space-y-4">
                     {/* Target Value and Unit - Hide for OneTime */}
                     {goal.type !== 'onetime' && goal.targetValue && (
-                        <div className="p-4 bg-neutral-800/50 border border-white/10 rounded-lg">
-                            <div className="text-neutral-400 text-sm mb-1">Target</div>
-                            <div className="text-2xl font-bold text-white">
+                        <div className="p-4 bg-surface-1/50 border border-line-subtle rounded-lg">
+                            <div className="text-content-secondary text-sm mb-1">Target</div>
+                            <div className="text-2xl font-bold text-content-primary">
                                 {goal.targetValue}
-                                {goal.unit && <span className="text-emerald-400"> {goal.unit}</span>}
+                                {goal.unit && <span className="text-accent-contrast"> {goal.unit}</span>}
                             </div>
                         </div>
                     )}
 
                     {/* Time Span */}
                     {timeSpan !== null && createdDateFormatted && completedDateFormatted && (
-                        <div className="p-4 bg-neutral-800/50 border border-white/10 rounded-lg">
-                            <div className="text-neutral-400 text-sm mb-1">Time Span</div>
-                            <div className="text-lg font-semibold text-white">
+                        <div className="p-4 bg-surface-1/50 border border-line-subtle rounded-lg">
+                            <div className="text-content-secondary text-sm mb-1">Time Span</div>
+                            <div className="text-lg font-semibold text-content-primary">
                                 {timeSpan === 0 ? 'Same day' : `${timeSpan} ${timeSpan === 1 ? 'day' : 'days'}`}
                             </div>
-                            <div className="text-neutral-400 text-xs mt-1">
+                            <div className="text-content-secondary text-xs mt-1">
                                 {createdDateFormatted} → {completedDateFormatted}
                             </div>
                         </div>
                     )}
 
                     {/* Habit Count */}
-                    <div className="p-4 bg-neutral-800/50 border border-white/10 rounded-lg">
-                        <div className="text-neutral-400 text-sm mb-1">Habits Involved</div>
-                        <div className="text-2xl font-bold text-white">
+                    <div className="p-4 bg-surface-1/50 border border-line-subtle rounded-lg">
+                        <div className="text-content-secondary text-sm mb-1">Habits Involved</div>
+                        <div className="text-2xl font-bold text-content-primary">
                             {habitCount} {habitCount === 1 ? 'habit' : 'habits'}
                         </div>
                     </div>
@@ -204,7 +204,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                     {/* Primary CTA: View Win Archive */}
                     <button
                         onClick={() => onViewWinArchive?.()}
-                        className="flex items-center gap-2 px-8 py-4 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-semibold rounded-lg transition-colors text-lg"
+                        className="flex items-center gap-2 px-8 py-4 bg-emerald-500 hover:bg-accent-strong text-neutral-900 font-semibold rounded-lg transition-colors text-lg"
                     >
                         <Trophy size={20} />
                         View Win Archive
@@ -219,7 +219,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                                 onBack();
                             }
                         }}
-                        className="flex items-center gap-2 px-6 py-3 bg-neutral-700 hover:bg-neutral-600 text-white font-medium rounded-lg transition-colors"
+                        className="flex items-center gap-2 px-6 py-3 bg-surface-2 hover:bg-surface-2 text-content-primary font-medium rounded-lg transition-colors"
                     >
                         Continue
                     </button>
@@ -227,33 +227,33 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
 
                 {/* What's Next? Decision Flow */}
                 {goal.type !== 'onetime' && (
-                    <div className="max-w-lg mx-auto mt-12 pt-8 border-t border-white/10">
-                        <h3 className="text-lg font-semibold text-white mb-2">What feels right next?</h3>
-                        <p className="text-neutral-400 text-sm mb-6">
+                    <div className="max-w-lg mx-auto mt-12 pt-8 border-t border-line-subtle">
+                        <h3 className="text-lg font-semibold text-content-primary mb-2">What feels right next?</h3>
+                        <p className="text-content-secondary text-sm mb-6">
                             Choose how you want to continue — or come back to this later.
                         </p>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                             <button
                                 onClick={() => onLevelUp?.(goalId)}
-                                className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-emerald-500/30 transition-all text-left"
+                                className="p-4 bg-surface-1/50 border border-line-subtle rounded-xl hover:bg-surface-1 hover:border-accent/30 transition-all text-left"
                             >
                                 <div className="flex items-center gap-2 mb-1">
-                                    <TrendingUp size={16} className="text-emerald-400" />
-                                    <span className="text-emerald-400 font-medium">Level Up</span>
+                                    <TrendingUp size={16} className="text-accent-contrast" />
+                                    <span className="text-accent-contrast font-medium">Level Up</span>
                                 </div>
-                                <div className="text-neutral-500 text-xs">
+                                <div className="text-content-muted text-xs">
                                     Raise the target and keep pushing
                                 </div>
                             </button>
                             <button
                                 onClick={() => onRepeat?.(goalId)}
-                                className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-blue-500/30 transition-all text-left"
+                                className="p-4 bg-surface-1/50 border border-line-subtle rounded-xl hover:bg-surface-1 hover:border-blue-500/30 transition-all text-left"
                             >
                                 <div className="flex items-center gap-2 mb-1">
                                     <RotateCcw size={16} className="text-blue-400" />
                                     <span className="text-blue-400 font-medium">Repeat</span>
                                 </div>
-                                <div className="text-neutral-500 text-xs">
+                                <div className="text-content-muted text-xs">
                                     Same target, fresh start
                                 </div>
                             </button>
@@ -262,25 +262,25 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                                     onArchive?.(goalId);
                                     if (onBack) onBack();
                                 }}
-                                className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-yellow-500/30 transition-all text-left"
+                                className="p-4 bg-surface-1/50 border border-line-subtle rounded-xl hover:bg-surface-1 hover:border-yellow-500/30 transition-all text-left"
                             >
                                 <div className="flex items-center gap-2 mb-1">
                                     <Archive size={16} className="text-yellow-400" />
                                     <span className="text-yellow-400 font-medium">Archive</span>
                                 </div>
-                                <div className="text-neutral-500 text-xs">
+                                <div className="text-content-muted text-xs">
                                     Save to Win Archive, done for now
                                 </div>
                             </button>
                             <button
                                 onClick={onBack}
-                                className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-white/20 transition-all text-left"
+                                className="p-4 bg-surface-1/50 border border-line-subtle rounded-xl hover:bg-surface-1 hover:border-line-strong transition-all text-left"
                             >
                                 <div className="flex items-center gap-2 mb-1">
-                                    <Clock size={16} className="text-neutral-300" />
-                                    <span className="text-neutral-300 font-medium">Decide Later</span>
+                                    <Clock size={16} className="text-content-secondary" />
+                                    <span className="text-content-secondary font-medium">Decide Later</span>
                                 </div>
-                                <div className="text-neutral-500 text-xs">
+                                <div className="text-content-muted text-xs">
                                     Come back to this anytime
                                 </div>
                             </button>

--- a/src/pages/goals/GoalDetailPage.tsx
+++ b/src/pages/goals/GoalDetailPage.tsx
@@ -278,7 +278,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
         return (
             <div className="flex flex-col items-center justify-center min-h-[50vh]">
                 <Loader2 className="text-emerald-500 animate-spin mb-4" size={32} />
-                <div className="text-neutral-400">Loading goal details...</div>
+                <div className="text-content-secondary">Loading goal details...</div>
             </div>
         );
     }
@@ -287,7 +287,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
         return (
             <div className="p-6 text-center">
                 <div className="text-red-400 mb-2">Error loading goal</div>
-                <button onClick={() => refetch()} className="text-white underline">Retry</button>
+                <button onClick={() => refetch()} className="text-content-primary underline">Retry</button>
             </div>
         );
     }
@@ -299,11 +299,11 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
     const canShowTrend = goal.type === 'cumulative' && goal.deadline;
 
     return (
-        <div className="w-full max-w-4xl mx-auto px-4 py-6 sm:px-6 lg:px-8 bg-[#0A0A0A] min-h-screen text-white">
+        <div className="w-full max-w-4xl mx-auto px-4 py-6 sm:px-6 lg:px-8 bg-[#0A0A0A] min-h-screen text-content-primary">
             {/* Top Navigation */}
             <div className="flex items-center justify-between mb-8">
                 {onBack && (
-                    <button onClick={onBack} className="flex items-center gap-2 text-neutral-400 hover:text-white transition-colors">
+                    <button onClick={onBack} className="flex items-center gap-2 text-content-secondary hover:text-content-primary transition-colors">
                         <ArrowLeft size={18} />
                         <span>Back</span>
                     </button>
@@ -324,28 +324,28 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                     } catch { /* ignore */ }
                                     setShowTrackMenu(true);
                                 }}
-                                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-emerald-400 hover:bg-emerald-500/10 rounded-lg transition-colors"
+                                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-accent-contrast hover:bg-accent-strong/10 rounded-lg transition-colors"
                                 aria-label="Add to track"
                                 title="Add to track"
                             >
                                 <Route size={18} />
                             </button>
                             {showTrackMenu && (
-                                <div className="absolute right-0 top-full mt-1 w-56 bg-neutral-800 border border-white/10 rounded-lg shadow-xl z-50 py-1">
+                                <div className="absolute right-0 top-full mt-1 w-56 bg-surface-1 border border-line-subtle rounded-lg shadow-xl z-50 py-1">
                                     <button
                                         onClick={() => {
                                             setShowTrackMenu(false);
                                             setShowCreateTrackModal(true);
                                         }}
-                                        className="w-full text-left px-3 py-2 text-sm text-emerald-400 hover:bg-neutral-700/50 flex items-center gap-2"
+                                        className="w-full text-left px-3 py-2 text-sm text-accent-contrast hover:bg-surface-2/50 flex items-center gap-2"
                                     >
                                         <Plus size={14} />
                                         Create new track
                                     </button>
                                     {availableTracks.length > 0 && (
                                         <>
-                                            <div className="border-t border-white/5 my-1" />
-                                            <div className="px-3 py-1 text-[10px] text-neutral-500 uppercase tracking-wider">Add to existing track</div>
+                                            <div className="border-t border-line-subtle my-1" />
+                                            <div className="px-3 py-1 text-[10px] text-content-muted uppercase tracking-wider">Add to existing track</div>
                                             {availableTracks.map(track => (
                                                 <button
                                                     key={track.id}
@@ -358,7 +358,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                                             console.error('Failed to add goal to track:', err);
                                                         }
                                                     }}
-                                                    className="w-full text-left px-3 py-2 text-sm text-neutral-300 hover:bg-neutral-700/50"
+                                                    className="w-full text-left px-3 py-2 text-sm text-content-secondary hover:bg-surface-2/50"
                                                 >
                                                     {track.name}
                                                 </button>
@@ -380,17 +380,17 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                     console.error('Failed to remove from track:', err);
                                 }
                             }}
-                            className="min-h-[44px] flex items-center gap-1.5 px-3 text-xs text-neutral-500 hover:text-neutral-300 hover:bg-white/5 rounded-lg transition-colors"
+                            className="min-h-[44px] flex items-center gap-1.5 px-3 text-xs text-content-muted hover:text-content-secondary hover:bg-surface-2 rounded-lg transition-colors"
                             title="Remove from track"
                         >
                             <Route size={14} />
                             <span>Remove from track</span>
                         </button>
                     )}
-                    <button onClick={() => setShowEditModal(true)} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors" aria-label="Edit goal">
+                    <button onClick={() => setShowEditModal(true)} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-content-primary hover:bg-surface-2 rounded-lg transition-colors" aria-label="Edit goal">
                         <Edit size={18} />
                     </button>
-                    <button onClick={() => setShowDeleteConfirm(true)} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors" aria-label="Delete goal">
+                    <button onClick={() => setShowDeleteConfirm(true)} className="min-h-[44px] min-w-[44px] flex items-center justify-center text-content-secondary hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors" aria-label="Delete goal">
                         <Trash2 size={18} />
                     </button>
                 </div>
@@ -403,14 +403,14 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                     <div className="flex items-start justify-between">
                         <div>
                             <div className="flex items-center gap-3 mb-2">
-                                <h1 className="text-3xl font-bold text-white tracking-tight">{goal.title}</h1>
+                                <h1 className="text-3xl font-bold text-content-primary tracking-tight">{goal.title}</h1>
                                 <GoalStatusChip status={goal.completedAt ? 'completed' : 'active'}>
                                     {goal.completedAt ? 'Completed' : 'Active'}
                                 </GoalStatusChip>
                             </div>
                             {/* Mantra / Notes (Read Only) */}
                             {goal.notes && (
-                                <p className="text-neutral-400 text-sm leading-relaxed max-w-2xl">
+                                <p className="text-content-secondary text-sm leading-relaxed max-w-2xl">
                                     “{goal.notes}”
                                 </p>
                             )}
@@ -420,7 +420,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                     {/* Track context info */}
                     {goal.trackId && goal.activeWindowStart && (
                         <div className="mt-2 px-3 py-2 bg-emerald-500/5 border border-emerald-500/10 rounded-lg">
-                            <p className="text-xs text-emerald-400/80">
+                            <p className="text-xs text-accent-contrast/80">
                                 {goal.trackStatus === 'active'
                                     ? `Progress tracked since ${format(parseISO(goal.activeWindowStart), 'MMM d, yyyy')}. Only habit entries from this date onward count toward this goal.`
                                     : goal.trackStatus === 'completed' && goal.activeWindowEnd
@@ -434,7 +434,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
 
                     {/* Progress Bar with Inline Milestones */}
                     <div className="relative pt-6 pb-2">
-                        <div className="h-4 bg-neutral-800 rounded-full overflow-hidden relative">
+                        <div className="h-4 bg-surface-1 rounded-full overflow-hidden relative">
                             <div
                                 className="h-full bg-emerald-500 transition-all duration-1000 ease-out"
                                 style={{ width: `${progressPercent}%` }}
@@ -448,7 +448,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                 />
                             ))}
                         </div>
-                        <div className="flex justify-between mt-2 text-xs font-medium text-neutral-500">
+                        <div className="flex justify-between mt-2 text-xs font-medium text-content-muted">
                             <span>Start</span>
                             {goal.targetValue && (
                                 <span>{goal.targetValue} {goal.unit}</span>
@@ -456,9 +456,9 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                         </div>
 
                         {/* Current Value Display */}
-                        <div className="mt-2 text-2xl font-semibold text-white">
+                        <div className="mt-2 text-2xl font-semibold text-content-primary">
                             {goal.type === 'cumulative'
-                                ? <span>{progress.currentValue} <span className="text-neutral-500 text-lg font-normal">/ {goal.targetValue} {goal.unit}</span></span>
+                                ? <span>{progress.currentValue} <span className="text-content-muted text-lg font-normal">/ {goal.targetValue} {goal.unit}</span></span>
                                 : <span>{progressPercent}% Complete</span>
                             }
                         </div>
@@ -466,8 +466,8 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
 
                     {/* Target Date */}
                     {goal.deadline && (
-                        <div className="flex items-center gap-2 text-neutral-500 text-sm">
-                            <span className=" px-2 py-0.5 bg-neutral-900 rounded border border-white/5">
+                        <div className="flex items-center gap-2 text-content-muted text-sm">
+                            <span className=" px-2 py-0.5 bg-surface-0 rounded border border-line-subtle">
                                 Target: {format(parseISO(goal.deadline), 'MMM d, yyyy')}
                             </span>
                         </div>
@@ -481,24 +481,24 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                     {!showCompleteConfirm ? (
                         <button
                             onClick={() => setShowCompleteConfirm(true)}
-                            className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 rounded-lg hover:bg-emerald-500/20 transition-colors font-medium text-sm"
+                            className="flex items-center gap-2 px-5 py-2.5 bg-accent-soft border border-accent/30 text-accent-contrast rounded-lg hover:bg-accent-strong/20 transition-colors font-medium text-sm"
                         >
                             <Trophy size={16} />
                             Mark as Complete
                         </button>
                     ) : (
-                        <div className="flex items-center gap-3 p-4 bg-emerald-500/10 border border-emerald-500/30 rounded-lg">
-                            <span className="text-sm text-emerald-300">Mark this goal as achieved?</span>
+                        <div className="flex items-center gap-3 p-4 bg-accent-soft border border-accent/30 rounded-lg">
+                            <span className="text-sm text-accent-contrast">Mark this goal as achieved?</span>
                             <button
                                 onClick={handleMarkComplete}
                                 disabled={isMarkingComplete}
-                                className="px-4 py-1.5 bg-emerald-500 text-neutral-900 font-medium text-sm rounded-lg hover:bg-emerald-400 transition-colors disabled:opacity-50"
+                                className="px-4 py-1.5 bg-emerald-500 text-neutral-900 font-medium text-sm rounded-lg hover:bg-accent-strong transition-colors disabled:opacity-50"
                             >
                                 {isMarkingComplete ? 'Completing...' : 'Yes, I did it!'}
                             </button>
                             <button
                                 onClick={() => setShowCompleteConfirm(false)}
-                                className="px-3 py-1.5 text-neutral-400 hover:text-white text-sm transition-colors"
+                                className="px-3 py-1.5 text-content-secondary hover:text-content-primary text-sm transition-colors"
                             >
                                 Cancel
                             </button>
@@ -523,14 +523,14 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                 <TrendingUp size={16} />
                                 Extend Goal
                             </button>
-                            <p className="text-neutral-500 text-xs mt-2">
+                            <p className="text-content-muted text-xs mt-2">
                                 Create a new goal with a higher target. This goal stays in your Win Archive.
                             </p>
                         </div>
                     ) : (
                         <div className="p-4 bg-blue-500/5 border border-blue-500/20 rounded-lg space-y-3">
                             <div className="text-sm text-blue-300 font-medium">Set your new target</div>
-                            <div className="text-xs text-neutral-500">
+                            <div className="text-xs text-content-muted">
                                 Original target: {goal.targetValue} {goal.unit} (completed). Your progress carries over to the new goal.
                             </div>
                             <div className="flex items-center gap-3">
@@ -539,11 +539,11 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                     value={extendTarget}
                                     onChange={(e) => setExtendTarget(e.target.value)}
                                     min={(goal.targetValue ?? 0) + 1}
-                                    className="w-32 bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
+                                    className="w-32 bg-surface-1 border border-line-subtle rounded-lg px-3 py-2 text-content-primary text-sm focus:outline-none focus:border-blue-500"
                                     placeholder="New target"
                                     autoFocus
                                 />
-                                {goal.unit && <span className="text-neutral-400 text-sm">{goal.unit}</span>}
+                                {goal.unit && <span className="text-content-secondary text-sm">{goal.unit}</span>}
                             </div>
                             {extendError && (
                                 <div className="text-red-400 text-xs">{extendError}</div>
@@ -552,14 +552,14 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                 <button
                                     onClick={handleExtendGoal}
                                     disabled={isExtending}
-                                    className="px-4 py-1.5 bg-blue-500 text-white font-medium text-sm rounded-lg hover:bg-blue-400 transition-colors disabled:opacity-50"
+                                    className="px-4 py-1.5 bg-blue-500 text-content-primary font-medium text-sm rounded-lg hover:bg-blue-400 transition-colors disabled:opacity-50"
                                 >
                                     {isExtending ? 'Creating...' : 'Create Extended Goal'}
                                 </button>
                                 <button
                                     onClick={() => setShowExtendForm(false)}
                                     disabled={isExtending}
-                                    className="px-3 py-1.5 text-neutral-400 hover:text-white text-sm transition-colors"
+                                    className="px-3 py-1.5 text-content-secondary hover:text-content-primary text-sm transition-colors"
                                 >
                                     Cancel
                                 </button>
@@ -570,12 +570,12 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
             )}
 
             {/* Tabs */}
-            <div className="flex border-b border-white/10 mb-8">
+            <div className="flex border-b border-line-subtle mb-8">
                 <button
                     onClick={() => setActiveTab('cumulative')}
                     className={`px-6 py-3 text-sm font-medium border-b-2 transition-colors ${activeTab === 'cumulative'
-                        ? 'border-emerald-500 text-emerald-400'
-                        : 'border-transparent text-neutral-400 hover:text-white'
+                        ? 'border-emerald-500 text-accent-contrast'
+                        : 'border-transparent text-content-secondary hover:text-content-primary'
                         }`}
                 >
                     Cumulative
@@ -584,8 +584,8 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                     <button
                         onClick={() => setActiveTab('trend')}
                         className={`px-6 py-3 text-sm font-medium border-b-2 transition-colors ${activeTab === 'trend'
-                            ? 'border-emerald-500 text-emerald-400'
-                            : 'border-transparent text-neutral-400 hover:text-white'
+                            ? 'border-emerald-500 text-accent-contrast'
+                            : 'border-transparent text-content-secondary hover:text-content-primary'
                             }`}
                     >
                         Trend
@@ -594,8 +594,8 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                 <button
                     onClick={() => setActiveTab('dayByDay')}
                     className={`px-6 py-3 text-sm font-medium border-b-2 transition-colors ${activeTab === 'dayByDay'
-                        ? 'border-emerald-500 text-emerald-400'
-                        : 'border-transparent text-neutral-400 hover:text-white'
+                        ? 'border-emerald-500 text-accent-contrast'
+                        : 'border-transparent text-content-secondary hover:text-content-primary'
                         }`}
                 >
                     Day by Day
@@ -608,7 +608,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                     <div className="space-y-8 h-full">
                         {/* Cumulative Chart */}
                         <div>
-                            <h3 className="text-neutral-400 text-sm font-medium mb-4 uppercase tracking-wider">Total Progress</h3>
+                            <h3 className="text-content-secondary text-sm font-medium mb-4 uppercase tracking-wider">Total Progress</h3>
                             <GoalCumulativeChart
                                 data={cumulativeData}
                                 color="#10b981"
@@ -625,8 +625,8 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                 {activeTab === 'trend' && canShowTrend && (
                     <div className="space-y-8 h-full">
                         <div>
-                            <h3 className="text-neutral-400 text-sm font-medium mb-4 uppercase tracking-wider">Progress Trend</h3>
-                            <p className="text-neutral-500 text-sm mb-4">
+                            <h3 className="text-content-secondary text-sm font-medium mb-4 uppercase tracking-wider">Progress Trend</h3>
+                            <p className="text-content-muted text-sm mb-4">
                                 Solid line is your actual progress. Dashed line is the pace needed to reach your target by the deadline.
                             </p>
                             <GoalTrendChart
@@ -651,10 +651,10 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
 
 
             {/* Linked Habits Section */}
-            <div className="mt-12 pt-8 border-t border-white/10">
+            <div className="mt-12 pt-8 border-t border-line-subtle">
                 <div className="mb-6">
-                    <p className="text-emerald-400 font-medium mb-1">Habits are how goals are achieved.</p>
-                    <p className="text-neutral-500 text-sm">Consistent daily action drives your progress.</p>
+                    <p className="text-accent-contrast font-medium mb-1">Habits are how goals are achieved.</p>
+                    <p className="text-content-muted text-sm">Consistent daily action drives your progress.</p>
                 </div>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -664,24 +664,24 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                             onClick={() => {
                                 if (onViewHabit) onViewHabit(habit.id);
                             }}
-                            className="flex items-center gap-4 p-4 bg-neutral-900/50 border border-white/5 rounded-xl hover:bg-neutral-800 hover:border-white/10 transition-all text-left group"
+                            className="flex items-center gap-4 p-4 bg-surface-0/50 border border-line-subtle rounded-xl hover:bg-surface-1 hover:border-line-subtle transition-all text-left group"
                         >
-                            <div className="w-10 h-10 rounded-lg bg-emerald-500/10 flex items-center justify-center text-emerald-500 group-hover:bg-emerald-500/20 transition-colors">
+                            <div className="w-10 h-10 rounded-lg bg-accent-soft flex items-center justify-center text-emerald-500 group-hover:bg-accent-strong/20 transition-colors">
                                 {habit.goal.type === 'boolean' ? <Check size={20} /> : <span className="font-bold text-xs">{habit.goal.unit}</span>}
                             </div>
                             <div>
-                                <div className="font-medium text-white group-hover:text-emerald-400 transition-colors">{habit.name}</div>
-                                <div className="text-xs text-neutral-500 mt-0.5">
+                                <div className="font-medium text-content-primary group-hover:text-accent-contrast transition-colors">{habit.name}</div>
+                                <div className="text-xs text-content-muted mt-0.5">
                                     {habit.goal.type === 'number' ? `Daily Target: ${habit.goal.target} ${habit.goal.unit}` : 'Daily Completion'}
                                 </div>
                             </div>
                         </button>
                     )) : (
-                        <div className="col-span-full p-6 border border-dashed border-neutral-800 rounded-xl text-center">
-                            <p className="text-neutral-500 text-sm mb-3">No habits linked to this goal yet.</p>
+                        <div className="col-span-full p-6 border border-dashed border-line-subtle rounded-xl text-center">
+                            <p className="text-content-muted text-sm mb-3">No habits linked to this goal yet.</p>
                             <button
                                 onClick={() => setShowEditModal(true)} // Edit modal allows linking/creating habits
-                                className="text-emerald-400 text-sm font-medium hover:underline"
+                                className="text-accent-contrast text-sm font-medium hover:underline"
                             >
                                 Link a habit
                             </button>

--- a/src/pages/goals/GoalScheduleView.tsx
+++ b/src/pages/goals/GoalScheduleView.tsx
@@ -107,7 +107,7 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
       <div className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-12">
         <div className="flex flex-col items-center gap-4">
           <Loader2 className="text-emerald-500 animate-spin" size={32} />
-          <div className="text-neutral-400 text-sm">Loading schedule insights...</div>
+          <div className="text-content-secondary text-sm">Loading schedule insights...</div>
         </div>
       </div>
     );
@@ -133,11 +133,11 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
     return (
       <div className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-12">
         <div className="text-center">
-          <div className="w-16 h-16 mx-auto bg-neutral-800 rounded-full flex items-center justify-center mb-4">
-            <Calendar className="text-neutral-500" size={32} />
+          <div className="w-16 h-16 mx-auto bg-surface-1 rounded-full flex items-center justify-center mb-4">
+            <Calendar className="text-content-muted" size={32} />
           </div>
-          <h2 className="text-lg font-semibold text-white mb-2">No Goals Yet</h2>
-          <p className="text-neutral-400 text-sm">
+          <h2 className="text-lg font-semibold text-content-primary mb-2">No Goals Yet</h2>
+          <p className="text-content-secondary text-sm">
             Create your first goal to see scheduling insights, forecasts, and milestones.
           </p>
         </div>
@@ -149,13 +149,13 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
     <div className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-4">
       {/* Focus Mode Banner */}
       {focusedGoalId && focusedGoalTitle && (
-        <div className="mb-4 flex items-center gap-2 px-3 py-2 bg-emerald-500/10 border border-emerald-500/30 rounded-lg">
-          <span className="text-sm text-emerald-400 font-medium flex-1 truncate">
+        <div className="mb-4 flex items-center gap-2 px-3 py-2 bg-accent-soft border border-accent/30 rounded-lg">
+          <span className="text-sm text-accent-contrast font-medium flex-1 truncate">
             Focused: {focusedGoalTitle}
           </span>
           <button
             onClick={() => setFocusedGoalId(null)}
-            className="p-1 rounded hover:bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+            className="p-1 rounded hover:bg-surface-1 text-content-secondary hover:text-content-primary transition-colors"
             aria-label="Exit focus mode"
           >
             <X size={16} />
@@ -168,12 +168,12 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
         <div className="mb-4">
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className="flex items-center gap-1.5 text-sm text-neutral-400 hover:text-white transition-colors mb-2"
+            className="flex items-center gap-1.5 text-sm text-content-secondary hover:text-content-primary transition-colors mb-2"
           >
             <Filter size={14} />
             <span>Filter by category</span>
             {selectedCategoryIds.length > 0 && (
-              <span className="ml-1 text-xs bg-emerald-500/20 text-emerald-400 px-1.5 py-0.5 rounded-full">
+              <span className="ml-1 text-xs bg-accent-soft text-accent-contrast px-1.5 py-0.5 rounded-full">
                 {selectedCategoryIds.length}
               </span>
             )}
@@ -183,7 +183,7 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
               {selectedCategoryIds.length > 0 && (
                 <button
                   onClick={clearFilters}
-                  className="px-2.5 py-1 text-xs font-medium rounded-full bg-neutral-800 text-neutral-400 hover:text-white transition-colors"
+                  className="px-2.5 py-1 text-xs font-medium rounded-full bg-surface-1 text-content-secondary hover:text-content-primary transition-colors"
                 >
                   Clear all
                 </button>
@@ -196,8 +196,8 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
                     onClick={() => handleCategoryToggle(cat.id)}
                     className={`px-2.5 py-1 text-xs font-medium rounded-full transition-all ${
                       isActive
-                        ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40'
-                        : 'bg-neutral-800 text-neutral-400 border border-transparent hover:text-white'
+                        ? 'bg-accent-soft text-accent-contrast border border-emerald-500/40'
+                        : 'bg-surface-1 text-content-secondary border border-transparent hover:text-content-primary'
                     }`}
                   >
                     {cat.name}
@@ -223,14 +223,14 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
         {(['target', 'forecast', 'milestone', 'completed'] as ScheduleEventType[]).map(type => (
           <div key={type} className="flex items-center gap-1.5">
             <span className={`w-2 h-2 rounded-full ${getEventTypeColor(type)}`} />
-            <span className="text-xs text-neutral-500">{getEventTypeLabel(type)}</span>
+            <span className="text-xs text-content-muted">{getEventTypeLabel(type)}</span>
           </div>
         ))}
       </div>
 
       {/* No Events in View */}
       {filteredEvents.length === 0 && (
-        <div className="mt-6 text-center text-neutral-500 text-sm py-8">
+        <div className="mt-6 text-center text-content-muted text-sm py-8">
           {selectedCategoryIds.length > 0
             ? 'No goal events for the selected categories. Try clearing the filter.'
             : 'No goal events to display. Add deadlines or track more progress to see forecasts.'}
@@ -239,15 +239,15 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
 
       {/* Selected Date Detail Panel */}
       {selectedDate && (
-        <div className="mt-4 bg-neutral-800/40 border border-white/[0.06] rounded-xl overflow-hidden">
+        <div className="mt-4 bg-surface-1/40 border border-white/[0.06] rounded-xl overflow-hidden">
           {/* Date Header */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-white/[0.06]">
-            <h4 className="text-sm font-semibold text-white">
+            <h4 className="text-sm font-semibold text-content-primary">
               {format(new Date(selectedDate + 'T12:00:00'), 'EEEE, MMMM d, yyyy')}
             </h4>
             <button
               onClick={() => setSelectedDate(null)}
-              className="p-1 rounded hover:bg-neutral-700 text-neutral-400 hover:text-white transition-colors"
+              className="p-1 rounded hover:bg-surface-2 text-content-secondary hover:text-content-primary transition-colors"
               aria-label="Close date details"
             >
               <X size={14} />
@@ -256,7 +256,7 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
 
           {/* Events */}
           {selectedDateEvents.length === 0 ? (
-            <div className="px-4 py-6 text-center text-neutral-500 text-sm">
+            <div className="px-4 py-6 text-center text-content-muted text-sm">
               No goal events on this date.
             </div>
           ) : (
@@ -268,10 +268,10 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
                   <div key={type} className="px-4 py-3">
                     <div className="flex items-center gap-2 mb-2">
                       <span className={`w-2 h-2 rounded-full ${getEventTypeColor(type)}`} />
-                      <span className="text-xs font-medium text-neutral-400 uppercase tracking-wide">
+                      <span className="text-xs font-medium text-content-secondary uppercase tracking-wide">
                         {getEventTypeLabel(type)}s
                       </span>
-                      <span className="text-xs text-neutral-600">{typeEvents.length}</span>
+                      <span className="text-xs text-content-muted">{typeEvents.length}</span>
                     </div>
                     <div className="space-y-2">
                       {typeEvents.map((event, idx) => (
@@ -288,7 +288,7 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
                                   setFocusedGoalId(event.goalId);
                                 }
                               }}
-                              className="text-sm font-medium text-neutral-200 hover:text-emerald-400 transition-colors text-left truncate block w-full"
+                              className="text-sm font-medium text-content-primary hover:text-accent-contrast transition-colors text-left truncate block w-full"
                               title={`Focus on ${event.goalTitle}`}
                             >
                               {event.goalTitle}
@@ -298,7 +298,7 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
                                 {getStatusLabel(event.status)}
                               </span>
                               {event.trendExplanation && (
-                                <span className="text-xs text-neutral-600">
+                                <span className="text-xs text-content-muted">
                                   &middot; {event.trendExplanation}
                                 </span>
                               )}
@@ -306,13 +306,13 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
                           </div>
                           {/* Progress indicator */}
                           <div className="flex items-center gap-2 flex-shrink-0">
-                            <div className="w-16 h-1.5 bg-neutral-700 rounded-full overflow-hidden">
+                            <div className="w-16 h-1.5 bg-surface-2 rounded-full overflow-hidden">
                               <div
                                 className="h-full bg-emerald-500 rounded-full transition-all"
                                 style={{ width: `${Math.min(100, event.progressPercent)}%` }}
                               />
                             </div>
-                            <span className="text-xs text-neutral-500 w-8 text-right">
+                            <span className="text-xs text-content-muted w-8 text-right">
                               {event.progressPercent}%
                             </span>
                           </div>
@@ -331,12 +331,12 @@ export const GoalScheduleView: React.FC<GoalScheduleViewProps> = ({ onViewGoal }
               {selectedDateEvents.length === 1 ? (
                 <button
                   onClick={() => onViewGoal(selectedDateEvents[0].goalId)}
-                  className="text-xs text-emerald-500 hover:text-emerald-400 transition-colors"
+                  className="text-xs text-emerald-500 hover:text-accent-contrast transition-colors"
                 >
                   View goal details
                 </button>
               ) : (
-                <span className="text-xs text-neutral-600">
+                <span className="text-xs text-content-muted">
                   Click a goal name to focus on it
                 </span>
               )}

--- a/src/pages/goals/GoalTrackDetailPage.tsx
+++ b/src/pages/goals/GoalTrackDetailPage.tsx
@@ -68,24 +68,24 @@ const SortableTrackGoal: React.FC<{
             style={style}
             {...attributes}
             className={`flex items-center gap-3 px-3 py-3 rounded-lg transition-colors ${
-                isDragging ? 'bg-neutral-700/50 shadow-lg' :
-                isActive ? 'bg-emerald-500/5 border border-emerald-500/20' :
-                'bg-neutral-800/30 border border-white/5'
+                isDragging ? 'bg-surface-2/50 shadow-lg' :
+                isActive ? 'bg-emerald-500/5 border border-accent/20' :
+                'bg-surface-1/30 border border-line-subtle'
             } ${isLocked ? 'opacity-60' : ''}`}
         >
             {/* Drag handle */}
             <div {...listeners} className="cursor-grab active:cursor-grabbing flex-shrink-0 touch-none">
-                <GripVertical size={16} className="text-neutral-500" />
+                <GripVertical size={16} className="text-content-muted" />
             </div>
 
             {/* State indicator */}
             <div className="flex-shrink-0 w-6 h-6 flex items-center justify-center">
                 {isCompleted ? (
-                    <div className="w-5 h-5 rounded-full bg-emerald-500/20 flex items-center justify-center">
-                        <Check size={12} className="text-emerald-400" />
+                    <div className="w-5 h-5 rounded-full bg-accent-soft flex items-center justify-center">
+                        <Check size={12} className="text-accent-contrast" />
                     </div>
                 ) : isLocked ? (
-                    <Lock size={14} className="text-neutral-600" />
+                    <Lock size={14} className="text-content-muted" />
                 ) : (
                     <div className="w-2.5 h-2.5 rounded-full bg-emerald-500 animate-pulse" />
                 )}
@@ -97,26 +97,26 @@ const SortableTrackGoal: React.FC<{
                 className="flex-1 min-w-0 text-left"
             >
                 <div className={`text-sm ${
-                    isCompleted ? 'text-neutral-500 line-through' :
-                    isLocked ? 'text-neutral-500' :
-                    'text-white font-medium'
+                    isCompleted ? 'text-content-muted line-through' :
+                    isLocked ? 'text-content-muted' :
+                    'text-content-primary font-medium'
                 }`}>
                     {goal.title}
                 </div>
                 {isActive && goal.activeWindowStart && (
-                    <div className="text-xs text-neutral-500 mt-0.5">
+                    <div className="text-xs text-content-muted mt-0.5">
                         Tracking since {format(parseISO(goal.activeWindowStart), 'MMM d, yyyy')}
                     </div>
                 )}
                 {isCompleted && goal.activeWindowEnd && (
-                    <div className="text-xs text-neutral-600 mt-0.5">
+                    <div className="text-xs text-content-muted mt-0.5">
                         Completed {format(parseISO(goal.activeWindowEnd), 'MMM d, yyyy')}
                     </div>
                 )}
             </button>
 
             {/* Step indicator */}
-            <span className="text-xs text-neutral-600 flex-shrink-0">{index + 1}/{total}</span>
+            <span className="text-xs text-content-muted flex-shrink-0">{index + 1}/{total}</span>
 
             {/* Remove button */}
             <button
@@ -124,7 +124,7 @@ const SortableTrackGoal: React.FC<{
                 className="p-1 rounded hover:bg-red-500/10 transition-colors flex-shrink-0"
                 title="Remove from track"
             >
-                <Trash2 size={13} className="text-neutral-600 hover:text-red-400" />
+                <Trash2 size={13} className="text-content-muted hover:text-red-400" />
             </button>
         </div>
     );
@@ -205,7 +205,7 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
             <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 py-12">
                 <div className="flex flex-col items-center gap-4">
                     <Loader2 className="text-emerald-500 animate-spin" size={32} />
-                    <div className="text-neutral-400 text-sm">Loading track...</div>
+                    <div className="text-content-secondary text-sm">Loading track...</div>
                 </div>
             </div>
         );
@@ -214,7 +214,7 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
     if (error || !data) {
         return (
             <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 py-6">
-                <button onClick={onBack} className="flex items-center gap-1.5 text-neutral-400 hover:text-white mb-4 text-sm">
+                <button onClick={onBack} className="flex items-center gap-1.5 text-content-secondary hover:text-content-primary mb-4 text-sm">
                     <ArrowLeft size={16} /> Back
                 </button>
                 <div className="text-red-400 text-sm">{error || 'Track not found'}</div>
@@ -234,7 +234,7 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
             {/* Back button */}
             <button
                 onClick={onBack}
-                className="flex items-center gap-1.5 text-neutral-400 hover:text-white mb-4 text-sm transition-colors"
+                className="flex items-center gap-1.5 text-content-secondary hover:text-content-primary mb-4 text-sm transition-colors"
             >
                 <ArrowLeft size={16} /> Back to Goals
             </button>
@@ -242,24 +242,24 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
             {/* Track header */}
             <div className="mb-6">
                 <div className="flex items-center gap-2.5 mb-2">
-                    <Route size={20} className="text-emerald-400" />
-                    <h1 className="text-xl font-bold text-white">{track.name}</h1>
+                    <Route size={20} className="text-accent-contrast" />
+                    <h1 className="text-xl font-bold text-content-primary">{track.name}</h1>
                 </div>
                 {track.description && (
-                    <p className="text-sm text-neutral-400 mb-3">{track.description}</p>
+                    <p className="text-sm text-content-secondary mb-3">{track.description}</p>
                 )}
                 <div className="flex items-center gap-3 text-sm">
                     {category && (
-                        <span className={`font-medium ${categoryColorClass || 'text-neutral-400'}`}>
+                        <span className={`font-medium ${categoryColorClass || 'text-content-secondary'}`}>
                             {category.name}
                         </span>
                     )}
-                    <span className="text-neutral-500">
+                    <span className="text-content-muted">
                         {completedCount} of {goals.length} completed
                     </span>
                 </div>
                 {/* Progress bar */}
-                <div className="mt-3 h-2 bg-neutral-700 rounded-full overflow-hidden">
+                <div className="mt-3 h-2 bg-surface-2 rounded-full overflow-hidden">
                     <div
                         className="h-full bg-emerald-500 rounded-full transition-all duration-300"
                         style={{ width: `${progressPercent}%` }}
@@ -295,17 +295,17 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
             {/* Add goal */}
             <div className="mt-4">
                 {showAddGoalPicker ? (
-                    <div className="bg-neutral-800/50 border border-white/10 rounded-lg p-3">
-                        <div className="text-sm font-medium text-white mb-2">Add a goal to this track</div>
+                    <div className="bg-surface-1/50 border border-line-subtle rounded-lg p-3">
+                        <div className="text-sm font-medium text-content-primary mb-2">Add a goal to this track</div>
                         {availableGoals.length === 0 ? (
-                            <div className="text-xs text-neutral-500">No available goals in this category</div>
+                            <div className="text-xs text-content-muted">No available goals in this category</div>
                         ) : (
                             <div className="space-y-1 max-h-48 overflow-y-auto">
                                 {availableGoals.map(goal => (
                                     <button
                                         key={goal.id}
                                         onClick={() => handleAddGoal(goal.id)}
-                                        className="w-full text-left px-3 py-2 text-sm text-neutral-300 hover:bg-neutral-700/50 rounded-md transition-colors"
+                                        className="w-full text-left px-3 py-2 text-sm text-content-secondary hover:bg-surface-2/50 rounded-md transition-colors"
                                     >
                                         {goal.title}
                                     </button>
@@ -314,7 +314,7 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
                         )}
                         <button
                             onClick={() => setShowAddGoalPicker(false)}
-                            className="mt-2 text-xs text-neutral-500 hover:text-neutral-400"
+                            className="mt-2 text-xs text-content-muted hover:text-content-secondary"
                         >
                             Cancel
                         </button>
@@ -322,7 +322,7 @@ export const GoalTrackDetailPage: React.FC<GoalTrackDetailPageProps> = ({
                 ) : (
                     <button
                         onClick={() => setShowAddGoalPicker(true)}
-                        className="flex items-center gap-1.5 text-sm text-neutral-400 hover:text-emerald-400 transition-colors"
+                        className="flex items-center gap-1.5 text-sm text-content-secondary hover:text-accent-contrast transition-colors"
                     >
                         <Plus size={15} /> Add goal to track
                     </button>

--- a/src/pages/goals/GoalsPage.tsx
+++ b/src/pages/goals/GoalsPage.tsx
@@ -166,7 +166,7 @@ const Stack: React.FC<StackProps> = ({
                 >
                     {stack.category.name}
                 </h2>
-                <span className="text-xs text-neutral-500 font-medium flex-shrink-0">
+                <span className="text-xs text-content-muted font-medium flex-shrink-0">
                     ({goalCount})
                 </span>
             </button>
@@ -380,7 +380,7 @@ export const GoalsPage: React.FC<GoalsPageProps> = ({
             <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 py-12">
                 <div className="flex flex-col items-center gap-4">
                     <Loader2 className="text-emerald-500 animate-spin" size={32} />
-                    <div className="text-neutral-400 text-sm">Loading goals...</div>
+                    <div className="text-content-secondary text-sm">Loading goals...</div>
                 </div>
             </div>
         );
@@ -405,19 +405,19 @@ export const GoalsPage: React.FC<GoalsPageProps> = ({
             {goalStacks.length === 0 ? (
                 <div className="text-center py-12">
                     <div className="max-w-md mx-auto">
-                        <div className="w-14 h-14 mx-auto bg-neutral-800 rounded-full flex items-center justify-center mb-5">
-                            <Target className="text-neutral-500" size={28} />
+                        <div className="w-14 h-14 mx-auto bg-surface-1 rounded-full flex items-center justify-center mb-5">
+                            <Target className="text-content-muted" size={28} />
                         </div>
-                        <h2 className="text-lg font-semibold text-white mb-2">
+                        <h2 className="text-lg font-semibold text-content-primary mb-2">
                             Goals give your habits direction.
                         </h2>
-                        <p className="text-sm text-neutral-400 mb-5 leading-relaxed">
+                        <p className="text-sm text-content-secondary mb-5 leading-relaxed">
                             Track progress over time toward outcomes, milestones, or events.
                         </p>
                         {onCreateGoal && (
                             <button
                                 onClick={onCreateGoal}
-                                className="flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-medium rounded-lg transition-colors text-sm"
+                                className="flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-accent-strong text-neutral-900 font-medium rounded-lg transition-colors text-sm"
                             >
                                 <Plus size={18} />
                                 Create Your First Goal

--- a/src/pages/goals/WinArchivePage.tsx
+++ b/src/pages/goals/WinArchivePage.tsx
@@ -17,7 +17,7 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
             <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
                 <div className="flex flex-col items-center gap-4">
                     <Loader2 className="text-emerald-500 animate-spin" size={32} />
-                    <div className="text-neutral-400 text-sm sm:text-base">Loading your wins...</div>
+                    <div className="text-content-secondary text-sm sm:text-base">Loading your wins...</div>
                 </div>
             </div>
         );
@@ -27,8 +27,8 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
         return (
             <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
                 <div className="mb-6 sm:mb-8">
-                    <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">Win Archive</h1>
-                    <p className="text-neutral-400 text-sm sm:text-base">
+                    <h1 className="text-2xl sm:text-3xl font-bold text-content-primary mb-2">Win Archive</h1>
+                    <p className="text-content-secondary text-sm sm:text-base">
                         Every goal you've completed becomes a badge of who you are becoming.
                     </p>
                 </div>
@@ -55,8 +55,8 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
         <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
             {/* Header */}
             <div className="mb-6 sm:mb-8">
-                <h1 className="text-2xl sm:text-3xl font-bold text-white mb-1">Win Archive</h1>
-                <p className="text-sm sm:text-base text-neutral-400">
+                <h1 className="text-2xl sm:text-3xl font-bold text-content-primary mb-1">Win Archive</h1>
+                <p className="text-sm sm:text-base text-content-secondary">
                     Every completed goal becomes a badge of who you are becoming.
                 </p>
             </div>
@@ -65,14 +65,14 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
             {!data || data.length === 0 ? (
                 <div className="text-center py-16 sm:py-20">
                     <div className="max-w-md mx-auto">
-                        <div className="w-16 h-16 mx-auto bg-neutral-800 rounded-full flex items-center justify-center mb-4">
+                        <div className="w-16 h-16 mx-auto bg-surface-1 rounded-full flex items-center justify-center mb-4">
                             <Trophy className="text-amber-400/50" size={32} />
                         </div>
-                        <h2 className="text-lg font-semibold text-white mb-2">Your Win Archive Awaits</h2>
-                        <p className="text-neutral-400 text-sm mb-1">
+                        <h2 className="text-lg font-semibold text-content-primary mb-2">Your Win Archive Awaits</h2>
+                        <p className="text-content-secondary text-sm mb-1">
                             Every completed goal becomes a badge of achievement here.
                         </p>
-                        <p className="text-neutral-500 text-xs">
+                        <p className="text-content-muted text-xs">
                             Complete your first goal to see it celebrated in your archive!
                         </p>
                     </div>
@@ -84,14 +84,14 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
                         <button
                             key={goal.id}
                             onClick={() => onViewGoal?.(goal.id)}
-                            className="group relative bg-neutral-800/40 border border-white/[0.06] rounded-xl overflow-hidden hover:border-emerald-500/40 hover:bg-neutral-800/70 transition-all duration-200 text-left win-card-animate focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+                            className="group relative bg-surface-1/40 border border-white/[0.06] rounded-xl overflow-hidden hover:border-emerald-500/40 hover:bg-surface-1/70 transition-all duration-200 text-left win-card-animate focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/50"
                             style={{
                                 animationDelay: `${index * 40}ms`,
                                 animationFillMode: 'both',
                             }}
                         >
                             {/* Badge icon area — square aspect */}
-                            <div className="relative aspect-square w-full bg-neutral-900/60 overflow-hidden p-4">
+                            <div className="relative aspect-square w-full bg-surface-0/60 overflow-hidden p-4">
                                 <CelebratoryBadgeIcon
                                     goalId={goal.id}
                                     badgeImageUrl={goal.badgeImageUrl}
@@ -102,11 +102,11 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
 
                             {/* Info — compact */}
                             <div className="px-2.5 py-2">
-                                <h3 className="text-xs sm:text-sm font-medium text-neutral-200 line-clamp-2 leading-tight group-hover:text-emerald-400 transition-colors duration-200">
+                                <h3 className="text-xs sm:text-sm font-medium text-content-primary line-clamp-2 leading-tight group-hover:text-accent-contrast transition-colors duration-200">
                                     {goal.title}
                                 </h3>
                                 {goal.completedAt && (
-                                    <div className="flex items-center gap-1 mt-1 text-neutral-500 text-[10px] sm:text-xs">
+                                    <div className="flex items-center gap-1 mt-1 text-content-muted text-[10px] sm:text-xs">
                                         <Calendar size={10} />
                                         <span>{formatCompletedDate(goal.completedAt)}</span>
                                     </div>

--- a/src/server/repositories/dashboardPrefsRepository.ts
+++ b/src/server/repositories/dashboardPrefsRepository.ts
@@ -39,10 +39,12 @@ export async function getDashboardPrefs(householdId: string, userId: string): Pr
   return prefs as DashboardPrefs;
 }
 
+const THEME_MODE_VALUES = new Set<'light' | 'dark' | 'system'>(['light', 'dark', 'system']);
+
 export async function updateDashboardPrefs(
   householdId: string,
   userId: string,
-  patch: { pinnedRoutineIds?: string[]; pinnedGoalIds?: string[]; pinnedJournalTemplateIds?: string[]; checkinExtraMetricKeys?: string[]; hideStreaks?: boolean }
+  patch: { pinnedRoutineIds?: string[]; pinnedGoalIds?: string[]; pinnedJournalTemplateIds?: string[]; checkinExtraMetricKeys?: string[]; hideStreaks?: boolean; themeMode?: 'light' | 'dark' | 'system' }
 ): Promise<DashboardPrefs> {
   const scope = requireScope(householdId, userId);
   await ensureIndexes();
@@ -119,6 +121,13 @@ export async function updateDashboardPrefs(
 
   if (patch.hideStreaks !== undefined) {
     update.hideStreaks = !!patch.hideStreaks;
+  }
+
+  if (patch.themeMode !== undefined) {
+    if (!THEME_MODE_VALUES.has(patch.themeMode)) {
+      throw new Error(`themeMode must be one of 'light' | 'dark' | 'system'`);
+    }
+    update.themeMode = patch.themeMode;
   }
 
   // Fix: Use full document replace approach to avoid MongoDB update conflicts

--- a/src/server/routes/dashboardPrefs.ts
+++ b/src/server/routes/dashboardPrefs.ts
@@ -29,9 +29,9 @@ export async function getDashboardPrefsRoute(req: Request, res: Response): Promi
 export async function updateDashboardPrefsRoute(req: Request, res: Response): Promise<void> {
   try {
     const { householdId, userId } = getRequestIdentity(req);
-    const { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks } = req.body || {};
+    const { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks, themeMode } = req.body || {};
 
-    const prefs = await updateDashboardPrefs(householdId, userId, { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks });
+    const prefs = await updateDashboardPrefs(householdId, userId, { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks, themeMode });
     res.status(200).json({ dashboardPrefs: prefs });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/store/DashboardPrefsContext.tsx
+++ b/src/store/DashboardPrefsContext.tsx
@@ -1,27 +1,45 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { fetchDashboardPrefs, updateDashboardPrefs } from '../lib/persistenceClient';
 import type { DashboardPrefs } from '../models/persistenceTypes';
+import { useTheme } from '../theme/ThemeContext';
+import type { ThemeMode } from '../theme/palette';
 
 interface DashboardPrefsContextValue {
   hideStreaks: boolean;
   setHideStreaks: (v: boolean) => void;
+  /**
+   * Persist the user's theme preference to the backend AND update the
+   * active ThemeContext state. Prefer this over calling ThemeContext.setMode
+   * directly from UI components so the choice syncs across devices.
+   */
+  setThemeMode: (mode: ThemeMode) => void;
 }
 
 const DashboardPrefsContext = createContext<DashboardPrefsContextValue>({
   hideStreaks: false,
   setHideStreaks: () => {},
+  setThemeMode: () => {},
 });
 
 export const DashboardPrefsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [hideStreaks, setHideStreaksLocal] = useState(false);
+  const { setMode } = useTheme();
+  const syncedThemeRef = useRef(false);
 
   useEffect(() => {
     fetchDashboardPrefs()
       .then((prefs: DashboardPrefs) => {
         setHideStreaksLocal(Boolean(prefs.hideStreaks));
+        // On first successful load, if the backend has an explicit theme mode,
+        // apply it. localStorage / pre-hydration already chose a plausible value;
+        // this overrides only if the server has a saved choice.
+        if (!syncedThemeRef.current && prefs.themeMode) {
+          syncedThemeRef.current = true;
+          setMode(prefs.themeMode);
+        }
       })
       .catch(() => {});
-  }, []);
+  }, [setMode]);
 
   const setHideStreaks = useCallback((v: boolean) => {
     setHideStreaksLocal(v);
@@ -30,8 +48,17 @@ export const DashboardPrefsProvider: React.FC<{ children: React.ReactNode }> = (
     });
   }, []);
 
+  const setThemeMode = useCallback((mode: ThemeMode) => {
+    // Optimistic local update first so the UI responds immediately.
+    setMode(mode);
+    // Fire-and-forget backend write. Failure leaves the user with the
+    // new theme locally (via localStorage) but un-synced across devices;
+    // any subsequent successful write will reconcile.
+    updateDashboardPrefs({ themeMode: mode }).catch(() => {});
+  }, [setMode]);
+
   return (
-    <DashboardPrefsContext.Provider value={{ hideStreaks, setHideStreaks }}>
+    <DashboardPrefsContext.Provider value={{ hideStreaks, setHideStreaks, setThemeMode }}>
       {children}
     </DashboardPrefsContext.Provider>
   );

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,0 +1,140 @@
+/**
+ * ThemeContext — theme mode state + side effects.
+ *
+ * Responsibilities:
+ *   - Holds the user's choice: `'light' | 'dark' | 'system'`
+ *   - Resolves that to the concrete applied mode (`'light' | 'dark'`)
+ *     by listening to `prefers-color-scheme` when mode === 'system'
+ *   - Applies `class="dark"` / `class="light"` to the <html> element
+ *   - Updates CSS `color-scheme` so scrollbars / native form controls follow
+ *   - Persists the chosen mode to localStorage (for pre-hydration sync)
+ *     and to the backend via DashboardPrefs (for cross-device sync)
+ *
+ * The pre-hydration script in index.html reads the same localStorage key
+ * before React boots, so first paint is never mismatched.
+ *
+ * Persistence to DashboardPrefs happens in src/store/DashboardPrefsContext
+ * (it calls setMode on mount once prefs arrive from the server).
+ */
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ResolvedThemeMode, ThemeMode } from './palette';
+import { ensureThemeVarsInjected } from './cssVars';
+
+export const THEME_STORAGE_KEY = 'hf_theme_mode';
+
+interface ThemeContextValue {
+  /** User's choice: light / dark / system */
+  mode: ThemeMode;
+  /** The concrete mode currently applied to the document */
+  resolvedMode: ResolvedThemeMode;
+  /**
+   * Update the user's mode preference. Persists to localStorage
+   * immediately. Does NOT persist to the backend — that's the caller's
+   * responsibility (see DashboardPrefsContext integration).
+   */
+  setMode: (mode: ThemeMode) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function readStoredMode(): ThemeMode {
+  if (typeof localStorage === 'undefined') return 'dark';
+  const raw = localStorage.getItem(THEME_STORAGE_KEY);
+  if (raw === 'light' || raw === 'dark' || raw === 'system') return raw;
+  return 'dark'; // default per product decision — preserve current appearance
+}
+
+function readSystemPreference(): ResolvedThemeMode {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function resolveMode(mode: ThemeMode): ResolvedThemeMode {
+  return mode === 'system' ? readSystemPreference() : mode;
+}
+
+function applyMode(resolved: ResolvedThemeMode): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (resolved === 'dark') {
+    root.classList.add('dark');
+    root.classList.remove('light');
+  } else {
+    root.classList.add('light');
+    root.classList.remove('dark');
+  }
+  root.style.colorScheme = resolved;
+}
+
+// Inject CSS vars once at module import so the first render already sees them.
+// `index.css` contains hand-written fallback values, so this is purely "keep in sync
+// with palette.ts" — not a first-paint dependency.
+if (typeof document !== 'undefined') {
+  ensureThemeVarsInjected();
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredMode());
+  const [resolvedMode, setResolvedMode] = useState<ResolvedThemeMode>(() => resolveMode(readStoredMode()));
+
+  // Apply the current resolved mode to <html> whenever it changes.
+  useEffect(() => {
+    applyMode(resolvedMode);
+  }, [resolvedMode]);
+
+  // When mode === 'system', listen to OS preference changes.
+  useEffect(() => {
+    if (mode !== 'system') return;
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (event: MediaQueryListEvent) => {
+      setResolvedMode(event.matches ? 'dark' : 'light');
+    };
+
+    // Sync immediately in case the preference changed while mode was 'explicit'
+    setResolvedMode(mql.matches ? 'dark' : 'light');
+
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', handler);
+      return () => mql.removeEventListener('change', handler);
+    }
+    // Legacy Safari fallback
+    mql.addListener(handler);
+    return () => mql.removeListener(handler);
+  }, [mode]);
+
+  const setMode = useCallback((next: ThemeMode) => {
+    setModeState(next);
+    setResolvedMode(resolveMode(next));
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch {
+        // quota errors / private-mode — ignore; in-memory state still works
+      }
+    }
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ mode, resolvedMode, setMode }),
+    [mode, resolvedMode, setMode],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    // Graceful fallback for components rendered outside the provider
+    // (e.g. ErrorBoundary). Returns dark-mode defaults; no subscription.
+    return {
+      mode: 'dark',
+      resolvedMode: 'dark',
+      setMode: () => {},
+    };
+  }
+  return ctx;
+}

--- a/src/theme/__tests__/cssVars.test.ts
+++ b/src/theme/__tests__/cssVars.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildThemeCss, ensureThemeVarsInjected } from '../cssVars';
+
+describe('buildThemeCss', () => {
+  const css = buildThemeCss();
+
+  it('emits both :root and .dark blocks', () => {
+    expect(css).toContain(':root {');
+    expect(css).toContain('.dark {');
+  });
+
+  it('emits space-separated RGB triplets (not commas)', () => {
+    // Any var declaration must look like `--name: N N N;`
+    const varLines = css.match(/--[a-z0-9-]+:\s*[^;]+;/g) ?? [];
+    expect(varLines.length).toBeGreaterThan(0);
+    for (const line of varLines) {
+      expect(line, `bad var line: ${line}`).toMatch(/--[a-z0-9-]+:\s*\d+\s+\d+\s+\d+;/);
+      expect(line, `var should not contain comma: ${line}`).not.toContain(',');
+      expect(line, `var should not contain rgb(: ${line}`).not.toContain('rgb(');
+    }
+  });
+
+  it('includes all 5 heatmap steps in each block', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(css).toContain(`--heatmap-${i}`);
+    }
+  });
+});
+
+describe('ensureThemeVarsInjected', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('creates a <style id="hf-theme-vars"> on first call', () => {
+    ensureThemeVarsInjected();
+    const node = document.getElementById('hf-theme-vars');
+    expect(node).toBeTruthy();
+    expect(node?.tagName).toBe('STYLE');
+  });
+
+  it('is idempotent — does not duplicate the style node', () => {
+    ensureThemeVarsInjected();
+    ensureThemeVarsInjected();
+    ensureThemeVarsInjected();
+    expect(document.querySelectorAll('style#hf-theme-vars')).toHaveLength(1);
+  });
+});

--- a/src/theme/__tests__/heatmap.test.ts
+++ b/src/theme/__tests__/heatmap.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { getHeatmapColor, HEATMAP_LEVELS } from '../heatmap';
+
+describe('getHeatmapColor', () => {
+  it('returns 5 distinct hex values per mode', () => {
+    for (const mode of ['light', 'dark'] as const) {
+      const values = Array.from({ length: HEATMAP_LEVELS }, (_, i) => getHeatmapColor(i, mode));
+      expect(new Set(values).size).toBe(HEATMAP_LEVELS);
+      values.forEach((hex) => expect(hex).toMatch(/^#[0-9a-f]{6}$/i));
+    }
+  });
+
+  it('clamps intensities below 0 and above max', () => {
+    expect(getHeatmapColor(-1, 'light')).toBe(getHeatmapColor(0, 'light'));
+    expect(getHeatmapColor(99, 'dark')).toBe(getHeatmapColor(HEATMAP_LEVELS - 1, 'dark'));
+  });
+
+  it('light and dark ladders are different', () => {
+    const light = Array.from({ length: HEATMAP_LEVELS }, (_, i) => getHeatmapColor(i, 'light'));
+    const dark = Array.from({ length: HEATMAP_LEVELS }, (_, i) => getHeatmapColor(i, 'dark'));
+    expect(light).not.toEqual(dark);
+  });
+});

--- a/src/theme/__tests__/palette.test.ts
+++ b/src/theme/__tests__/palette.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { palette, hexToTriplet, type ThemeColors } from '../palette';
+
+const HEX_RE = /^#[0-9a-f]{6}$/i;
+
+describe('palette', () => {
+  const modes = ['light', 'dark'] as const;
+
+  for (const mode of modes) {
+    describe(mode, () => {
+      const p = palette[mode];
+
+      it('has a valid 6-digit hex for every scalar color token', () => {
+        (Object.entries(p) as Array<[keyof ThemeColors, unknown]>).forEach(([key, value]) => {
+          if (key === 'heatmap') return;
+          expect(value, `${mode}.${key}`).toMatch(HEX_RE);
+        });
+      });
+
+      it('has exactly 5 heatmap steps, all valid hex', () => {
+        expect(p.heatmap).toHaveLength(5);
+        p.heatmap.forEach((hex, idx) => {
+          expect(hex, `${mode}.heatmap[${idx}]`).toMatch(HEX_RE);
+        });
+      });
+
+      it('heatmap steps are unique', () => {
+        expect(new Set(p.heatmap).size).toBe(p.heatmap.length);
+      });
+    });
+  }
+
+  it('light and dark have the same set of keys', () => {
+    expect(Object.keys(palette.light).sort()).toEqual(Object.keys(palette.dark).sort());
+  });
+});
+
+describe('hexToTriplet', () => {
+  it('converts #rrggbb to space-separated RGB triplet', () => {
+    expect(hexToTriplet('#10b981')).toBe('16 185 129');
+    expect(hexToTriplet('#ffffff')).toBe('255 255 255');
+    expect(hexToTriplet('#000000')).toBe('0 0 0');
+  });
+
+  it('accepts hex without leading #', () => {
+    expect(hexToTriplet('10b981')).toBe('16 185 129');
+  });
+
+  it('throws on malformed input', () => {
+    expect(() => hexToTriplet('#xyz')).toThrow();
+    expect(() => hexToTriplet('#fff')).toThrow();
+    expect(() => hexToTriplet('')).toThrow();
+  });
+});

--- a/src/theme/cssVars.ts
+++ b/src/theme/cssVars.ts
@@ -1,0 +1,97 @@
+/**
+ * Runtime CSS-variable emission for the HabitFlow theme.
+ *
+ * The Tailwind config consumes semantic token names (e.g. `bg-surface-1`,
+ * `text-content-muted`) that resolve through CSS variables. This module
+ * emits those variables from the TypeScript palette so the CSS and TS
+ * values can never drift apart.
+ *
+ * `index.css` also contains hand-written `:root` / `.dark` blocks as a
+ * pre-hydration fallback so the first paint is never unstyled.
+ */
+
+import { palette, hexToTriplet, type ThemeColors } from './palette';
+
+const STYLE_TAG_ID = 'hf-theme-vars';
+
+/**
+ * Map token keys (camelCase in TS) to CSS variable names (kebab).
+ * Heatmap is emitted as an indexed family (--heatmap-0 .. --heatmap-4)
+ * and is handled specially.
+ */
+const VAR_NAMES: Readonly<Record<keyof Omit<ThemeColors, 'heatmap'>, string>> = {
+  surface0: '--surface-0',
+  surface1: '--surface-1',
+  surface2: '--surface-2',
+  contentPrimary: '--content-primary',
+  contentSecondary: '--content-secondary',
+  contentMuted: '--content-muted',
+  contentOnAccent: '--content-on-accent',
+  lineSubtle: '--line-subtle',
+  lineStrong: '--line-strong',
+  accent: '--accent',
+  accentStrong: '--accent-strong',
+  accentSoft: '--accent-soft',
+  accentContrast: '--accent-contrast',
+  warning: '--warning',
+  warningSoft: '--warning-soft',
+  warningContrast: '--warning-contrast',
+  danger: '--danger',
+  dangerSoft: '--danger-soft',
+  dangerContrast: '--danger-contrast',
+  focus: '--focus-ring',
+  chartGrid: '--chart-grid',
+  chartAxis: '--chart-axis',
+  chartTooltipBg: '--chart-tooltip-bg',
+};
+
+function emitBlock(selector: string, colors: ThemeColors): string {
+  const lines: string[] = [];
+  (Object.keys(VAR_NAMES) as Array<keyof typeof VAR_NAMES>).forEach((key) => {
+    const varName = VAR_NAMES[key];
+    const hex = colors[key];
+    lines.push(`  ${varName}: ${hexToTriplet(hex)};`);
+  });
+  colors.heatmap.forEach((hex, idx) => {
+    lines.push(`  --heatmap-${idx}: ${hexToTriplet(hex)};`);
+  });
+  return `${selector} {\n${lines.join('\n')}\n}`;
+}
+
+/**
+ * Generate the full CSS text for both theme blocks.
+ * Light is the default (`:root`); dark is activated by `.dark` on <html>.
+ */
+export function buildThemeCss(): string {
+  return [
+    emitBlock(':root', palette.light),
+    emitBlock('.dark', palette.dark),
+  ].join('\n\n');
+}
+
+/**
+ * Inject (or update) the theme CSS variables into the document head.
+ * Safe to call repeatedly; idempotent.
+ *
+ * In JSDOM / test environments where `document` is defined, this still
+ * works and the vars will be readable by any assertion that parses them
+ * from the style node.
+ */
+export function ensureThemeVarsInjected(): void {
+  if (typeof document === 'undefined') return;
+
+  const existing = document.getElementById(STYLE_TAG_ID) as HTMLStyleElement | null;
+  const css = buildThemeCss();
+
+  if (existing) {
+    if (existing.textContent !== css) {
+      existing.textContent = css;
+    }
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_TAG_ID;
+  style.textContent = css;
+  document.head.appendChild(style);
+}

--- a/src/theme/heatmap.ts
+++ b/src/theme/heatmap.ts
@@ -1,0 +1,28 @@
+/**
+ * Theme-aware heatmap color resolution.
+ *
+ * The heatmap intensity ladder (0 = empty, 4 = strongest) is defined
+ * per-theme in src/theme/palette.ts. This module exposes a pure function
+ * that callers use with their active theme mode.
+ *
+ * Callers should read the current mode from `useTheme().resolvedMode`
+ * and apply the returned hex via inline `style={{ background: ... }}`.
+ */
+
+import { palette, type ResolvedThemeMode } from './palette';
+
+/**
+ * Return the hex color for a given intensity (0..4) and theme mode.
+ * Intensities outside the range are clamped.
+ */
+export function getHeatmapColor(intensity: number, mode: ResolvedThemeMode): string {
+  const ladder = palette[mode].heatmap;
+  const idx = Math.max(0, Math.min(intensity, ladder.length - 1));
+  return ladder[idx];
+}
+
+/**
+ * Number of distinct intensity levels in the heatmap ladder.
+ * Useful for legends and scale computations.
+ */
+export const HEATMAP_LEVELS = palette.light.heatmap.length;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,6 @@
+export { palette, hexToTriplet } from './palette';
+export type { ThemeColors, ThemeMode, ResolvedThemeMode } from './palette';
+export { ThemeProvider, useTheme, THEME_STORAGE_KEY } from './ThemeContext';
+export { useThemeColors } from './useThemeColors';
+export { getHeatmapColor, HEATMAP_LEVELS } from './heatmap';
+export { ensureThemeVarsInjected, buildThemeCss } from './cssVars';

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,0 +1,182 @@
+/**
+ * HabitFlow theme palette — single source of truth.
+ *
+ * Both light and dark themes share the same token keys. Values here are the
+ * ONLY place hex strings should live for theming purposes (category colors
+ * for data encoding remain in src/utils/categoryColors.ts).
+ *
+ * These hex values are also emitted as CSS variables at runtime
+ * (see src/theme/cssVars.ts), so the Tailwind semantic aliases like
+ * `bg-surface-1` and `text-content-muted` resolve correctly for whichever
+ * theme class is on the <html> element.
+ *
+ * Design intent is documented in the plan at
+ * /Users/tjgalloway/.claude/plans/purring-growing-corbato.md
+ */
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type ResolvedThemeMode = 'light' | 'dark';
+
+export interface ThemeColors {
+  /** App background (page) */
+  surface0: string;
+  /** Cards, modal panels, primary containers */
+  surface1: string;
+  /** Elevated surfaces: popovers, tooltips, nested cards, hover tints */
+  surface2: string;
+
+  /** Headings, high-emphasis body text */
+  contentPrimary: string;
+  /** Body copy, labels */
+  contentSecondary: string;
+  /** Hints, captions, placeholders */
+  contentMuted: string;
+  /** Text drawn on an accent-colored background (e.g. white on emerald) */
+  contentOnAccent: string;
+
+  /** Hairline dividers between sections */
+  lineSubtle: string;
+  /** Form-field borders, table borders */
+  lineStrong: string;
+
+  /** Primary brand fill (buttons, active indicators) */
+  accent: string;
+  /** Hover / pressed / chart-line deep */
+  accentStrong: string;
+  /** Tinted soft fill for chips, selection bg, tags */
+  accentSoft: string;
+  /** Readable accent-flavored text on surface backgrounds */
+  accentContrast: string;
+
+  /** Warning solid fill */
+  warning: string;
+  /** Warning tinted bg (e.g. notification banners) */
+  warningSoft: string;
+  /** Warning-flavored text on surface backgrounds */
+  warningContrast: string;
+
+  /** Danger solid fill */
+  danger: string;
+  /** Danger tinted bg (delete confirmations, error banners) */
+  dangerSoft: string;
+  /** Danger-flavored text on surface backgrounds */
+  dangerContrast: string;
+
+  /** Focus ring color — visually distinct from accent in light */
+  focus: string;
+
+  /** Chart gridlines */
+  chartGrid: string;
+  /** Chart axis labels */
+  chartAxis: string;
+  /** Chart tooltip background */
+  chartTooltipBg: string;
+
+  /** Heatmap intensity ladder (index 0 = empty, 4 = strongest) */
+  heatmap: readonly [string, string, string, string, string];
+}
+
+/**
+ * Light mode: calm, premium, slightly warm. Cards are the whitest surface;
+ * the app background is a softer warm-gray so cards read as elevated.
+ */
+const light: ThemeColors = {
+  surface0: '#fafafa',
+  surface1: '#ffffff',
+  surface2: '#f5f5f5',
+
+  contentPrimary: '#171717',
+  contentSecondary: '#525252',
+  contentMuted: '#737373',
+  contentOnAccent: '#ffffff',
+
+  lineSubtle: '#e5e5e5',
+  lineStrong: '#d4d4d4',
+
+  accent: '#10b981',
+  accentStrong: '#059669',
+  accentSoft: '#ecfdf5',
+  accentContrast: '#047857',
+
+  warning: '#d97706',
+  warningSoft: '#fef3c7',
+  warningContrast: '#b45309',
+
+  danger: '#dc2626',
+  dangerSoft: '#fee2e2',
+  dangerContrast: '#b91c1c',
+
+  focus: '#2563eb',
+
+  chartGrid: '#e5e5e5',
+  chartAxis: '#737373',
+  chartTooltipBg: '#ffffff',
+
+  heatmap: ['#f5f5f5', '#d1fae5', '#6ee7b7', '#10b981', '#047857'],
+};
+
+/**
+ * Dark mode: preserves the current HabitFlow appearance. Do not tune these
+ * values casually — existing users should see no change when they first
+ * upgrade to a themed build.
+ */
+const dark: ThemeColors = {
+  surface0: '#171717',
+  surface1: '#262626',
+  surface2: '#404040',
+
+  contentPrimary: '#ffffff',
+  contentSecondary: '#d4d4d4',
+  contentMuted: '#a3a3a3',
+  contentOnAccent: '#0a0a0a',
+
+  lineSubtle: '#2a2a2a',
+  lineStrong: '#404040',
+
+  accent: '#10b981',
+  accentStrong: '#34d399',
+  accentSoft: '#0a2e23',
+  accentContrast: '#34d399',
+
+  warning: '#f59e0b',
+  warningSoft: '#3a2a0a',
+  warningContrast: '#fbbf24',
+
+  danger: '#fb7185',
+  dangerSoft: '#3a0d14',
+  dangerContrast: '#fda4af',
+
+  focus: '#10b981',
+
+  chartGrid: '#404040',
+  chartAxis: '#a3a3a3',
+  chartTooltipBg: '#262626',
+
+  heatmap: ['#262626', '#064e3b', '#047857', '#10b981', '#6ee7b7'],
+};
+
+export const palette: Readonly<Record<ResolvedThemeMode, ThemeColors>> = {
+  light,
+  dark,
+};
+
+/**
+ * Convert a hex color (#rrggbb) to a space-separated RGB triplet string
+ * suitable for use as a CSS variable consumed by Tailwind's
+ * `rgb(var(--token) / <alpha-value>)` pattern.
+ *
+ * @example hexToTriplet('#10b981') === '16 185 129'
+ */
+export function hexToTriplet(hex: string): string {
+  const clean = hex.trim().replace(/^#/, '');
+  if (clean.length !== 6) {
+    throw new Error(`hexToTriplet: expected 6-digit hex, got "${hex}"`);
+  }
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  if ([r, g, b].some((n) => Number.isNaN(n))) {
+    throw new Error(`hexToTriplet: invalid hex digits in "${hex}"`);
+  }
+  return `${r} ${g} ${b}`;
+}

--- a/src/theme/useThemeColors.ts
+++ b/src/theme/useThemeColors.ts
@@ -1,0 +1,17 @@
+/**
+ * `useThemeColors` — React hook returning the active palette as hex strings.
+ *
+ * Use inside recharts components, SVG consumers, inline `style={{...}}`
+ * gradient builders — anywhere the Tailwind class layer can't reach.
+ *
+ * Prefer Tailwind semantic classes (`bg-surface-1`, `text-content-muted`)
+ * wherever possible. This hook is only for hex consumers.
+ */
+
+import { palette, type ThemeColors } from './palette';
+import { useTheme } from './ThemeContext';
+
+export function useThemeColors(): ThemeColors {
+  const { resolvedMode } = useTheme();
+  return palette[resolvedMode];
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -85,6 +85,12 @@ export const calculateHabitStats = (habit: Habit, logs: Record<string, DayLog>):
     };
 };
 
+/**
+ * @deprecated The class-returning form is retained for compatibility with
+ * legacy call-sites but always returns the dark-mode ladder and cannot
+ * honor the active theme. Prefer `getHeatmapColor(intensity, mode)` from
+ * `src/theme/heatmap.ts` which returns a theme-aware hex string.
+ */
 export const getHeatmapColor = (intensity: number) => {
     if (intensity === 0) return 'bg-neutral-800/50';
     if (intensity === 1) return 'bg-emerald-900/80';
@@ -92,3 +98,6 @@ export const getHeatmapColor = (intensity: number) => {
     if (intensity === 3) return 'bg-emerald-500';
     return 'bg-emerald-400';
 };
+
+// Re-export the theme-aware form so callers can migrate incrementally.
+export { getHeatmapColor as getHeatmapColorForTheme, HEATMAP_LEVELS } from '../theme/heatmap';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,13 +4,17 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  // Class-based dark mode: the ThemeProvider toggles `class="dark"` / `class="light"`
+  // on <html>. The pre-hydration script in index.html sets the correct class before
+  // React boots so first paint matches the user's preference.
+  darkMode: 'class',
   safelist: [
-    // Safelist text colors corresponding to category bg colors (used in Day View headers)
+    // Category colors for data encoding (habit/goal categories).
+    // These are NOT theme tokens — they remain visually distinct in both modes.
     {
       pattern: /text-(emerald|violet|rose|amber|blue|fuchsia|cyan|green)-500/,
       variants: ['hover', 'group-hover'],
     },
-    // Also likely need bg classes if they aren't explicitly used elsewhere (though they are in predefinedHabits)
     {
       pattern: /bg-(emerald|violet|rose|amber|blue|fuchsia|cyan|green)-500/,
     }
@@ -18,7 +22,41 @@ export default {
   theme: {
     extend: {
       colors: {
-        // We can add custom colors here later
+        // Semantic theme tokens, driven by CSS variables defined in src/index.css
+        // (and emitted at runtime from src/theme/palette.ts). The `rgb(var(--x) / <alpha-value>)`
+        // pattern lets the existing opacity syntax (`bg-surface-1/80`) keep working.
+        surface: {
+          0: 'rgb(var(--surface-0) / <alpha-value>)',
+          1: 'rgb(var(--surface-1) / <alpha-value>)',
+          2: 'rgb(var(--surface-2) / <alpha-value>)',
+        },
+        content: {
+          primary: 'rgb(var(--content-primary) / <alpha-value>)',
+          secondary: 'rgb(var(--content-secondary) / <alpha-value>)',
+          muted: 'rgb(var(--content-muted) / <alpha-value>)',
+          'on-accent': 'rgb(var(--content-on-accent) / <alpha-value>)',
+        },
+        line: {
+          subtle: 'rgb(var(--line-subtle) / <alpha-value>)',
+          strong: 'rgb(var(--line-strong) / <alpha-value>)',
+        },
+        accent: {
+          DEFAULT: 'rgb(var(--accent) / <alpha-value>)',
+          strong: 'rgb(var(--accent-strong) / <alpha-value>)',
+          soft: 'rgb(var(--accent-soft) / <alpha-value>)',
+          contrast: 'rgb(var(--accent-contrast) / <alpha-value>)',
+        },
+        warning: {
+          DEFAULT: 'rgb(var(--warning) / <alpha-value>)',
+          soft: 'rgb(var(--warning-soft) / <alpha-value>)',
+          contrast: 'rgb(var(--warning-contrast) / <alpha-value>)',
+        },
+        danger: {
+          DEFAULT: 'rgb(var(--danger) / <alpha-value>)',
+          soft: 'rgb(var(--danger-soft) / <alpha-value>)',
+          contrast: 'rgb(var(--danger-contrast) / <alpha-value>)',
+        },
+        focus: 'rgb(var(--focus-ring) / <alpha-value>)',
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
## Summary

- Installs a real theme system (CSS-variable-backed semantic tokens + Tailwind `rgb(var(--x) / <alpha-value>)` aliases) so light/dark share one source of truth.
- Ships a calm, premium light mode across all high-impact surfaces (shell, dashboard, tracker, goals, routines, journal, tasks, modals, forms, charts, heatmaps).
- 3-way theme toggle (Light / Dark / System) in the user menu and Settings → Appearance, persisted locally and on the server via `DashboardPrefs.themeMode` for cross-device sync. Default stays Dark so existing users see no change.

## What's in it

- **Foundation** — `src/theme/` (palette, runtime CSS-var injector, `ThemeContext`, `useThemeColors`, theme-aware `getHeatmapColor`), `darkMode: 'class'` in Tailwind, `@layer components` helpers in `index.css`, pre-hydration script in `index.html` so first paint never flickers.
- **Persistence** — `DashboardPrefs.themeMode` on the backend; `DashboardPrefsContext` exposes `setThemeMode` that updates React state + localStorage + backend in one call.
- **Migrations** — 40+ components converted to semantic tokens (`bg-surface-*`, `text-content-*`, `border-line-*`, `bg-accent`, `bg-accent-soft`, `bg-danger-soft`, etc.). Category colors (`bg-emerald-500`, `bg-blue-500`, ...) stay literal because they encode data, not theme.
- **Charts + heatmaps** — recharts/SVG consumers read hex from `useThemeColors()`; heatmap has per-mode intensity ladders so light mode reads pale → saturated instead of dark → saturated.
- **Guardrails** — `scripts/check-theme-tokens.sh` lint gate on migrated dirs rejects raw `bg-neutral-600/700/800/900`, `bg-white/*`, `border-white/*` drift. 18 passing unit tests on palette / CSS-var emission / heatmap clamping.
- **Docs** — `docs/FEATURES.md`, `docs/product/HABITFLOW_UI_ARCHITECTURE.md`, `docs/ARCHITECTURE.md` updated to describe the system.

## Out of scope (future PRs)

Analytics page, Wellbeing History, Apple Health, Accomplishments log, login/invite pages — these remain dark-only in both modes. The lint gate is intentionally NOT applied to them so they don't fail CI until they're migrated.

## Test plan

- [ ] `npm run build` passes (tsc -b + vite build)
- [ ] `npx vitest run src/theme` — 18 theme tests pass
- [ ] `./scripts/check-theme-tokens.sh` — lint guard passes
- [ ] Open the app — existing users see dark mode unchanged (default is still Dark)
- [ ] Open user menu → toggle Light/Dark/System — live switch works, no flicker on reload
- [ ] Settings modal → Appearance section renders, selecting a mode persists and syncs
- [ ] Hard-refresh with `hf_theme_mode=light` in localStorage — first paint is light (no dark flash)
- [ ] Spot-check: Dashboard, Habits tracker, Goals detail page (charts), Year heatmap in both modes
- [ ] `prefers-color-scheme: dark` + System mode → reads OS preference; toggling OS theme while app open updates UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
