### PR TITLE
Unify Today view and Dashboard Daily Habits ring via shared getTodayHabitStats helper

### DIFF
--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect } from 'react';
 import { useHabitStore } from '../../store/HabitContext';
-import { getHabitsForDate } from '../../utils/habitUtils';
+import { getTodayHabitStats } from '../../utils/habitUtils';
 import { evaluateChecklistSuccess } from '../../shared/checklistSuccessRule';
 import { PinnedHabitsStrip } from './PinnedHabitsStrip';
 import { DayCategorySection } from './DayCategorySection';
@@ -154,11 +154,13 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
         return new Map(dayViewData.habits.map(status => [status.habit.id, status]));
     }, [dayViewData]);
 
+    const todayHabitStats = useMemo(
+        () => getTodayHabitStats(habits, logs, dateStr),
+        [habits, logs, dateStr]
+    );
+
     // 1. Filter Habits for Today (Root level, frequency match)
-    const todaysHabits = useMemo(() => {
-        if (!habits) return [];
-        return getHabitsForDate(habits, dateStr);
-    }, [habits, dateStr]);
+    const todaysHabits = todayHabitStats.scheduledHabitsForToday;
 
     // Lookup Map for Bundle Resolution
     const allHabitsLookup = useMemo(() => {
@@ -197,15 +199,26 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
             }
         };
 
-        // Merge root habits
-        todaysHabits.forEach(mergeHabitLog);
-
-        // Merge sub-habits of bundles so DayCategorySection can look up their status
+        // Merge root habits + shared completion semantics
         todaysHabits.forEach(habit => {
             if (habit.type === 'bundle' && habit.subHabitIds) {
                 habit.subHabitIds.forEach(subId => {
                     const subHabit = allHabitsLookup.get(subId);
                     if (subHabit) mergeHabitLog(subHabit);
+                });
+            }
+
+            const existing = map.get(habit.id);
+            const isComplete = todayHabitStats.habitCompletionStates[habit.id] ?? false;
+            if (existing) {
+                map.set(habit.id, { ...existing, isComplete });
+            } else {
+                map.set(habit.id, {
+                    habit,
+                    isComplete,
+                    currentValue: 0,
+                    targetValue: 1,
+                    progressPercent: isComplete ? 100 : 0,
                 });
             }
         });
@@ -221,9 +234,11 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
                 });
 
                 const totalChildren = habit.subHabitIds.length;
-                const parentComplete = habit.bundleType === 'choice'
-                    ? completedChildren > 0
-                    : evaluateChecklistSuccess(completedChildren, totalChildren, habit.checklistSuccessRule).meetsSuccessRule;
+                const parentComplete = todayHabitStats.habitCompletionStates[habit.id] ?? (
+                    habit.bundleType === 'choice'
+                        ? completedChildren > 0
+                        : evaluateChecklistSuccess(completedChildren, totalChildren, habit.checklistSuccessRule).meetsSuccessRule
+                );
 
                 const existing = map.get(habit.id);
                 if (existing) {
@@ -238,7 +253,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
         });
 
         return map;
-    }, [habitStatusMap, logs, todaysHabits, dateStr, allHabitsLookup]);
+    }, [habitStatusMap, logs, todaysHabits, dateStr, allHabitsLookup, todayHabitStats.habitCompletionStates]);
 
     // 2. Identify Pinned Habits
     const pinnedHabits = useMemo(() => {

--- a/src/utils/habitRingProgress.test.ts
+++ b/src/utils/habitRingProgress.test.ts
@@ -13,6 +13,7 @@ import {
     getRootHabits,
     isHabitComplete,
     getDailyHabitRingProgress,
+    getTodayHabitStats,
     getBundleChildIds,
     computeBundleStatus,
     getHabitsForDate,
@@ -108,6 +109,30 @@ describe('Case A — standalone habits only', () => {
         ]);
         const result = getDailyHabitRingProgress(habits, logs, DATE);
         expect(result).toEqual({ completed: 2, total: 3 });
+    });
+
+    it('number habit completion uses value-to-target semantics (today and ring stay aligned)', () => {
+        const habits = [
+            makeHabit({
+                id: 'h-num',
+                name: 'Drink water',
+                goal: { type: 'number', frequency: 'daily', target: 8, unit: 'cups' },
+            }),
+        ];
+        const logs = Object.fromEntries([
+            makeLog('h-num', DATE, false, 8),
+        ]);
+        const result = getDailyHabitRingProgress(habits, logs, DATE);
+        expect(result).toEqual({ completed: 1, total: 1 });
+    });
+
+    it('checking/unchecking a today habit updates shared completedCount', () => {
+        const habits = [makeHabit({ id: 'h1', name: 'Meditate' })];
+        const checkedLogs = Object.fromEntries([makeLog('h1', DATE, true)]);
+        const uncheckedLogs = Object.fromEntries([makeLog('h1', DATE, false)]);
+
+        expect(getTodayHabitStats(habits, checkedLogs, DATE).completedCount).toBe(1);
+        expect(getTodayHabitStats(habits, uncheckedLogs, DATE).completedCount).toBe(0);
     });
 });
 
