### PR TITLE
Soft-delete habits to preserve orphaned-entry context

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -50,6 +50,12 @@ Pending suggestions created when a `suggest` rule is satisfied. User must accept
 - **Subjective-state truth:** `wellbeingEntries`
 - **Derived read-model surfaces** (computed from entries, not stored): day view, day summary, progress/overview, streaks, goal progress.
 
+## Soft Delete
+
+- **Habits** are soft-deleted: `DELETE /api/habits/:id` sets `Habit.deletedAt` rather than removing the row. The document is retained so that orphan entries (which still contribute to goal progress) can display the habit's original name and unit in historical views. Default readers (`getHabitsByUser`, etc.) filter out soft-deleted; goal-progress code opts in via `{ includeDeleted: true }`.
+- **Entries** are soft-deleted via `HabitEntry.deletedAt`.
+- **Truth records** are never hard-deleted.
+
 ## HabitEntry Semantics
 
 `HabitEntry` fields are defined in `src/models/persistenceTypes.ts`.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -20,7 +20,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Habit-Goal Linking** — Link habits to goals so completions count as goal progress. A single habit can be linked to multiple goals simultaneously (e.g., one "study session" habit contributing to a sequence of exam goals in a track).
 - **Habit-Routine Linking** — Link habits to routine steps so routine completion auto-logs habits
 - **Archiving** — Archive habits instead of deleting; soft-delete pattern
-- **Deletion with Goal Warning** — Deleting a habit linked to one or more goals surfaces a confirmation modal listing the affected goals. Historical progress on those goals is preserved — past entries continue to count — but the habit is removed from the goal's linked-habits list and can no longer be logged
+- **Deletion with Goal Warning** — Deleting a habit linked to one or more goals surfaces a confirmation modal listing the affected goals. Historical progress on those goals is preserved — past entries continue to count — but the habit is removed from the goal's linked-habits list and can no longer be logged. Deletion is soft: the habit's name/unit is retained so orphaned historical entries can still render with their original label on goal detail pages
 - **Reordering** — Drag-and-drop to reorder habits within categories
 
 ## Routines
@@ -44,7 +44,8 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Goal Types: One-time** — Binary milestone achievement (e.g., "Pass the B2 exam")
 - **Linked Habits** — Connect habits that contribute to goal progress; completions auto-update progress
 - **Progress Visualization** — Real-time progress bar with milestone markers at 25/50/75%
-- **Cumulative Chart** — Line graph of total progress over time
+- **Cumulative Chart** — Line graph of total progress over time. Renders from the same server-derived contributions series as the top "currentValue" total, so the two always agree
+- **Removed-Habit Contributors** — When a goal has historical progress from habits that have since been deleted, the goal detail page surfaces those contributions in a "Removed habits still contributing" list. The habit name is preserved via soft-delete so users can see exactly which removed habit is contributing how many units
 - **Trend Analysis** — Compare actual vs. required pace to hit deadline
 - **Weekly Summary** — Aggregated contribution data by week
 - **Day-by-Day View** — Chronological list of individual contributions

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -112,7 +112,7 @@ HabitFlow App
 | Goals — All | Page | Bottom tab "Goals", "All" toggle | Collapsible category stacks with progress bars. "New Track" button in header bar next to "+" | Goals, Categories | Create Goal Flow, Goal Detail, Edit Goal Modal, Create Track Modal |
 | Goals — Schedule | Page | "Schedule" toggle on Goals | Insight calendar with deadlines, forecasts, milestones | Goals, Categories | Goal Detail, Focus Mode |
 | Goals — Achievements | Page | "Achievements" toggle on Goals (trophy icon) | Gallery of completed goals (was Win Archive) | Goals | Goal Detail |
-| Goal Detail | Page | Click goal card / pinned goal | Charts, entries, linked habits for one goal | Goals, Habits, Entries | Edit Goal Modal, Goal Completed |
+| Goal Detail | Page | Click goal card / pinned goal | Charts, entries, linked habits (plus a "Removed habits still contributing" list when the goal has orphan contributions from deleted habits) for one goal | Goals, Habits, Entries | Edit Goal Modal, Goal Completed |
 | Goal Completed | Page | Auto-shown on 100% or manual | Celebratory screen with next actions | Goals | Achievements, Goal Detail, Level Up |
 | Goal Track Detail | Page | Click track in Goals page | Track name, ordered goals with states, reorder, add/remove goals | Goal Tracks, Goals | Goal Detail, Goals List |
 | Create Goal (Step 1) | Modal | "+ Goal" button on Goals page | Enter goal details (title, type, target, deadline, category) | Goals, Categories | Create Goal Step 2 |

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -366,6 +366,9 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                 <p className="text-xs text-neutral-500 mt-2">
                   <span className="font-semibold text-emerald-400">Goal Tracks</span> — Create ordered sequences of goals within a category (e.g., Exam 1 → Exam 2 → Exam 3). Only one goal per track is active at a time. When you complete the active goal, the next one unlocks automatically. Progress for each goal only counts from when it became active, so shared habits won't leak progress forward.
                 </p>
