### PR TITLE
Fix race in routine execute-mode init that can crash on close

### DIFF
--- a/src/components/RoutineRunnerModal.test.tsx
+++ b/src/components/RoutineRunnerModal.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Reproduction test: clicking the close (X) icon in execute mode must not
+ * trigger a React render-loop / hooks-mismatch error.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { RoutineProvider } from '../store/RoutineContext';
+import { HabitProvider } from '../store/HabitContext';
+import { ToastProvider } from './Toast';
+import { RoutineRunnerModal } from './RoutineRunnerModal';
+import type { Routine } from '../models/persistenceTypes';
+
+const mockRoutine: Routine = {
+    id: 'routine-1',
+    userId: 'user-1',
+    title: 'Test Routine',
+    linkedHabitIds: [],
+    steps: [
+        { id: 'step-a', title: 'Step A', timerSeconds: 30 },
+        { id: 'step-b', title: 'Step B' },
+    ],
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+vi.mock('../lib/persistenceClient', async () => {
+    const actual = await vi.importActual<typeof import('../lib/persistenceClient')>('../lib/persistenceClient');
+    return {
+        ...actual,
+        fetchRoutines: vi.fn().mockResolvedValue([]),
+        fetchRoutineLogs: vi.fn().mockResolvedValue({}),
+        fetchCategories: vi.fn().mockResolvedValue([]),
+        fetchHabits: vi.fn().mockResolvedValue([]),
+        fetchDayLogs: vi.fn().mockResolvedValue({}),
+        fetchWellbeingLogs: vi.fn().mockResolvedValue({}),
+        fetchPotentialEvidence: vi.fn().mockResolvedValue([]),
+        submitRoutine: vi.fn().mockResolvedValue(undefined),
+        batchCreateEntries: vi.fn().mockResolvedValue(undefined),
+        recordRoutineStepsReachedBatch: vi.fn().mockResolvedValue(undefined),
+    };
+});
+
+function Harness() {
+    const [open, setOpen] = React.useState(true);
+    return (
+        <React.StrictMode>
+            <ToastProvider>
+                <HabitProvider>
+                    <RoutineProvider>
+                        <RoutineRunnerModal
+                            isOpen={open}
+                            routine={mockRoutine}
+                            variantId={undefined}
+                            onClose={() => setOpen(false)}
+                        />
+                    </RoutineProvider>
+                </HabitProvider>
+            </ToastProvider>
+        </React.StrictMode>
+    );
+}
+
+describe('RoutineRunnerModal — close button', () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => {
+        errorSpy.mockRestore();
+    });
+
+    it('closes cleanly without a React error when close icon is clicked', async () => {
+        render(<Harness />);
+        await waitFor(() => {
+            expect(screen.getByLabelText('Close')).toBeTruthy();
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByLabelText('Close'));
+        });
+        // After close, modal should no longer be in the DOM
+        expect(screen.queryByLabelText('Close')).toBeNull();
+        // No React errors should have been logged
+        const reactErrors = errorSpy.mock.calls.filter((args: unknown[]) =>
+            args.some((a: unknown) => typeof a === 'string' && (a.includes('Minified React error') || a.includes('Too many re-renders') || a.includes('Rendered fewer hooks')))
+        );
+        expect(reactErrors).toEqual([]);
+    });
+
+    it('closes cleanly after starting the timer', async () => {
+        render(<Harness />);
+        await waitFor(() => {
+            expect(screen.getByLabelText('Close')).toBeTruthy();
+        });
+        // Start the countdown timer (step-a has timerSeconds: 30)
+        const startBtn = screen.queryByText('Start');
+        if (startBtn) {
+            await act(async () => {
+                fireEvent.click(startBtn);
+            });
+        }
+        await act(async () => {
+            fireEvent.click(screen.getByLabelText('Close'));
+        });
+        expect(screen.queryByLabelText('Close')).toBeNull();
+        const reactErrors = errorSpy.mock.calls.filter((args: unknown[]) =>
+            args.some((a: unknown) => typeof a === 'string' && (a.includes('Minified React error') || a.includes('Too many re-renders') || a.includes('Rendered fewer hooks')))
+        );
+        expect(reactErrors).toEqual([]);
+    });
+
+    it('closes cleanly after navigating to the completion view', async () => {
+        render(<Harness />);
+        await waitFor(() => {
+            expect(screen.getByLabelText('Close')).toBeTruthy();
+        });
+        // Advance through all steps to reach completion view
+        for (let i = 0; i < 5; i++) {
+            const nextBtn = screen.queryByText(/Next Step|Finish/);
+            if (nextBtn) {
+                await act(async () => {
+                    fireEvent.click(nextBtn);
+                });
+            }
+        }
+        // Now try closing
+        await act(async () => {
+            fireEvent.click(screen.getByLabelText('Close'));
+        });
+        expect(screen.queryByLabelText('Close')).toBeNull();
+        const reactErrors = errorSpy.mock.calls.filter((args: unknown[]) =>
+            args.some((a: unknown) => typeof a === 'string' && (a.includes('Minified React error') || a.includes('Too many re-renders') || a.includes('Rendered fewer hooks')))
+        );
+        expect(reactErrors).toEqual([]);
+    });
+});