@@ -239,6 +264,28 @@ describe('Case E — bundle completion semantics', () => {
             ]);
             const result = getDailyHabitRingProgress(habits, logs, DATE);
             expect(result).toEqual({ completed: 1, total: 1 });
+        });
+
+        it('ring respects checklist threshold success rule', () => {
+            const thresholdBundle = makeHabit({
+                id: 'bundle-threshold',
+                name: 'Threshold Bundle',
+                type: 'bundle',
+                bundleType: 'checklist',
+                checklistSuccessRule: { type: 'threshold', threshold: 2 },
+                subHabitIds: ['t-child-1', 't-child-2', 't-child-3'],
+            });
+            const habitsWithChildren = [
+                thresholdBundle,
+                makeHabit({ id: 't-child-1', name: 'A', bundleParentId: 'bundle-threshold' }),
+                makeHabit({ id: 't-child-2', name: 'B', bundleParentId: 'bundle-threshold' }),
+                makeHabit({ id: 't-child-3', name: 'C', bundleParentId: 'bundle-threshold' }),
+            ];
+            const logs = Object.fromEntries([
+                makeLog('t-child-1', DATE, true),
+                makeLog('t-child-2', DATE, true),
+            ]);
+            expect(getDailyHabitRingProgress(habitsWithChildren, logs, DATE)).toEqual({ completed: 1, total: 1 });
         });
     });
 