+                <p className="text-xs text-neutral-500 mt-2">
+                  <span className="font-semibold text-emerald-400">Removed habits still contributing</span> — If you delete a habit that was linked to a goal, its historical entries still count toward that goal's total. The goal detail page lists those removed habits under a "Removed habits still contributing" section so you can see exactly where the progress came from.
+                </p>
               </div>
             </div>
           )}

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -121,6 +121,13 @@ export interface Habit {
     /** Whether the habit is archived (hidden from active tracking) */
     archived: boolean;
 
+    /**
+     * Soft delete marker (ISO 8601). When set, the habit is removed from
+     * active views but the document is retained so historical entries keep
+     * a resolvable name/unit for goal progress displays.
+     */
+    deletedAt?: string;
+
     /** ISO 8601 timestamp of when the habit was created */
     createdAt: string;
 

--- a/src/pages/goals/GoalDetailPage.tsx
+++ b/src/pages/goals/GoalDetailPage.tsx
@@ -99,6 +99,24 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
         });
     }, [combinedEntries]);
 
+    // Deleted-habit contributors. Users need to see these so the gap
+    // between active-habit entries and progress.currentValue is explainable
+    // ("Chin ups was removed but its 88 pull-ups still count here").
+    const deletedContributors = useMemo(() => {
+        if (!data?.contributions) return [];
+        const byHabit = new Map<string, { habitName: string; total: number; count: number }>();
+        for (const c of data.contributions) {
+            if (!c.habitDeleted) continue;
+            const existing = byHabit.get(c.habitId) ?? { habitName: c.habitName, total: 0, count: 0 };
+            existing.total += c.value;
+            existing.count += 1;
+            byHabit.set(c.habitId, existing);
+        }
+        return Array.from(byHabit.entries())
+            .map(([habitId, v]) => ({ habitId, ...v }))
+            .sort((a, b) => b.total - a.total);
+    }, [data]);
+
 
     // Inline Milestones Logic
     const milestones = useMemo(() => {
@@ -620,6 +638,48 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                         </div>
                     )}
                 </div>
