### PR TITLE
Include bundle parents in habit ring progress metrics

### DIFF
--- a/src/server/routes/__tests__/daySummary.test.ts
+++ b/src/server/routes/__tests__/daySummary.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../repositories/bundleMembershipRepository', () => ({
 
 import { getHabitsByUser } from '../../repositories/habitRepository';
 import { getHabitEntriesByUser } from '../../repositories/habitEntryRepository';
+import { getAllMembershipsByUser } from '../../repositories/bundleMembershipRepository';
 
 function createRes(): Response {
   return {
@@ -142,6 +143,7 @@ describe('getDaySummary', () => {
     vi.mocked(getHabitEntriesByUser).mockResolvedValue(entries);
 
     const req = {
+      householdId: 'test-household',
       userId: 'test-user',
       query: {
         startDayKey: '2026-02-15',
@@ -226,6 +228,7 @@ describe('getDaySummary', () => {
     vi.mocked(getHabitEntriesByUser).mockResolvedValue(entries);
 
     const req = {
+      householdId: 'test-household',
       userId: 'test-user',
       query: {
         startDayKey: '2026-02-17',
@@ -248,5 +251,87 @@ describe('getDaySummary', () => {
       expect(dayKey).toMatch(dayKeyRegex);
       expect(dayKey >= body.startDayKey && dayKey <= body.endDayKey).toBe(true);
     }
+  });
+
+  it('derived bundle parent respects membership daysOfWeek filter', async () => {
+    // 2026-01-07 is a Wednesday (day-of-week = 3).
+    // 2026-01-08 is a Thursday (day-of-week = 4).
+    const parent: Habit = {
+      id: 'bundle-parent',
+      categoryId: 'cat-1',
+      name: 'Morning Routine',
+      goal: { type: 'boolean', frequency: 'daily', target: 1 },
+      type: 'bundle',
+      bundleType: 'checklist',
+      subHabitIds: ['child-wed-only'],
+      archived: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    const child: Habit = {
+      id: 'child-wed-only',
+      categoryId: 'cat-1',
+      name: 'Stretch (Wednesdays only)',
+      goal: { type: 'boolean', frequency: 'daily', target: 1 },
+      bundleParentId: 'bundle-parent',
+      archived: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    vi.mocked(getHabitsByUser).mockResolvedValue([parent, child]);
+    vi.mocked(getAllMembershipsByUser).mockResolvedValue([
+      {
+        id: 'm-1',
+        parentHabitId: 'bundle-parent',
+        childHabitId: 'child-wed-only',
+        activeFromDayKey: '2026-01-01',
+        activeToDayKey: null,
+        daysOfWeek: [3], // Wednesday only
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    vi.mocked(getHabitEntriesByUser).mockResolvedValue([
+      createEntry({
+        id: 'e-wed',
+        habitId: 'child-wed-only',
+        dayKey: '2026-01-07',
+        timestamp: '2026-01-07T12:00:00.000Z',
+        source: 'manual',
+        value: 1,
+      }),
+      createEntry({
+        id: 'e-thu',
+        habitId: 'child-wed-only',
+        dayKey: '2026-01-08',
+        timestamp: '2026-01-08T12:00:00.000Z',
+        source: 'manual',
+        value: 1,
+      }),
+    ]);
+
+    const req = {
+      householdId: 'test-household',
+      userId: 'test-user',
+      query: {
+        startDayKey: '2026-01-07',
+        endDayKey: '2026-01-08',
+        timeZone: 'UTC',
+      },
+    } as unknown as Request;
+
+    const res = createRes();
+    await getDaySummary(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = vi.mocked(res.json).mock.calls[0][0];
+
+    // Wednesday: child is active per membership, so parent log is derived and complete.
+    expect(body.logs['bundle-parent-2026-01-07']).toEqual(
+      expect.objectContaining({ completed: true })
+    );
+
+    // Thursday: child is NOT active per membership (daysOfWeek=[3]).
+    // No active children => no derived parent log for that day.
+    expect(body.logs['bundle-parent-2026-01-08']).toBeUndefined();
   });
 });

--- a/src/server/routes/daySummary.ts
+++ b/src/server/routes/daySummary.ts
@@ -228,7 +228,10 @@ export async function getDaySummary(req: Request, res: Response): Promise<void> 
               if (m.activeFromDayKey > dayKey) return false;
               if (m.activeToDayKey && m.activeToDayKey < dayKey) return false;
               if (m.daysOfWeek && m.daysOfWeek.length > 0) {
-                const dayOfWeek = new Date(dayKey + 'T12:00:00').getDay();
+                // Noon-UTC + getUTCDay so the day-of-week is independent of
+                // the server's local timezone, matching bundleMembershipRepository,
+                // progress.ts, scheduleEngine, and client habitUtils.
+                const dayOfWeek = new Date(dayKey + 'T12:00:00Z').getUTCDay();
                 if (!m.daysOfWeek.includes(dayOfWeek)) return false;
               }
               return true;

--- a/src/utils/habitRingProgress.test.ts
+++ b/src/utils/habitRingProgress.test.ts
@@ -122,18 +122,38 @@ describe('Case B — standalone + checklist bundle', () => {
         ...cl.children,
     ];
 
-    it('total = 2 (standalone only — bundle parents excluded from ring metrics)', () => {
+    it('total = 3 (2 standalone + 1 bundle parent — matches Today view rows)', () => {
         const result = getDailyHabitRingProgress(habits, {}, DATE);
-        expect(result.total).toBe(2);
+        expect(result.total).toBe(3);
     });
 
-    it('bundle children are excluded from root habits, parent is still in root (for DayView rendering)', () => {
+    it('bundle children are excluded from root habits, parent is in root (for DayView + ring)', () => {
         const childIds = getBundleChildIds(habits);
         expect(childIds.size).toBe(4);
         const root = getRootHabits(habits);
         expect(root).toHaveLength(3);
         expect(root.map(h => h.id)).toContain('bundle-cl');
         expect(root.map(h => h.id)).not.toContain('cl-child-1');
+    });
+
+    it('bundle parent counts toward completed when all children are done', () => {
+        const logs = Object.fromEntries([
+            makeLog('cl-child-1', DATE, true),
+            makeLog('cl-child-2', DATE, true),
+            makeLog('cl-child-3', DATE, true),
+            makeLog('cl-child-4', DATE, true),
+        ]);
+        const result = getDailyHabitRingProgress(habits, logs, DATE);
+        expect(result).toEqual({ completed: 1, total: 3 });
+    });
+
+    it('bundle parent not counted when only some children done', () => {
+        const logs = Object.fromEntries([
+            makeLog('cl-child-1', DATE, true),
+            makeLog('cl-child-2', DATE, true),
+        ]);
+        const result = getDailyHabitRingProgress(habits, logs, DATE);
+        expect(result).toEqual({ completed: 0, total: 3 });
     });
 });
 
@@ -148,9 +168,17 @@ describe('Case C — standalone + choice bundle', () => {
         ...ch.children,
     ];
 
-    it('total = 2 (standalone only — bundle parents excluded from ring metrics)', () => {
+    it('total = 3 (2 standalone + 1 bundle parent — matches Today view rows)', () => {
         const result = getDailyHabitRingProgress(habits, {}, DATE);
-        expect(result.total).toBe(2);
+        expect(result.total).toBe(3);
+    });
+
+    it('choice bundle counts as complete when any child done', () => {
+        const logs = Object.fromEntries([
+            makeLog('ch-opt-2', DATE, true),
+        ]);
+        const result = getDailyHabitRingProgress(habits, logs, DATE);
+        expect(result).toEqual({ completed: 1, total: 3 });
     });
 });
 
@@ -168,9 +196,9 @@ describe('Case D — mixed: standalone + checklist + choice', () => {
         ...ch.children,
     ];
 
-    it('total = 1 (standalone only — bundle parents excluded from ring metrics)', () => {
+    it('total = 3 (1 standalone + 2 bundle parents — matches Today view rows)', () => {
         const result = getDailyHabitRingProgress(habits, {}, DATE);
-        expect(result.total).toBe(1);
+        expect(result.total).toBe(3);
     });
 });
 
@@ -202,7 +230,7 @@ describe('Case E — bundle completion semantics', () => {
             expect(isHabitComplete(cl.parent, logs, DATE)).toBe(true);
         });
 
-        it('ring excludes bundle parents — 0 trackable when only bundles present', () => {
+        it('ring counts bundle parent as 1 completed when checklist rule met', () => {
             const logs = Object.fromEntries([
                 makeLog('cl-child-1', DATE, true),
                 makeLog('cl-child-2', DATE, true),
@@ -210,7 +238,7 @@ describe('Case E — bundle completion semantics', () => {
                 makeLog('cl-child-4', DATE, true),
             ]);
             const result = getDailyHabitRingProgress(habits, logs, DATE);
-            expect(result).toEqual({ completed: 0, total: 0 });
+            expect(result).toEqual({ completed: 1, total: 1 });
         });
     });
 
@@ -229,12 +257,12 @@ describe('Case E — bundle completion semantics', () => {
             expect(isHabitComplete(ch.parent, {}, DATE)).toBe(false);
         });
 
-        it('ring excludes bundle parents — 0 trackable when only bundles present', () => {
+        it('ring counts bundle parent as 1 completed when any child done', () => {
             const logs = Object.fromEntries([
                 makeLog('ch-opt-1', DATE, true),
             ]);
             const result = getDailyHabitRingProgress(habits, logs, DATE);
-            expect(result).toEqual({ completed: 0, total: 0 });
+            expect(result).toEqual({ completed: 1, total: 1 });
         });
     });
 });
@@ -260,7 +288,7 @@ describe('Case F — no double-counting of parent and children', () => {
         expect(root[0].id).toBe('bundle-ch');
     });
 
-    it('mixed scenario: ring counts only standalone habits (bundle parents excluded)', () => {
+    it('mixed scenario: ring counts standalone habits and bundle parents (matches Today view rows)', () => {
         const standalone = standaloneHabits();
         const habits = [
             ...standalone,
@@ -279,11 +307,11 @@ describe('Case F — no double-counting of parent and children', () => {
             makeLog('ch-opt-1', DATE, true),
         ]);
         const result = getDailyHabitRingProgress(habits, logs, DATE);
-        // Ring counts 3 standalone only — bundle parents excluded for
-        // consistency with analytics (which also excludes bundle parents
-        // via isTrackableHabit). Children are excluded by getBundleChildIds.
-        expect(result.total).toBe(3);
-        expect(result.completed).toBe(3);
+        // 3 standalone + 2 bundle parents = 5 rows on the Today view.
+        // Children are excluded from rows by getBundleChildIds; bundle parents
+        // are counted, so the ring mirrors Today.
+        expect(result.total).toBe(5);
+        expect(result.completed).toBe(5);
         expect(result.completed).toBeLessThanOrEqual(result.total);
     });
 });

--- a/src/utils/habitUtils.ts
+++ b/src/utils/habitUtils.ts
@@ -282,23 +282,19 @@ export function isHabitComplete(
 }
 
 /**
- * Computes daily habit ring progress: { completed, total } for top-level daily habit units.
- * Uses the same filtering as the Today view (getHabitsForDate): only daily-frequency,
- * non-archived, root-level habits count toward the ring.
+ * Computes daily habit ring progress: { completed, total } matching the rows
+ * the Today view displays. Bundle parents count as a single row (children are
+ * already excluded via getBundleChildIds); their completion is derived from
+ * children via isHabitComplete -> computeBundleStatus. Keeping bundles in the
+ * tally keeps the dashboard ring aligned with the check state a user sees on
+ * the Today page.
  */
 export function getDailyHabitRingProgress(
     habits: Habit[],
     logs: Record<string, DayLog>,
     date: string
 ): { completed: number; total: number } {
-    const dailyRootHabits = getHabitsForDate(habits, date);
-    // Exclude bundle parents from ring metrics — their completion is derived
-    // from children, who are already excluded from root. This aligns with
-    // analytics (which also excludes bundle parents via isTrackableHabit).
-    // Without this, a user with 3 standalone + 1 bundle sees 4 total in the
-    // ring but 5 total in analytics (3 standalone + 2 children), causing
-    // inconsistent completion percentages across views.
-    const trackable = dailyRootHabits.filter(h => h.type !== 'bundle');
+    const trackable = getHabitsForDate(habits, date);
     const completed = trackable.filter(h => isHabitComplete(h, logs, date)).length;
     return { completed, total: trackable.length };
 }


### PR DESCRIPTION
## Summary
This PR aligns the daily habit ring progress metrics with the Today view by including bundle parents in the total count. Previously, bundle parents were excluded from ring metrics while their children were also excluded from the view, causing inconsistency between what users saw on the Today page and what the dashboard ring reported.

## Key Changes

- **Ring Progress Calculation**: Modified `getDailyHabitRingProgress()` to include bundle parents in the total count. Bundle completion is derived from their children via `isHabitComplete()`, so they now count as a single trackable unit matching the Today view rows.

- **Bundle Membership Filtering**: Fixed day-of-week filtering in `getDaySummary()` to use `getUTCDay()` instead of `getDay()`, ensuring timezone-independent day-of-week calculations consistent with other parts of the codebase (bundleMembershipRepository, progress.ts, scheduleEngine, client habitUtils).

- **Test Coverage**: 
  - Added comprehensive test in `daySummary.test.ts` verifying that derived bundle parents respect membership `daysOfWeek` filters
  - Updated `habitRingProgress.test.ts` test expectations to reflect bundle parents now being counted in ring metrics
  - Added new test cases for bundle completion semantics (checklist and choice bundles)

## Implementation Details

- Bundle parents are now included in `getHabitsForDate()` results and counted toward ring progress
- Bundle completion logic remains unchanged—checklist bundles require all children complete, choice bundles require any child complete
- The change ensures the ring progress percentage matches the completion state users see on the Today page, improving consistency across the UI
- Day-of-week calculations now consistently use UTC-based noon timestamps to avoid timezone-dependent behavior

https://claude.ai/code/session_01SfGHSDNCwsKNziRmwgmJ9k