### PR TITLE
Fix "View all" on Goals at a glance to load goals list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -574,6 +574,7 @@ const HabitTrackerContent: React.FC = () => {
             onNavigateToJournal={() => handleNavigate('journal')}
             onNavigateToRoutines={() => handleNavigate('routines')}
             onNavigateToTasks={() => handleNavigate('tasks')}
+            onNavigateToGoals={() => handleNavigate('goals')}
             onNavigate={(route) => handleNavigate(route as AppRoute)}
           />
         ) : view === 'wellbeing-history' ? (

--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -101,6 +101,7 @@ interface ProgressDashboardProps {
     onNavigateToJournal?: () => void;
     onNavigateToRoutines?: () => void;
     onNavigateToTasks?: () => void;
+    onNavigateToGoals?: () => void;
     onNavigate?: (route: string, params?: Record<string, string>) => void;
 }
 
@@ -114,6 +115,7 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
     onNavigateToJournal,
     onNavigateToRoutines,
     onNavigateToTasks,
+    onNavigateToGoals,
     onNavigate,
 }) => {
     const { user } = useAuth();
@@ -231,7 +233,7 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
                             </button>
                         )}
                         <button
-                            onClick={() => onViewGoal && onViewGoal('all')}
+                            onClick={() => onNavigateToGoals?.()}
                             className="text-xs text-neutral-500 hover:text-white transition-colors"
                         >
                             View all


### PR DESCRIPTION
The button called onViewGoal('all'), which routed to
?view=goals&goalId=all and rendered GoalDetailPage for a non-existent
goal id, so the goals list never appeared. Add a dedicated
onNavigateToGoals prop matching the existing Journal/Routines/Tasks
pattern, wired to handleNavigate('goals') which clears goalId.

https://claude.ai/code/session_01XpAYkmApkGt4Ss4BoxiZaU