+
+                {deletedContributors.length > 0 && (
+                    <div className="mt-8">
+                        <div className="mb-3">
+                            <p className="text-neutral-300 text-sm font-medium">Removed habits still contributing</p>
+                            <p className="text-neutral-500 text-xs mt-0.5">
+                                These habits have been deleted but their historical entries still count toward this goal's total.
+                            </p>
+                        </div>
+                        <div className="space-y-2">
+                            {deletedContributors.map(contrib => (
+                                <div
+                                    key={contrib.habitId}
+                                    className="flex items-center justify-between p-3 bg-neutral-900/30 border border-white/5 rounded-lg"
+                                >
+                                    <div className="flex items-center gap-3 min-w-0">
+                                        <div className="w-8 h-8 rounded-lg bg-neutral-800 flex items-center justify-center text-neutral-500 flex-shrink-0">
+                                            <Trash2 size={14} />
+                                        </div>
+                                        <div className="min-w-0">
+                                            <div className="text-neutral-200 text-sm font-medium truncate">
+                                                {contrib.habitName}
+                                            </div>
+                                            <div className="text-neutral-500 text-xs">
+                                                <span className="inline-block px-1.5 py-0.5 bg-neutral-800 text-neutral-400 text-[10px] rounded mr-1.5">
+                                                    Removed
+                                                </span>
+                                                {contrib.count} {contrib.count === 1 ? 'entry' : 'entries'}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div className="text-right flex-shrink-0">
+                                        <div className="text-neutral-200 text-sm font-medium">
+                                            +{Number.isInteger(contrib.total) ? contrib.total : contrib.total.toFixed(1)}
+                                            {goal.unit && <span className="text-neutral-500 text-xs font-normal ml-1">{goal.unit}</span>}
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
             </div>
 
             {/* Manual contribution area removed in V1: progress is derived from habit entries */}

--- a/src/pages/goals/GoalDetailPage.tsx
+++ b/src/pages/goals/GoalDetailPage.tsx
@@ -24,7 +24,6 @@ import type { GoalTrack } from '../../types';
 import { GoalCumulativeChart } from '../../components/goals/GoalCumulativeChart';
 import { GoalWeeklySummary } from '../../components/goals/GoalWeeklySummary';
 import { GoalEntryList } from '../../components/goals/GoalEntryList';
-import type { HabitEntry } from '../../models/persistenceTypes';
 
 interface GoalDetailPageProps {
     goalId: string;
@@ -39,7 +38,7 @@ type Tab = 'cumulative' | 'dayByDay' | 'trend';
 
 export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, onNavigateToCompleted, onViewHabit, onViewGoal }) => {
     const { data, loading, error, refetch } = useGoalDetail(goalId);
-    const { habits, logs } = useHabitStore();
+    const { habits } = useHabitStore();
     const [activeTab, setActiveTab] = useState<Tab>('cumulative');
     const [showEditModal, setShowEditModal] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -64,7 +63,8 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
         return map;
     }, [habits]);
 
-    // Get linked habits
+    // Get linked habits (active only — deleted contributors are rendered from
+    // the server-provided contributions list below).
     const linkedHabits = useMemo(() => {
         if (!data) return [];
         return data.goal.linkedHabitIds
@@ -72,101 +72,33 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
             .filter((habit): habit is NonNullable<typeof habit> => habit !== undefined);
     }, [data, habitMap]);
 
-    // Derive linked habit entries from HabitContext logs (already pre-fetched)
-    // instead of making N separate API calls per linked habit
-    const linkedHabitEntries = useMemo(() => {
-        if (!data?.goal.linkedHabitIds.length) return [];
-
-        const linkedSet = new Set(data.goal.linkedHabitIds);
-        const entries: HabitEntry[] = [];
-
-        for (const [_key, dayLog] of Object.entries(logs)) {
-            if (!linkedSet.has(dayLog.habitId)) continue;
-            if (!dayLog.completed && !dayLog.value) continue;
-
-            entries.push({
-                id: `entry-${dayLog.habitId}-${dayLog.date}`,
-                habitId: dayLog.habitId,
-                timestamp: dayLog.date,
-                dayKey: dayLog.date,
-                date: dayLog.date,
-                dateKey: dayLog.date,
-                value: dayLog.value ?? (dayLog.completed ? 1 : 0),
-                source: dayLog.source,
-                routineId: dayLog.routineId,
-                deletedAt: undefined,
-                createdAt: dayLog.date,
-                updatedAt: dayLog.date,
-            } as HabitEntry);
-        }
-
-        return entries;
-    }, [data?.goal.linkedHabitIds, logs]);
-
-    // Combine Data for Charts/List
+    // Canonical per-entry contributions come from the server. All derived
+    // views (chart, weekly summary, day-by-day list) render from this so
+    // sum(combinedEntries[].value) === progress.currentValue by construction.
     const combinedEntries = useMemo(() => {
-        if (!data) return [];
+        if (!data?.contributions) return [];
+        return data.contributions
+            .map(c => ({
+                id: c.id,
+                date: c.date,
+                value: c.value,
+                source: 'habit' as const,
+                habitName: c.habitName,
+                habitDeleted: c.habitDeleted,
+                unit: c.unit ?? data.goal.unit,
+            }))
+            .sort((a, b) => a.date.localeCompare(b.date));
+    }, [data]);
 
-        const fromHabits = linkedHabitEntries
-            .filter(entry => {
-                const habit = habitMap.get(entry.habitId);
-                if (!habit) return false;
-
-                // Type-Based Aggregation Logic
-                if (data.goal.type === 'cumulative') {
-                    // Include all habits (boolean habits contribute their target per entry)
-                    return true;
-                }
-
-                // For other goal types (onetime), accept everything
-                return true;
-            })
-            .map(entry => {
-                const habit = habitMap.get(entry.habitId);
-                // Use entry.date (YYYY-MM-DD) as the canonical date source.
-                // Fallback to timestamp split if needed, but entry.date is required.
-                const dateStr = entry.date || entry.timestamp.split('T')[0];
-
-                return {
-                    id: entry.id,
-                    date: dateStr,
-                    // Now that we filtered incompatible units, we can safely use value.
-                    // If value is undefined but unit matched (unlikely if strictly checked, but possible for some data shapes),
-                    // we might default to 0 or 1.
-                    // If goal is cumulative, we expect a number.
-                    value: (() => {
-                        const h = habitMap.get(entry.habitId);
-                        // Boolean habits contribute their target value per entry
-                        if (h?.goal.type === 'boolean' && data.goal.type === 'cumulative') {
-                            return h.goal.target ?? 1;
-                        }
-                        return entry.value !== undefined ? entry.value : 0;
-                    })(),
-                    source: 'habit' as const,
-                    habitName: habit?.name,
-                    unit: habit?.goal.unit || data.goal.unit
-                };
-            });
-
-        const combined = fromHabits.filter(item => item.date);
-        console.log('[GoalDetail] Final combined entries:', combined);
-        return combined.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
-    }, [data, linkedHabitEntries, habitMap]);
-
-    // Calculate Cumulative Data for Chart
+    // Cumulative series for the chart: running sum of contribution values.
     const cumulativeData = useMemo(() => {
         let total = 0;
-        // Sort ascending by date safely
-        const sorted = [...combinedEntries].sort((a, b) => (a.date || '').localeCompare(b.date || ''));
-
-        return sorted.map(entry => {
+        return combinedEntries.map(entry => {
             total += entry.value;
-            return {
-                date: entry.date,
-                value: total
-            };
+            return { date: entry.date, value: total };
         });
     }, [combinedEntries]);
+
 
     // Inline Milestones Logic
     const milestones = useMemo(() => {

--- a/src/server/repositories/habitRepository.ts
+++ b/src/server/repositories/habitRepository.ts
@@ -69,8 +69,14 @@ export async function createHabit(
   // Atomic upsert: prevents TOCTOU race where concurrent requests both
   // pass a findOne check and then both insert, creating duplicates.
   // $setOnInsert only applies fields when a new document is created.
+  // Filter by deletedAt absent so a soft-deleted habit with the same name
+  // does not silently resurrect when the user creates a new habit.
   const result = await collection.findOneAndUpdate(
-    scopeFilter(householdId, userId, { name: data.name, categoryId: data.categoryId }),
+    scopeFilter(householdId, userId, {
+      name: data.name,
+      categoryId: data.categoryId,
+      deletedAt: { $exists: false },
+    }),
     {
       $setOnInsert: {
         id,
@@ -96,12 +102,32 @@ export async function createHabit(
   return stripScope(result);
 }
 
-export async function getHabitsByUser(householdId: string, userId: string): Promise<Habit[]> {
+export interface HabitReadOptions {
+  /**
+   * When true, include soft-deleted habits (deletedAt set) in results.
+   * Default: false. Used by goal progress to resolve historical names/units.
+   */
+  includeDeleted?: boolean;
+}
+
+function withDeletedFilter(
+  extra: Record<string, unknown>,
+  includeDeleted: boolean | undefined
+): Record<string, unknown> {
+  if (includeDeleted) return extra;
+  return { ...extra, deletedAt: { $exists: false } };
+}
+
+export async function getHabitsByUser(
+  householdId: string,
+  userId: string,
+  options?: HabitReadOptions
+): Promise<Habit[]> {
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
   const documents = await collection
-    .find(scopeFilter(householdId, userId))
+    .find(scopeFilter(householdId, userId, withDeletedFilter({}, options?.includeDeleted)))
     .sort({ order: 1, createdAt: 1 })
     .toArray();
 
@@ -111,13 +137,14 @@ export async function getHabitsByUser(householdId: string, userId: string): Prom
 export async function getHabitsByCategory(
   categoryId: string,
   householdId: string,
-  userId: string
+  userId: string,
+  options?: HabitReadOptions
 ): Promise<Habit[]> {
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
   const documents = await collection
-    .find(scopeFilter(householdId, userId, { categoryId }))
+    .find(scopeFilter(householdId, userId, withDeletedFilter({ categoryId }, options?.includeDeleted)))
     .sort({ order: 1, createdAt: 1 })
     .toArray();
 
@@ -127,12 +154,15 @@ export async function getHabitsByCategory(
 export async function getHabitById(
   id: string,
   householdId: string,
-  userId: string
+  userId: string,
+  options?: HabitReadOptions
 ): Promise<Habit | null> {
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
-  const document = await collection.findOne(scopeFilter(householdId, userId, { id }));
+  const document = await collection.findOne(
+    scopeFilter(householdId, userId, withDeletedFilter({ id }, options?.includeDeleted))
+  );
   if (!document) return null;
 
   return stripScope(document);
@@ -148,8 +178,10 @@ export async function updateHabit(
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
+  // Refuse to update soft-deleted habits: they should only be resurrectable
+  // via an explicit restore path, not via an ordinary PATCH.
   const result = await collection.findOneAndUpdate(
-    scopeFilter(householdId, userId, { id }),
+    scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
     { $set: patch },
     { returnDocument: 'after', session }
   );
@@ -158,6 +190,14 @@ export async function updateHabit(
   return stripScope(result);
 }
 
+/**
+ * Soft-delete a habit. Sets `deletedAt`; the document is retained so that
+ * orphaned entries (which still contribute to goal progress) can display
+ * the habit's original name and unit in historical views.
+ *
+ * Idempotent: deleting an already-deleted habit returns false without
+ * updating deletedAt (so the original deletion timestamp is preserved).
+ */
 export async function deleteHabit(
   id: string,
   householdId: string,
@@ -166,8 +206,11 @@ export async function deleteHabit(
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
-  const result = await collection.deleteOne(scopeFilter(householdId, userId, { id }));
-  return result.deletedCount > 0;
+  const result = await collection.updateOne(
+    scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
+    { $set: { deletedAt: new Date().toISOString() } }
+  );
+  return result.modifiedCount > 0;
 }
 
 export async function reorderHabits(
@@ -267,8 +310,9 @@ export async function linkHabitsToGoal(
   const goalsCollection = db.collection(GOALS_COLLECTION);
 
   // Fetch the habits we're linking and their existing linkedGoalId values.
+  // Skip soft-deleted habits: re-linking a removed habit would resurrect it.
   const habits = await habitsCollection
-    .find(scopeFilter(householdId, userId, { id: { $in: habitIds } }))
+    .find(scopeFilter(householdId, userId, { id: { $in: habitIds }, deletedAt: { $exists: false } }))
     .project({ id: 1, linkedGoalId: 1 })
     .toArray();
 
@@ -338,8 +382,9 @@ export async function unlinkHabitsFromGoal(
   const goalsCollection = db.collection(GOALS_COLLECTION);
 
   // Find habits currently pointing at this goal.
+  // Skip soft-deleted habits: they no longer carry the primary-goal UI hint.
   const habitsPointingHere = await habitsCollection
-    .find(scopeFilter(householdId, userId, { linkedGoalId: goalId }))
+    .find(scopeFilter(householdId, userId, { linkedGoalId: goalId, deletedAt: { $exists: false } }))
     .project({ id: 1 })
     .toArray();
 

--- a/src/server/routes/__tests__/goals.detailInvariants.test.ts
+++ b/src/server/routes/__tests__/goals.detailInvariants.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Invariant tests for /api/goals/:id/detail.
+ *
+ * The goal detail page renders three derived views (cumulative chart,
+ * weekly summary, day-by-day list) plus a top "currentValue" number.
+ * Previously the chart and the top diverged because they used different
+ * data sources with different orphan-entry filters — a user with a
+ * removed habit saw top=298 / chart=210. These tests lock in the
+ * invariant that sum(contributions[].value) === progress.currentValue,
+ * regardless of whether any linked habits have been soft-deleted.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { createCategory } from '../../repositories/categoryRepository';
+import { createHabit, deleteHabit } from '../../repositories/habitRepository';
+import { createGoal } from '../../repositories/goalRepository';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import { createHabitEntryRoute } from '../habitEntries';
+import { getGoalDetailRoute } from '../goals';
+import { requestContextMiddleware } from '../../middleware/requestContext';
+
+const TEST_HOUSEHOLD = 'test-household-goals-detail-invariants';
+const TEST_USER = 'test-user-goals-detail-invariants';
+
+let app: Express;
+
+function daysAgoKey(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+describe('Goal detail: contributions sum equals progress.currentValue', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+
+    app = express();
+    app.use(express.json());
+    app.use(requestContextMiddleware);
+    app.use((req, _res, next) => {
+      (req as any).householdId = TEST_HOUSEHOLD;
+      (req as any).userId = TEST_USER;
+      next();
+    });
+
+    app.post('/api/entries', createHabitEntryRoute);
+    app.get('/api/goals/:id/detail', getGoalDetailRoute);
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await Promise.all([
+      db.collection('categories').deleteMany({ householdId: TEST_HOUSEHOLD, userId: TEST_USER }),
+      db.collection('habits').deleteMany({ householdId: TEST_HOUSEHOLD, userId: TEST_USER }),
+      db.collection('habitEntries').deleteMany({ householdId: TEST_HOUSEHOLD, userId: TEST_USER }),
+      db.collection('goals').deleteMany({ householdId: TEST_HOUSEHOLD, userId: TEST_USER }),
+    ]);
+  });
+
+  it('sum mode: matches currentValue across active and deleted habits', async () => {
+    const cat = await createCategory({ name: 'Fitness', color: '#FF0000' }, TEST_HOUSEHOLD, TEST_USER);
+
+    const pullUps = await createHabit(
+      {
+        name: 'Pull ups',
+        categoryId: cat.id,
+        goal: { type: 'number', frequency: 'daily', target: 10, unit: 'reps' },
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+    const chinUps = await createHabit(
+      {
+        name: 'Chin ups',
+        categoryId: cat.id,
+        goal: { type: 'number', frequency: 'daily', target: 10, unit: 'reps' },
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    const goal = await createGoal(
+      {
+        title: 'Do 500 pull ups',
+        type: 'cumulative',
+        targetValue: 500,
+        unit: 'reps',
+        linkedHabitIds: [pullUps.id, chinUps.id],
+        aggregationMode: 'sum',
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    // Pull-ups: 210 reps spread across 3 days.
+    await request(app).post('/api/entries').send({
+      habitId: pullUps.id, dayKey: daysAgoKey(2), value: 70, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: pullUps.id, dayKey: daysAgoKey(1), value: 70, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: pullUps.id, dayKey: daysAgoKey(0), value: 70, source: 'manual', timeZone: 'UTC',
+    });
+
+    // Chin-ups: 88 reps in the past, then the habit gets removed.
+    await request(app).post('/api/entries').send({
+      habitId: chinUps.id, dayKey: daysAgoKey(5), value: 44, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: chinUps.id, dayKey: daysAgoKey(4), value: 44, source: 'manual', timeZone: 'UTC',
+    });
+
+    // Soft-delete the chin-ups habit (orphans its 88 reps of entries).
+    const deleted = await deleteHabit(chinUps.id, TEST_HOUSEHOLD, TEST_USER);
+    expect(deleted).toBe(true);
+
+    const res = await request(app).get(`/api/goals/${goal.id}/detail`).query({ timeZone: 'UTC' });
+    expect(res.status).toBe(200);
+
+    const { progress, contributions } = res.body as {
+      progress: { currentValue: number };
+      contributions: Array<{ habitId: string; habitName: string; habitDeleted: boolean; value: number }>;
+    };
+
+    // The critical invariant: the cumulative chart (sum of contributions)
+    // must match the headline number at the top of the page.
+    const sumOfContributions = contributions.reduce((s, c) => s + c.value, 0);
+    expect(sumOfContributions).toBe(progress.currentValue);
+    expect(sumOfContributions).toBe(298); // 210 + 88
+
+    // The removed habit's entries are still present in the series, with
+    // habitDeleted=true so the UI can surface them in a "Removed" list.
+    const orphaned = contributions.filter(c => c.habitDeleted);
+    expect(orphaned.length).toBe(2);
+    expect(orphaned.every(c => c.habitName === 'Chin ups')).toBe(true);
+    expect(orphaned.reduce((s, c) => s + c.value, 0)).toBe(88);
+  });
+
+  it('sum mode with boolean habit: entries contribute the habit target, not entry.value', async () => {
+    const cat = await createCategory({ name: 'Health', color: '#00FF00' }, TEST_HOUSEHOLD, TEST_USER);
+
+    // Boolean habit: each check-in is worth `target` toward the goal.
+    const habit = await createHabit(
+      {
+        name: 'Quick pushup set',
+        categoryId: cat.id,
+        goal: { type: 'boolean', frequency: 'daily', target: 25 },
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+    const goal = await createGoal(
+      {
+        title: '1000 pushups',
+        type: 'cumulative',
+        targetValue: 1000,
+        linkedHabitIds: [habit.id],
+        aggregationMode: 'sum',
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    // Three check-ins → should contribute 75 total (3 * 25).
+    await request(app).post('/api/entries').send({
+      habitId: habit.id, dayKey: daysAgoKey(2), value: 1, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: habit.id, dayKey: daysAgoKey(1), value: 1, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: habit.id, dayKey: daysAgoKey(0), value: 1, source: 'manual', timeZone: 'UTC',
+    });
+
+    const res = await request(app).get(`/api/goals/${goal.id}/detail`).query({ timeZone: 'UTC' });
+    const { progress, contributions } = res.body;
+
+    const sumOfContributions = contributions.reduce((s: number, c: { value: number }) => s + c.value, 0);
+    expect(progress.currentValue).toBe(75);
+    expect(sumOfContributions).toBe(progress.currentValue);
+  });
+
+  it('count mode (distinctDays): contributions dedupe per day', async () => {
+    const cat = await createCategory({ name: 'Mindfulness', color: '#0000FF' }, TEST_HOUSEHOLD, TEST_USER);
+    const habit = await createHabit(
+      {
+        name: 'Meditate',
+        categoryId: cat.id,
+        goal: { type: 'boolean', frequency: 'daily', target: 1 },
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+    const goal = await createGoal(
+      {
+        title: 'Meditate 30 days',
+        type: 'cumulative',
+        targetValue: 30,
+        linkedHabitIds: [habit.id],
+        aggregationMode: 'count',
+        countMode: 'distinctDays',
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    // Two entries on the same day, one on another. distinctDays = 2.
+    await request(app).post('/api/entries').send({
+      habitId: habit.id, dayKey: daysAgoKey(1), value: 1, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: habit.id, dayKey: daysAgoKey(1), value: 1, source: 'manual', timeZone: 'UTC',
+    });
+    await request(app).post('/api/entries').send({
+      habitId: habit.id, dayKey: daysAgoKey(0), value: 1, source: 'manual', timeZone: 'UTC',
+    });
+
+    const res = await request(app).get(`/api/goals/${goal.id}/detail`).query({ timeZone: 'UTC' });
+    const { progress, contributions } = res.body;
+
+    expect(progress.currentValue).toBe(2);
+    const sumOfContributions = contributions.reduce((s: number, c: { value: number }) => s + c.value, 0);
+    expect(sumOfContributions).toBe(progress.currentValue);
+  });
+});

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -858,6 +858,12 @@ export async function getGoalDetailRoute(req: Request, res: Response): Promise<v
     }
 
     const { getEntryViewsForHabits } = await import('../services/truthQuery');
+    const { getAggregationMode, getCountMode } = await import('../utils/goalLinkSemantics');
+
+    // Build habit map including soft-deleted so orphan entries resolve a name
+    // and boolean-target multipliers still apply.
+    const allHabits = await getHabitsByUser(householdId, userId, { includeDeleted: true });
+    const habitMap = new Map(allHabits.map(h => [h.id, h]));
 
     const entryViews = await getEntryViewsForHabits(goal.linkedHabitIds, householdId, userId, {
       timeZone: userTimeZone,
@@ -865,6 +871,69 @@ export async function getGoalDetailRoute(req: Request, res: Response): Promise<v
 
     const activeEntries = entryViews.filter(e => !e.deletedAt);
 
+    // Respect the goal's active window if it is a tracked goal.
+    const dateWindow = goal.activeWindowStart
+      ? { start: goal.activeWindowStart, end: goal.activeWindowEnd || undefined }
+      : undefined;
+    const windowedEntries = dateWindow
+      ? activeEntries.filter(e => {
+          if (e.dayKey < dateWindow.start) return false;
+          if (dateWindow.end && e.dayKey > dateWindow.end) return false;
+          return true;
+        })
+      : activeEntries;
+
+    // Build the canonical per-entry contributions list. All derived views on
+    // the frontend (cumulative chart, weekly summary, day-by-day list) must
+    // render from this so the sum matches progress.currentValue by construction.
+    const aggregationMode = getAggregationMode(goal);
+    const countMode = getCountMode(goal);
+
+    // For count-mode='distinctDays', dedupe by dayKey server-side. currentValue =
+    // distinct-day count, so we emit one contribution per day (worth 1) so
+    // that sum(contributions[].value) === currentValue.
+    const sourceEntries = (aggregationMode === 'count' && countMode === 'distinctDays')
+      ? (() => {
+          const seen = new Map<string, typeof windowedEntries[number]>();
+          for (const e of windowedEntries) {
+            if (!seen.has(e.dayKey)) seen.set(e.dayKey, e);
+          }
+          return Array.from(seen.values());
+        })()
+      : windowedEntries;
+
+    const contributions = sourceEntries.map((entry, idx) => {
+      const habit = habitMap.get(entry.habitId);
+      let value: number;
+      if (aggregationMode === 'sum') {
+        // Boolean habits contribute their target per entry (e.g. "do 25 pull ups"
+        // records 1 entry but counts for 25). Missing habit (shouldn't happen
+        // post soft-delete, but guard): fall back to the entry's raw value.
+        if (habit?.goal.type === 'boolean') {
+          value = habit.goal.target ?? 1;
+        } else {
+          value = entry.value ?? 0;
+        }
+      } else {
+        // count-mode: each unit of progress is worth 1 (entry or day).
+        value = 1;
+      }
+
+      return {
+        // EntryView has no stable id; synthesize one per row (stable for a
+        // given fetched response — the frontend only needs it for React keys).
+        id: `${entry.habitId}-${entry.dayKey}-${entry.timestampUtc ?? idx}`,
+        date: entry.dayKey,
+        habitId: entry.habitId,
+        habitName: habit?.name ?? 'Removed habit',
+        habitDeleted: !!habit?.deletedAt,
+        value,
+        unit: habit?.goal.unit ?? goal.unit,
+        source: entry.source,
+      };
+    });
+
+    // Legacy 30-day history (kept for transitional clients until removed).
     const historyMap = new Map<string, number>();
     const last30Days: string[] = [];
     for (let i = 0; i < 30; i++) {
@@ -872,17 +941,10 @@ export async function getGoalDetailRoute(req: Request, res: Response): Promise<v
       last30Days.push(dateStr);
       historyMap.set(dateStr, 0);
     }
-
-    for (const entry of activeEntries) {
-      if (!historyMap.has(entry.dayKey)) continue;
-      const current = historyMap.get(entry.dayKey) || 0;
-      if (goal.type === 'cumulative') {
-        historyMap.set(entry.dayKey, current + (entry.value ?? 0));
-      } else {
-        historyMap.set(entry.dayKey, current + 1);
-      }
+    for (const c of contributions) {
+      if (!historyMap.has(c.date)) continue;
+      historyMap.set(c.date, (historyMap.get(c.date) || 0) + c.value);
     }
-
     const history = last30Days.reverse().map(date => ({
       date,
       value: historyMap.get(date) || 0,
@@ -891,6 +953,7 @@ export async function getGoalDetailRoute(req: Request, res: Response): Promise<v
     res.status(200).json({
       goal,
       progress,
+      contributions,
       history,
     });
   } catch (error) {

--- a/src/server/utils/goalProgressUtilsV2.ts
+++ b/src/server/utils/goalProgressUtilsV2.ts
@@ -43,7 +43,9 @@ function getDateString(daysAgo: number): string {
  */
 async function resolveBundleIds(habitIds: string[], householdId: string, userId: string): Promise<string[]> {
   const resolvedIds = new Set<string>();
-  const allHabits = await getHabitsByUser(householdId, userId);
+  // Include soft-deleted habits so bundle resolution still works for goals
+  // that linked to a bundle that was later removed.
+  const allHabits = await getHabitsByUser(householdId, userId, { includeDeleted: true });
   const habitMap = new Map(allHabits.map(h => [h.id, h]));
 
   for (const id of habitIds) {
@@ -121,7 +123,9 @@ export async function computeGoalProgressV2(
     timeZone,
   });
 
-  const allHabits = await getHabitsByUser(householdId, userId);
+  // Include soft-deleted habits so boolean-target multipliers and unit matches
+  // still apply for orphan entries (habit was removed but its entries remain).
+  const allHabits = await getHabitsByUser(householdId, userId, { includeDeleted: true });
   const habitMap = new Map(allHabits.map(h => [h.id, h]));
 
   // For tracked goals, only count entries within the active window
@@ -288,7 +292,8 @@ export async function computeGoalsWithProgressV2(
 
   const [goals, allHabits] = await Promise.all([
     getGoalsByUser(householdId, userId),
-    getHabitsByUser(householdId, userId),
+    // Include soft-deleted habits so goal progress preserves orphan contributions.
+    getHabitsByUser(householdId, userId, { includeDeleted: true }),
   ]);
 
   return computeGoalsWithProgressFromData(goals, allHabits, householdId, userId, timeZone);
@@ -317,6 +322,22 @@ export async function computeGoalsWithProgressFromData(
   prefetchedEntries?: HabitEntry[]
 ): Promise<Array<{ goal: Goal; progress: GoalProgress }>> {
   const habitMap = new Map(allHabits.map(h => [h.id, h]));
+
+  // Supplement with soft-deleted habits referenced by any goal's linkedHabitIds.
+  // Callers typically pass only active habits (for other purposes). We need the
+  // deleted ones so boolean-target multipliers and unit checks still apply to
+  // orphan entries.
+  const referencedIds = new Set<string>();
+  for (const goal of goals) {
+    for (const id of goal.linkedHabitIds) referencedIds.add(id);
+  }
+  const missingIds = Array.from(referencedIds).filter(id => !habitMap.has(id));
+  if (missingIds.length > 0) {
+    const deletedHabits = await getHabitsByUser(householdId, userId, { includeDeleted: true });
+    for (const habit of deletedHabits) {
+      if (missingIds.includes(habit.id)) habitMap.set(habit.id, habit);
+    }
+  }
 
   // Pre-fetch memberships for all bundle parents referenced by goals
   const bundleParentIds = new Set<string>();
@@ -410,6 +431,20 @@ export async function computeGoalListProgress(
   timeZone: string = 'UTC'
 ): Promise<Array<{ goal: Goal; progress: GoalProgress }>> {
   const habitMap = new Map(allHabits.map(h => [h.id, h]));
+
+  // Supplement with soft-deleted habits referenced by any goal. Needed so
+  // boolean-target multipliers and unit checks still apply to orphan entries.
+  const referencedIds = new Set<string>();
+  for (const goal of goals) {
+    for (const id of goal.linkedHabitIds) referencedIds.add(id);
+  }
+  const missingIds = Array.from(referencedIds).filter(id => !habitMap.has(id));
+  if (missingIds.length > 0) {
+    const allWithDeleted = await getHabitsByUser(householdId, userId, { includeDeleted: true });
+    for (const habit of allWithDeleted) {
+      if (missingIds.includes(habit.id)) habitMap.set(habit.id, habit);
+    }
+  }
 
   // Pre-fetch memberships for all bundle parents referenced by goals
   const bundleParentIds = new Set<string>();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -166,13 +166,39 @@ export interface GoalTrackWithGoals {
 export type CompletedGoal = Goal;
 
 /**
+ * Per-entry contribution to a goal. Server-derived so that chart + weekly
+ * summary + day-by-day list all sum to `progress.currentValue` by construction.
+ */
+export interface GoalContribution {
+    id: string;
+    /** DayKey (YYYY-MM-DD) */
+    date: string;
+    habitId: string;
+    /** Name at query time; retained for deleted habits via soft delete. */
+    habitName: string;
+    /** True if the habit has been deleted (soft). Entry still contributes. */
+    habitDeleted: boolean;
+    /** Value added by this entry, already adjusted for boolean target. */
+    value: number;
+    unit?: string;
+    source?: string;
+}
+
+/**
  * Goal Detail
  *
- * Data for goal detail page: goal, progress, and history (entries-derived).
+ * Data for goal detail page: goal, progress, and a full per-entry
+ * contributions array. All derived views (cumulative chart, weekly
+ * summary, day-by-day list) must render from `contributions` so they
+ * stay in lockstep with `progress.currentValue`.
  */
 export interface GoalDetail {
     goal: Goal;
     progress: GoalProgress;
+    contributions: GoalContribution[];
+    /**
+     * @deprecated Use `contributions`. Kept for transitional reads only.
+     */
     history?: { date: string; value: number }[];
 }
 


### PR DESCRIPTION
Hard-deleting a habit left its entries orphaned in habitEntries: goal
progress still summed them (by design) but the habit name was gone, and
every view that iterated active habits silently dropped them. The top
total and the cumulative chart diverged because they applied different
deleted-habit filters.

This commit switches habit deletion to soft-delete (deletedAt). Default
readers filter it out; goalProgressUtilsV2 opts in to includeDeleted so
boolean-target multipliers and unit checks still apply to orphan entries.