@@ -403,6 +450,45 @@ describe('Edge cases', () => {
         // Saturday — only h2 counts toward the ring
         const result = getDailyHabitRingProgress(habits, {}, DATE);
         expect(result.total).toBe(1);
+    });
+
+    it('Tuesday-only habit is included Tuesday and excluded Wednesday', () => {
+        const tuesday = '2026-03-24';
+        const wednesday = '2026-03-25';
+        const habits = [
+            makeHabit({ id: 'h-tue', name: 'Tuesday only', assignedDays: [2] }),
+            makeHabit({ id: 'h-daily', name: 'Daily' }),
+        ];
+
+        const tueStats = getTodayHabitStats(habits, {}, tuesday);
+        const wedStats = getTodayHabitStats(habits, {}, wednesday);
+
+        expect(tueStats.scheduledHabitsForToday.map(h => h.id)).toContain('h-tue');
+        expect(wedStats.scheduledHabitsForToday.map(h => h.id)).not.toContain('h-tue');
+    });
+
+    it('scheduled checklist bundle is excluded on off-day (regression: prevented ring/today mismatch)', () => {
+        const bundle = makeHabit({
+            id: 'bundle-scheduled',
+            name: 'Tue Checklist',
+            type: 'bundle',
+            bundleType: 'checklist',
+            assignedDays: [2], // Tuesday only
+            subHabitIds: ['bundle-scheduled-child-1', 'bundle-scheduled-child-2'],
+        });
+        const child1 = makeHabit({ id: 'bundle-scheduled-child-1', name: 'A', bundleParentId: bundle.id });
+        const child2 = makeHabit({ id: 'bundle-scheduled-child-2', name: 'B', bundleParentId: bundle.id });
+        const habits = [bundle, child1, child2];
+        const logs = Object.fromEntries([
+            makeLog('bundle-scheduled-child-1', '2026-03-24', true),
+            makeLog('bundle-scheduled-child-2', '2026-03-24', true),
+        ]);
+
+        const tuesdayResult = getDailyHabitRingProgress(habits, logs, '2026-03-24');
+        const wednesdayResult = getDailyHabitRingProgress(habits, logs, '2026-03-25');
+
+        expect(tuesdayResult).toEqual({ completed: 1, total: 1 });
+        expect(wednesdayResult).toEqual({ completed: 0, total: 0 });
     });
 
     it('child with bundleParentId excluded even if parent subHabitIds is missing', () => {

--- a/src/utils/habitUtils.ts
+++ b/src/utils/habitUtils.ts
@@ -278,7 +278,93 @@ export function isHabitComplete(
     if (habit.type === 'bundle' && habit.subHabitIds && habit.subHabitIds.length > 0) {
         return computeBundleStatus(habit, logs, date).completed;
     }
-    return !!logs[`${habit.id}-${date}`]?.completed;
+
+    const log = logs[`${habit.id}-${date}`];
+    if (!log) return false;
+
+    if (habit.goal?.type === 'number') {
+        const currentValue = log.value ?? 0;
+        const targetValue = habit.goal?.target;
+        return typeof targetValue === 'number' && targetValue > 0
+            ? currentValue >= targetValue
+            : currentValue > 0;
+    }
+
+    // For boolean habits, prefer explicit completion; fallback to value > 0 for legacy entries.
+    if (typeof log.completed === 'boolean') {
+        return log.completed;
+    }
+    return (log.value ?? 0) > 0;
+}
+
+export interface TodayHabitStats {
+    scheduledHabitsForToday: Habit[];
+    completedCount: number;
+    totalCount: number;
+    completionPercentage: number;
+    habitCompletionStates: Record<string, boolean>;
+}
+
+/**
+ * Shared source of truth for "today habits" statistics used by both Today View
+ * and the dashboard ring so they stay in lockstep for:
+ * - schedule filtering
+ * - bundle parent/child semantics
+ * - numeric vs boolean completion semantics
+ */
+export function getTodayHabitStats(
+    habits: Habit[],
+    logs: Record<string, DayLog>,
+    date: string
+): TodayHabitStats {
+    const scheduledHabitsForToday = getHabitsForDate(habits, date);
+    const habitLookup = new Map(habits.map(h => [h.id, h]));
+    const completionStates = new Map<string, boolean>();
+
+    const computeComplete = (habit: Habit): boolean => {
+        const cached = completionStates.get(habit.id);
+        if (cached !== undefined) return cached;
+
+        let isComplete = false;
+
+        if (habit.type === 'bundle' && habit.subHabitIds && habit.subHabitIds.length > 0) {
+            const childCompletions = habit.subHabitIds.map((childId) => {
+                const childHabit = habitLookup.get(childId);
+                if (!childHabit) return false;
+                return computeComplete(childHabit);
+            });
+
+            if (habit.bundleType === 'choice') {
+                isComplete = childCompletions.some(Boolean);
+            } else {
+                const completedChildren = childCompletions.filter(Boolean).length;
+                isComplete = evaluateChecklistSuccess(
+                    completedChildren,
+                    habit.subHabitIds.length,
+                    habit.checklistSuccessRule
+                ).meetsSuccessRule;
+            }
+        } else {
+            isComplete = isHabitComplete(habit, logs, date);
+        }
+
+        completionStates.set(habit.id, isComplete);
+        return isComplete;
+    };
+
+    const completedCount = scheduledHabitsForToday.reduce((acc, habit) => (
+        computeComplete(habit) ? acc + 1 : acc
+    ), 0);
+    const totalCount = scheduledHabitsForToday.length;
+    const completionPercentage = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+
+    return {
+        scheduledHabitsForToday,
+        completedCount,
+        totalCount,
+        completionPercentage,
+        habitCompletionStates: Object.fromEntries(completionStates.entries()),
+    };
 }
 
 /**
@@ -294,9 +380,8 @@ export function getDailyHabitRingProgress(
     logs: Record<string, DayLog>,
     date: string
 ): { completed: number; total: number } {
-    const trackable = getHabitsForDate(habits, date);
-    const completed = trackable.filter(h => isHabitComplete(h, logs, date)).length;
-    return { completed, total: trackable.length };
+    const stats = getTodayHabitStats(habits, logs, date);
+    return { completed: stats.completedCount, total: stats.totalCount };
 }
 
 export function getHabitsForDate(


### PR DESCRIPTION
### Motivation
- The Dashboard ring and Today view were using slightly different completion and scheduling logic which caused mismatched completed counts for daily habits (notably numeric goals and bundle semantics). 
- The change funnels both surfaces to a single shared derived calculation so the ring always reflects the same source-of-truth used by Today.

### Description
- Added a shared helper `getTodayHabitStats(habits, logs, date)` in `src/utils/habitUtils.ts` that returns `scheduledHabitsForToday`, `completedCount`, `totalCount`, `completionPercentage`, and `habitCompletionStates` and implements bundle + numeric completion semantics. 
- Improved `isHabitComplete` to respect numeric habit semantics (`value >= target` or `value > 0` fallback) and boolean `completed` semantics for legacy entries. 
- Updated `getDailyHabitRingProgress` to delegate to `getTodayHabitStats` so the dashboard ring uses the same derived results as Today. 
- Refactored `DayView` (`src/components/day-view/DayView.tsx`) to consume `getTodayHabitStats` and merge the shared completion states into the existing day view status map, and updated `src/utils/habitRingProgress.test.ts` with scheduling/bundle/number-goal tests and a regression case for scheduled bundles.

### Testing
- Ran unit tests for the modified scope: `vitest run src/utils/habitRingProgress.test.ts` and `vitest run src/utils/habitAggregation.test.ts`, both succeeded (`34 tests` and `8 tests` respectively, all passing). 
- Existing checklist bundle semantics tests remain green and new tests exercise numeric completion, check/uncheck sync, assigned-day scheduling (Tuesday-only include/exclude), checklist threshold rules, and the scheduled-bundle regression case. 
- No UI snapshots or data-model migrations were introduced and the implementation preserves existing persisted data semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb70abe8c48321ad0d829afaad60ed)