--- a/src/components/RoutineRunnerModal.tsx
+++ b/src/components/RoutineRunnerModal.tsx
@@ -25,7 +25,7 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
 }) => {
     const { refreshDayLogs, habits } = useHabitStore();
     const {
-        selectRoutine, startRoutine, exitRoutine,
+        startRoutine, exitRoutine,
         stepStates, setStepState, startedAt,
         stepTrackingData, stepTimingData,
         setStepTrackingValue, recordStepTime,
@@ -52,12 +52,14 @@ export const RoutineRunnerModal: React.FC<RoutineRunnerModalProps> = ({
     // Track previous step index to record timing on step change
     const prevStepIndexRef = useRef(currentStepIndex);
 
-    // Sync execution state with context: init stepStates when runner opens
+    // Sync execution state with context: init stepStates when runner opens.
+    // Uses the atomic startRoutine(routine, variantId) so initialization does
+    // not depend on intermediate state flushing between two separate calls.
     useEffect(() => {
         if (isOpen && routine) {
-            selectRoutine(routine.id);
-            startRoutine(variantId);
+            startRoutine(routine, variantId);
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen, routine?.id, variantId]);
 
     const handleClose = () => {

--- a/src/store/RoutineContext.test.tsx
+++ b/src/store/RoutineContext.test.tsx
@@ -47,7 +47,7 @@ function TestConsumer({ onMount }: { onMount?: (store: ReturnType<typeof useRout
             <span data-testid="step-states">{JSON.stringify(store.stepStates)}</span>
             <span data-testid="execution-state">{store.executionState}</span>
             <button onClick={() => store.selectRoutine(mockRoutine.id)}>Select</button>
-            <button onClick={() => store.startRoutine()}>Start</button>
+            <button onClick={() => store.activeRoutine && store.startRoutine(store.activeRoutine)}>Start</button>
             <button onClick={() => store.setStepState('step-a', 'done')}>Mark A done</button>
             <button onClick={() => store.setStepState('step-b', 'skipped')}>Mark B skipped</button>
             <button onClick={() => store.exitRoutine()}>Exit</button>

--- a/src/store/RoutineContext.tsx
+++ b/src/store/RoutineContext.tsx
@@ -43,7 +43,7 @@ interface RoutineContextType {
     // Execution Actions
     selectRoutine: (routineId: string) => void;
     selectVariant: (variantId: string) => void;
-    startRoutine: (variantId?: string) => void;
+    startRoutine: (routine: Routine, variantId?: string) => void;
     exitRoutine: () => void;
     nextStep: () => void;
     prevStep: () => void;
@@ -187,37 +187,43 @@ export const RoutineProvider: React.FC<{ children: React.ReactNode }> = ({ child
         setActiveVariantId(variantId);
     };
 
-    const startRoutine = (variantId?: string) => {
-        if (activeRoutine) {
-            const effectiveVariantId = variantId || activeVariantId;
-            setActiveVariantId(effectiveVariantId);
-            setExecutionState('execute');
-            setCurrentStepIndex(0);
-            setStartedAt(new Date().toISOString());
+    // Atomically enter execute mode for the given routine. Accepts the routine
+    // directly so step-state initialization never reads a stale closure value
+    // (the prior implementation chained selectRoutine → startRoutine and relied
+    // on activeRoutine being set, which isn't flushed yet within the same
+    // effect — leaving stepStates uninitialized and executionState stuck at
+    // 'preview' even though the UI rendered the execute view).
+    const startRoutine = (routine: Routine, variantId?: string) => {
+        const effectiveVariantId = variantId || routine.defaultVariantId || routine.variants?.[0]?.id || null;
 
-            // Initialize step states from the resolved variant's steps
-            const steps = resolveSteps(activeRoutine, effectiveVariantId || undefined);
-            const initial: StepStates = {};
-            const initialTracking: Record<string, Record<string, string | number>> = {};
-            for (const step of steps) {
-                initial[step.id] = 'neutral';
-                // Pre-populate tracking fields with defaults
-                if (step.trackingFields?.length) {
-                    const fieldValues: Record<string, string | number> = {};
-                    for (const field of step.trackingFields) {
-                        if (field.defaultValue !== undefined) {
-                            fieldValues[field.id] = field.defaultValue;
-                        }
-                    }
-                    if (Object.keys(fieldValues).length > 0) {
-                        initialTracking[step.id] = fieldValues;
+        setActiveRoutine(routine);
+        setActiveVariantId(effectiveVariantId);
+        setExecutionState('execute');
+        setCurrentStepIndex(0);
+        setStartedAt(new Date().toISOString());
+
+        // Initialize step states from the resolved variant's steps
+        const steps = resolveSteps(routine, effectiveVariantId || undefined);
+        const initial: StepStates = {};
+        const initialTracking: Record<string, Record<string, string | number>> = {};
+        for (const step of steps) {
+            initial[step.id] = 'neutral';
+            // Pre-populate tracking fields with defaults
+            if (step.trackingFields?.length) {
+                const fieldValues: Record<string, string | number> = {};
+                for (const field of step.trackingFields) {
+                    if (field.defaultValue !== undefined) {
+                        fieldValues[field.id] = field.defaultValue;
                     }
                 }
+                if (Object.keys(fieldValues).length > 0) {
+                    initialTracking[step.id] = fieldValues;
+                }
             }
-            setStepStates(initial);
-            setStepTrackingData(initialTracking);
-            setStepTimingData({});
         }
+        setStepStates(initial);
+        setStepTrackingData(initialTracking);
+        setStepTimingData({});
     };
 
     const exitRoutine = () => {


### PR DESCRIPTION
The routine runner's mount effect was calling selectRoutine(id) then
startRoutine(variantId) back-to-back. startRoutine read activeRoutine
from closure — still null within the same effect tick — so its
if (activeRoutine) guard short-circuited and the function silently did
nothing. Result: executionState stayed at 'preview' while the UI rendered
the execute view, and stepStates / stepTrackingData / startedAt were
never initialized. That inconsistency is a plausible trigger for the
React error #300 reported when tapping the top-right close icon.

Refactor startRoutine to accept the routine object directly and perform
all execute-mode initialization atomically in one call, so initialization
no longer depends on intermediate state flushing. The runner now calls
startRoutine(routine, variantId) alone; selectRoutine is reserved for
the preview flow that still uses it.