### PR TITLE
Add iteratedFromGoalId backref on Goal so iteration chains are recoverable

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -51,8 +51,8 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Day-by-Day View** — Chronological list of individual contributions
 - **Goal Schedule View** — Calendar showing deadlines, forecasts, and milestones across all goals
 - **Achievement Badges** — Auto-generated badges for completed goals
-- **Win Archive** — Gallery of completed goals with badges
-- **Goal Extension** — Create a continuation goal with higher target after completion
+- **Achievements Gallery** — Three structured sections of completed goals: **Single** (one-time wins), **Progressive** (cumulative goals with their full iteration history rendered as connected milestone nodes — e.g. 25 → 50 → 100), and **Track** (per-track horizontal rows showing earned goal badges plus muted lock stubs for goals not yet earned). In-progress tracks appear here as soon as one goal in the track is earned.
+- **Goal Extension** — Create a continuation goal with higher target after completion. Extended goals carry an `iteratedFromGoalId` backref so the Achievements gallery can collapse the chain into a single Progressive card showing the full target history.
 - **Mark Complete** — Manually mark goals as achieved
 - **Goal Ordering** — Drag-and-drop reorder within category groups
 - **Inactivity Coaching** — Rule-based popup suggestions when a goal is stagnant

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -75,7 +75,7 @@ HabitFlow App
 │       │   ├── Category filter
 │       │   ├── Single-goal focus mode
 │       │   └── Date detail panel (cluster inspection)
-│       ├── Achievements — Completed goals gallery (was Win Archive)
+│       ├── Achievements — Three-section gallery: Single, Progressive (with iteration-history milestone nodes), Track (horizontal rows per track with locked stubs for not-yet-earned goals)
 │       ├── [+] Create Goal (→ multi-step flow)
 │       ├── Goal Detail Page (charts, entries, linked habits)
 │       ├── Edit Goal (→ modal)
@@ -111,7 +111,7 @@ HabitFlow App
 | Routines List | Page | Bottom tab "Routines" | Card list of all routines | Routines | Routine Editor, Runner, Preview |
 | Goals — All | Page | Bottom tab "Goals", "All" toggle | Collapsible category stacks with progress bars. "New Track" button in header bar next to "+" | Goals, Categories | Create Goal Flow, Goal Detail, Edit Goal Modal, Create Track Modal |
 | Goals — Schedule | Page | "Schedule" toggle on Goals | Insight calendar with deadlines, forecasts, milestones | Goals, Categories | Goal Detail, Focus Mode |
-| Goals — Achievements | Page | "Achievements" toggle on Goals (trophy icon) | Gallery of completed goals (was Win Archive) | Goals | Goal Detail |
+| Goals — Achievements | Page | "Achievements" toggle on Goals (trophy icon) | Three-section accomplishments gallery — Single (one-time wins), Progressive (cumulative goals with iteration-chain milestone nodes), Track (horizontal per-track rows with locked stubs for not-yet-earned goals). Section-local "View all" expands long Single/Progressive lists | Goals, Goal Tracks | Goal Detail, Goal Track Detail |
 | Goal Detail | Page | Click goal card / pinned goal | Charts, entries, linked habits (plus a "Removed habits still contributing" list when the goal has orphan contributions from deleted habits) for one goal | Goals, Habits, Entries | Edit Goal Modal, Goal Completed |
 | Goal Completed | Page | Auto-shown on 100% or manual | Celebratory screen with next actions | Goals | Achievements, Goal Detail, Level Up |
 | Goal Track Detail | Page | Click track in Goals page | Track name, ordered goals with states, reorder, add/remove goals | Goal Tracks, Goals | Goal Detail, Goals List |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -489,6 +489,9 @@ const HabitTrackerContent: React.FC = () => {
             onViewGoal={(goalId) => {
               handleNavigate('goals', { goalId });
             }}
+            onViewTrack={(trackId) => {
+              handleNavigate('goals', { trackId });
+            }}
           />
         ) : selectedGoalId ? (
           <GoalDetailPage
@@ -615,6 +618,9 @@ const HabitTrackerContent: React.FC = () => {
           <WinArchivePage
             onViewGoal={(goalId) => {
               handleNavigate('goals', { goalId });
+            }}
+            onViewTrack={(trackId) => {
+              handleNavigate('goals', { trackId });
             }}
           />
         ) : (

--- a/src/components/goals/achievements/AchievementSectionHeader.tsx
+++ b/src/components/goals/achievements/AchievementSectionHeader.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ChevronRight, type LucideIcon } from 'lucide-react';
+
+interface AchievementSectionHeaderProps {
+    icon: LucideIcon;
+    title: string;
+    description: string;
+    /** Tailwind text color class for the icon (e.g. 'text-emerald-400'). */
+    iconColor?: string;
+    /** Tailwind background tint class for the icon tile (e.g. 'bg-emerald-500/10'). */
+    iconBg?: string;
+    showViewAll?: boolean;
+    onViewAll?: () => void;
+    viewAllLabel?: string;
+}
+
+export const AchievementSectionHeader: React.FC<AchievementSectionHeaderProps> = ({
+    icon: Icon,
+    title,
+    description,
+    iconColor = 'text-emerald-400',
+    iconBg = 'bg-emerald-500/10',
+    showViewAll,
+    onViewAll,
+    viewAllLabel = 'View all',
+}) => {
+    return (
+        <div className="flex items-start justify-between gap-3 mb-3 sm:mb-4">
+            <div className="flex items-start gap-3 min-w-0">
+                <div className={`flex-shrink-0 w-10 h-10 rounded-full ${iconBg} flex items-center justify-center border border-white/[0.06]`}>
+                    <Icon size={18} className={iconColor} />
+                </div>
+                <div className="min-w-0">
+                    <h2 className="text-base sm:text-lg font-semibold text-white leading-tight">{title}</h2>
+                    <p className="text-xs sm:text-sm text-neutral-400 leading-tight mt-0.5">{description}</p>
+                </div>
+            </div>
+            {showViewAll && (
+                <button
+                    onClick={onViewAll}
+                    className="flex-shrink-0 flex items-center gap-1 text-xs sm:text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 rounded px-1"
+                >
+                    {viewAllLabel}
+                    <ChevronRight size={14} />
+                </button>
+            )}
+        </div>
+    );
+};

--- a/src/components/goals/achievements/MilestoneNodes.tsx
+++ b/src/components/goals/achievements/MilestoneNodes.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface MilestoneNodesProps {
+    /** Each entry is one node label (e.g. [25, 50, 100]). All nodes are rendered as completed. */
+    targets: number[];
+}
+
+export const MilestoneNodes: React.FC<MilestoneNodesProps> = ({ targets }) => {
+    if (targets.length === 0) return null;
+
+    return (
+        <div className="flex items-center w-full" role="list" aria-label="Milestone targets">
+            {targets.map((value, idx) => {
+                const isLast = idx === targets.length - 1;
+                return (
+                    <React.Fragment key={`${idx}-${value}`}>
+                        <div
+                            role="listitem"
+                            className="flex-shrink-0 w-7 h-7 rounded-full bg-emerald-500/15 border-2 border-emerald-500 text-emerald-400 text-[10px] font-semibold flex items-center justify-center"
+                        >
+                            {value}
+                        </div>
+                        {!isLast && <div className="flex-1 h-px bg-emerald-500/40 mx-1" aria-hidden />}
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+};

--- a/src/components/goals/achievements/ProgressiveAchievementCard.tsx
+++ b/src/components/goals/achievements/ProgressiveAchievementCard.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import { CelebratoryBadgeIcon } from '../CelebratoryBadgeIcon';
+import { MilestoneNodes } from './MilestoneNodes';
+import type { IterationChain } from '../../../utils/goalIterationChains';
+
+interface ProgressiveAchievementCardProps {
+    chain: IterationChain;
+    onClick?: (goalId: string) => void;
+    animationDelayMs?: number;
+}
+
+function formatCompletedDate(completedAt: string): string {
+    try {
+        return format(parseISO(completedAt), 'MMM yyyy');
+    } catch {
+        return completedAt;
+    }
+}
+
+export const ProgressiveAchievementCard: React.FC<ProgressiveAchievementCardProps> = ({
+    chain,
+    onClick,
+    animationDelayMs,
+}) => {
+    const { head, targets } = chain;
+    const milestoneLabel = head.targetValue
+        ? `Milestone: ${head.targetValue}${head.unit ? ` ${head.unit}` : ''}`
+        : 'Milestone reached';
+
+    return (
+        <button
+            onClick={() => onClick?.(head.id)}
+            className="group bg-neutral-800/40 border border-white/[0.06] rounded-xl p-3 sm:p-4 text-left hover:border-emerald-500/40 hover:bg-neutral-800/70 transition-all duration-200 win-card-animate focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 w-full"
+            style={animationDelayMs !== undefined ? {
+                animationDelay: `${animationDelayMs}ms`,
+                animationFillMode: 'both',
+            } : undefined}
+        >
+            <div className="flex items-start gap-3 mb-3">
+                <div className="flex-shrink-0">
+                    <CelebratoryBadgeIcon
+                        goalId={head.id}
+                        badgeImageUrl={head.badgeImageUrl}
+                        size={36}
+                        className="group-hover:scale-105 transition-transform duration-300"
+                    />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-semibold text-neutral-100 line-clamp-1 leading-tight group-hover:text-emerald-400 transition-colors">
+                        {head.title}
+                    </h3>
+                    <p className="text-[11px] sm:text-xs text-neutral-400 mt-0.5 line-clamp-1">
+                        {milestoneLabel}
+                    </p>
+                </div>
+            </div>
+            <div className="px-1 sm:px-2">
+                <MilestoneNodes targets={targets} />
+            </div>
+            {head.completedAt && (
+                <div className="flex items-center justify-end gap-1 mt-3 text-neutral-500 text-[10px] sm:text-xs">
+                    <Calendar size={10} />
+                    <span>Completed {formatCompletedDate(head.completedAt)}</span>
+                </div>
+            )}
+        </button>
+    );
+};

--- a/src/components/goals/achievements/SingleAchievementCard.tsx
+++ b/src/components/goals/achievements/SingleAchievementCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import type { Goal } from '../../../types';
+import { CelebratoryBadgeIcon } from '../CelebratoryBadgeIcon';
+
+interface SingleAchievementCardProps {
+    goal: Goal;
+    onClick?: (goalId: string) => void;
+    animationDelayMs?: number;
+}
+
+function formatCompletedDate(completedAt: string): string {
+    try {
+        return format(parseISO(completedAt), 'MMM yyyy');
+    } catch {
+        return completedAt;
+    }
+}
+
+export const SingleAchievementCard: React.FC<SingleAchievementCardProps> = ({
+    goal,
+    onClick,
+    animationDelayMs,
+}) => {
+    return (
+        <button
+            onClick={() => onClick?.(goal.id)}
+            className="group relative bg-neutral-800/40 border border-white/[0.06] rounded-xl overflow-hidden hover:border-emerald-500/40 hover:bg-neutral-800/70 transition-all duration-200 text-left win-card-animate focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+            style={animationDelayMs !== undefined ? {
+                animationDelay: `${animationDelayMs}ms`,
+                animationFillMode: 'both',
+            } : undefined}
+        >
+            <div className="relative aspect-square w-full bg-neutral-900/60 overflow-hidden p-4">
+                <CelebratoryBadgeIcon
+                    goalId={goal.id}
+                    badgeImageUrl={goal.badgeImageUrl}
+                    size={44}
+                    className="group-hover:scale-105 transition-transform duration-300"
+                />
+            </div>
+            <div className="px-2.5 py-2">
+                <h3 className="text-xs sm:text-sm font-medium text-neutral-200 line-clamp-2 leading-tight group-hover:text-emerald-400 transition-colors duration-200">
+                    {goal.title}
+                </h3>
+                {goal.completedAt && (
+                    <div className="flex items-center gap-1 mt-1 text-neutral-500 text-[10px] sm:text-xs">
+                        <Calendar size={10} />
+                        <span>{formatCompletedDate(goal.completedAt)}</span>
+                    </div>
+                )}
+            </div>
+        </button>
+    );
+};

--- a/src/components/goals/achievements/TrackAchievementRow.tsx
+++ b/src/components/goals/achievements/TrackAchievementRow.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Calendar, Flag, Lock } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import type { Goal, GoalTrack } from '../../../types';
+import { CelebratoryBadgeIcon } from '../CelebratoryBadgeIcon';
+
+interface TrackAchievementRowProps {
+    track: GoalTrack;
+    goals: Goal[];
+    onViewGoal?: (goalId: string) => void;
+    onViewTrack?: (trackId: string) => void;
+}
+
+function formatCompletedDate(completedAt: string): string {
+    try {
+        return format(parseISO(completedAt), 'MMM yyyy');
+    } catch {
+        return completedAt;
+    }
+}
+
+export const TrackAchievementRow: React.FC<TrackAchievementRowProps> = ({
+    track,
+    goals,
+    onViewGoal,
+    onViewTrack,
+}) => {
+    const ordered = [...goals].sort((a, b) => (a.trackOrder ?? 0) - (b.trackOrder ?? 0));
+    const completedCount = ordered.filter(g => g.completedAt).length;
+    const totalCount = ordered.length;
+    const fullyComplete = completedCount === totalCount && totalCount > 0;
+
+    const summaryAccent = fullyComplete
+        ? 'border-emerald-500/40 bg-emerald-500/5'
+        : 'border-amber-500/30 bg-amber-500/5';
+    const summaryText = fullyComplete ? 'text-emerald-400' : 'text-amber-400';
+
+    return (
+        <div className="mb-4">
+            <div className="flex gap-2 sm:gap-3 overflow-x-auto pb-2 -mx-4 px-4 sm:-mx-0 sm:px-0">
+                <button
+                    onClick={() => onViewTrack?.(track.id)}
+                    className={`flex-shrink-0 w-32 sm:w-36 rounded-xl border ${summaryAccent} p-3 text-left transition-all hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50`}
+                >
+                    <Flag size={18} className={`${summaryText} mb-2`} />
+                    <h3 className="text-sm font-semibold text-white line-clamp-2 leading-tight">{track.name}</h3>
+                    <p className={`mt-2 text-[11px] font-medium ${summaryText}`}>
+                        {completedCount} of {totalCount} Completed
+                    </p>
+                </button>
+                {ordered.map((goal) => {
+                    const isCompleted = !!goal.completedAt;
+                    if (isCompleted) {
+                        return (
+                            <button
+                                key={goal.id}
+                                onClick={() => onViewGoal?.(goal.id)}
+                                className="group flex-shrink-0 w-28 sm:w-32 bg-neutral-800/40 border border-white/[0.06] rounded-xl overflow-hidden hover:border-emerald-500/40 hover:bg-neutral-800/70 transition-all duration-200 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+                            >
+                                <div className="relative aspect-square w-full bg-neutral-900/60 overflow-hidden p-3">
+                                    <CelebratoryBadgeIcon
+                                        goalId={goal.id}
+                                        badgeImageUrl={goal.badgeImageUrl}
+                                        size={36}
+                                        className="group-hover:scale-105 transition-transform duration-300"
+                                    />
+                                </div>
+                                <div className="px-2 py-2">
+                                    <h4 className="text-[11px] sm:text-xs font-medium text-neutral-200 line-clamp-2 leading-tight group-hover:text-emerald-400 transition-colors">
+                                        {goal.title}
+                                    </h4>
+                                    {goal.completedAt && (
+                                        <div className="flex items-center gap-1 mt-1 text-neutral-500 text-[10px]">
+                                            <Calendar size={9} />
+                                            <span>{formatCompletedDate(goal.completedAt)}</span>
+                                        </div>
+                                    )}
+                                </div>
+                            </button>
+                        );
+                    }
+                    return (
+                        <div
+                            key={goal.id}
+                            className="flex-shrink-0 w-28 sm:w-32 bg-neutral-900/40 border border-white/[0.04] rounded-xl overflow-hidden opacity-60"
+                        >
+                            <div className="relative aspect-square w-full bg-neutral-900/60 overflow-hidden p-3 flex items-center justify-center">
+                                <Lock size={28} className="text-neutral-600" />
+                            </div>
+                            <div className="px-2 py-2">
+                                <h4 className="text-[11px] sm:text-xs font-medium text-neutral-500 line-clamp-2 leading-tight">
+                                    {goal.title}
+                                </h4>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -1084,6 +1084,13 @@ export interface Goal {
      * Undefined means the window is still open (goal is currently active).
      */
     activeWindowEnd?: string;
+
+    /**
+     * ID of the prior goal in an iteration chain. Set by the server when a
+     * cumulative goal is "extended" (iterated). Undefined for original goals
+     * and for goals iterated before this field existed (legacy data).
+     */
+    iteratedFromGoalId?: string;
 }
 
 /** Goals stored as an array */

--- a/src/pages/goals/WinArchivePage.tsx
+++ b/src/pages/goals/WinArchivePage.tsx
@@ -1,18 +1,66 @@
-import React from 'react';
-import { Trophy, Calendar } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Trophy, Star, TrendingUp, Flag, Loader2, AlertCircle } from 'lucide-react';
 import { useCompletedGoals } from '../../lib/useCompletedGoals';
-import { format, parseISO } from 'date-fns';
-import { Loader2, AlertCircle } from 'lucide-react';
-import { CelebratoryBadgeIcon } from '../../components/goals/CelebratoryBadgeIcon';
+import { useGoalTracks } from '../../lib/useGoalTracks';
+import { buildIterationChains } from '../../utils/goalIterationChains';
+import { AchievementSectionHeader } from '../../components/goals/achievements/AchievementSectionHeader';
+import { SingleAchievementCard } from '../../components/goals/achievements/SingleAchievementCard';
+import { ProgressiveAchievementCard } from '../../components/goals/achievements/ProgressiveAchievementCard';
+import { TrackAchievementRow } from '../../components/goals/achievements/TrackAchievementRow';
+import type { Goal } from '../../types';
 
 interface WinArchivePageProps {
     onViewGoal?: (goalId: string) => void;
+    onViewTrack?: (trackId: string) => void;
 }
 
-export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) => {
-    const { data, loading, error } = useCompletedGoals();
+const SINGLE_PREVIEW_LIMIT = 8;
+const PROGRESSIVE_PREVIEW_LIMIT = 4;
 
-    if (loading) {
+export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onViewTrack }) => {
+    const { data: completedGoals, loading: completedLoading, error: completedError } = useCompletedGoals();
+    const { data: tracks, loading: tracksLoading } = useGoalTracks();
+
+    const [singleExpanded, setSingleExpanded] = useState(false);
+    const [progressiveExpanded, setProgressiveExpanded] = useState(false);
+
+    const { singleGoals, progressiveChains, trackRows } = useMemo(() => {
+        const goals = completedGoals ?? [];
+        const single = goals
+            .filter(g => g.completedAt && !g.trackId && g.type === 'onetime')
+            .sort((a, b) => (b.completedAt ?? '').localeCompare(a.completedAt ?? ''));
+
+        const progressiveCandidates = goals.filter(g => g.completedAt && !g.trackId && g.type === 'cumulative');
+        const progressive = buildIterationChains(progressiveCandidates);
+
+        const trackedGoalsByTrackId = new Map<string, Goal[]>();
+        for (const g of goals) {
+            if (!g.trackId) continue;
+            const list = trackedGoalsByTrackId.get(g.trackId) ?? [];
+            list.push(g);
+            trackedGoalsByTrackId.set(g.trackId, list);
+        }
+
+        const rows = (tracks ?? [])
+            .map(track => {
+                const earned = trackedGoalsByTrackId.get(track.id) ?? [];
+                if (earned.length === 0) return null;
+                return { track, goals: earned };
+            })
+            .filter((r): r is { track: typeof tracks[number]; goals: Goal[] } => r !== null)
+            .sort((a, b) => {
+                const at = a.track.completedAt ?? a.track.updatedAt ?? '';
+                const bt = b.track.completedAt ?? b.track.updatedAt ?? '';
+                return bt.localeCompare(at);
+            });
+
+        return { singleGoals: single, progressiveChains: progressive, trackRows: rows };
+    }, [completedGoals, tracks]);
+
+    const loading = completedLoading || tracksLoading;
+    const hasAnyAchievements = singleGoals.length > 0 || progressiveChains.length > 0 || trackRows.length > 0;
+
+    if (loading && !completedGoals) {
         return (
             <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
                 <div className="flex flex-col items-center gap-4">
@@ -23,110 +71,132 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal }) =>
         );
     }
 
-    if (error) {
+    if (completedError) {
         return (
             <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
                 <div className="mb-6 sm:mb-8">
-                    <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">Win Archive</h1>
-                    <p className="text-neutral-400 text-sm sm:text-base">
-                        Every goal you've completed becomes a badge of who you are becoming.
-                    </p>
+                    <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">Achievements</h1>
+                    <p className="text-neutral-400 text-sm sm:text-base">A gallery of your accomplishments.</p>
                 </div>
                 <div className="p-4 bg-red-500/10 border border-red-500/50 rounded-lg flex items-start gap-3">
                     <AlertCircle className="text-red-400 flex-shrink-0 mt-0.5" size={20} />
                     <div className="flex-1">
                         <div className="text-red-400 font-medium mb-1">Error</div>
-                        <div className="text-red-300 text-sm">{error.message}</div>
+                        <div className="text-red-300 text-sm">{completedError.message}</div>
                     </div>
                 </div>
             </div>
         );
     }
 
-    const formatCompletedDate = (completedAt: string): string => {
-        try {
-            return format(parseISO(completedAt), 'MMM yyyy');
-        } catch {
-            return completedAt;
-        }
-    };
+    const visibleSingles = singleExpanded ? singleGoals : singleGoals.slice(0, SINGLE_PREVIEW_LIMIT);
+    const visibleProgressives = progressiveExpanded ? progressiveChains : progressiveChains.slice(0, PROGRESSIVE_PREVIEW_LIMIT);
 
     return (
         <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-            {/* Header */}
             <div className="mb-6 sm:mb-8">
-                <h1 className="text-2xl sm:text-3xl font-bold text-white mb-1">Win Archive</h1>
-                <p className="text-sm sm:text-base text-neutral-400">
-                    Every completed goal becomes a badge of who you are becoming.
-                </p>
+                <h1 className="text-2xl sm:text-3xl font-bold text-white mb-1">Achievements</h1>
+                <p className="text-sm sm:text-base text-neutral-400">A gallery of your accomplishments.</p>
             </div>
 
-            {/* Empty State */}
-            {!data || data.length === 0 ? (
+            {!hasAnyAchievements ? (
                 <div className="text-center py-16 sm:py-20">
                     <div className="max-w-md mx-auto">
                         <div className="w-16 h-16 mx-auto bg-neutral-800 rounded-full flex items-center justify-center mb-4">
                             <Trophy className="text-amber-400/50" size={32} />
                         </div>
-                        <h2 className="text-lg font-semibold text-white mb-2">Your Win Archive Awaits</h2>
-                        <p className="text-neutral-400 text-sm mb-1">
-                            Every completed goal becomes a badge of achievement here.
-                        </p>
-                        <p className="text-neutral-500 text-xs">
-                            Complete your first goal to see it celebrated in your archive!
-                        </p>
+                        <h2 className="text-lg font-semibold text-white mb-2">Your gallery awaits</h2>
+                        <p className="text-neutral-400 text-sm mb-1">Every completed goal becomes a badge here.</p>
+                        <p className="text-neutral-500 text-xs">Complete your first goal to get started.</p>
                     </div>
                 </div>
             ) : (
-                /* Gallery Grid — compact cards */
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-4">
-                    {data.map((goal, index) => (
-                        <button
-                            key={goal.id}
-                            onClick={() => onViewGoal?.(goal.id)}
-                            className="group relative bg-neutral-800/40 border border-white/[0.06] rounded-xl overflow-hidden hover:border-emerald-500/40 hover:bg-neutral-800/70 transition-all duration-200 text-left win-card-animate focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
-                            style={{
-                                animationDelay: `${index * 40}ms`,
-                                animationFillMode: 'both',
-                            }}
-                        >
-                            {/* Badge icon area — square aspect */}
-                            <div className="relative aspect-square w-full bg-neutral-900/60 overflow-hidden p-4">
-                                <CelebratoryBadgeIcon
-                                    goalId={goal.id}
-                                    badgeImageUrl={goal.badgeImageUrl}
-                                    size={44}
-                                    className="group-hover:scale-105 transition-transform duration-300"
-                                />
+                <div className="space-y-8 sm:space-y-10">
+                    <section>
+                        <AchievementSectionHeader
+                            icon={Star}
+                            title="Single Achievements"
+                            description="One-time goals you've completed."
+                            iconColor="text-emerald-400"
+                            iconBg="bg-emerald-500/10"
+                            showViewAll={singleGoals.length > SINGLE_PREVIEW_LIMIT}
+                            onViewAll={() => setSingleExpanded(v => !v)}
+                            viewAllLabel={singleExpanded ? 'Show less' : 'View all'}
+                        />
+                        {singleGoals.length === 0 ? (
+                            <p className="text-xs sm:text-sm text-neutral-500 italic pl-1">Complete a one-time goal to see it here.</p>
+                        ) : (
+                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-4">
+                                {visibleSingles.map((goal, idx) => (
+                                    <SingleAchievementCard
+                                        key={goal.id}
+                                        goal={goal}
+                                        onClick={onViewGoal}
+                                        animationDelayMs={idx * 40}
+                                    />
+                                ))}
                             </div>
+                        )}
+                    </section>
 
-                            {/* Info — compact */}
-                            <div className="px-2.5 py-2">
-                                <h3 className="text-xs sm:text-sm font-medium text-neutral-200 line-clamp-2 leading-tight group-hover:text-emerald-400 transition-colors duration-200">
-                                    {goal.title}
-                                </h3>
-                                {goal.completedAt && (
-                                    <div className="flex items-center gap-1 mt-1 text-neutral-500 text-[10px] sm:text-xs">
-                                        <Calendar size={10} />
-                                        <span>{formatCompletedDate(goal.completedAt)}</span>
-                                    </div>
-                                )}
+                    <section>
+                        <AchievementSectionHeader
+                            icon={TrendingUp}
+                            title="Progressive Achievements"
+                            description="Goals with milestones or increasing targets."
+                            iconColor="text-purple-400"
+                            iconBg="bg-purple-500/10"
+                            showViewAll={progressiveChains.length > PROGRESSIVE_PREVIEW_LIMIT}
+                            onViewAll={() => setProgressiveExpanded(v => !v)}
+                            viewAllLabel={progressiveExpanded ? 'Show less' : 'View all'}
+                        />
+                        {progressiveChains.length === 0 ? (
+                            <p className="text-xs sm:text-sm text-neutral-500 italic pl-1">Complete a cumulative goal to see it here.</p>
+                        ) : (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+                                {visibleProgressives.map((chain, idx) => (
+                                    <ProgressiveAchievementCard
+                                        key={chain.head.id}
+                                        chain={chain}
+                                        onClick={onViewGoal}
+                                        animationDelayMs={idx * 40}
+                                    />
+                                ))}
                             </div>
-                        </button>
-                    ))}
+                        )}
+                    </section>
+
+                    <section>
+                        <AchievementSectionHeader
+                            icon={Flag}
+                            title="Track Achievements"
+                            description="Milestones earned as part of goal tracks."
+                            iconColor="text-cyan-400"
+                            iconBg="bg-cyan-500/10"
+                        />
+                        {trackRows.length === 0 ? (
+                            <p className="text-xs sm:text-sm text-neutral-500 italic pl-1">Complete a goal in a track to see it here.</p>
+                        ) : (
+                            <div>
+                                {trackRows.map(({ track, goals }) => (
+                                    <TrackAchievementRow
+                                        key={track.id}
+                                        track={track}
+                                        goals={goals}
+                                        onViewGoal={onViewGoal}
+                                        onViewTrack={onViewTrack}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </section>
                 </div>
             )}
 
             <style>{`
                 @keyframes win-card-enter {
-                    from {
-                        opacity: 0;
-                        transform: translateY(12px) scale(0.97);
-                    }
-                    to {
-                        opacity: 1;
-                        transform: translateY(0) scale(1);
-                    }
+                    from { opacity: 0; transform: translateY(12px) scale(0.97); }
+                    to { opacity: 1; transform: translateY(0) scale(1); }
                 }
                 .win-card-animate {
                     animation: win-card-enter 0.35s ease-out;

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -129,6 +129,10 @@ function validateGoalData(data: any): string | null {
     }
   }
 
+  if (data.iteratedFromGoalId !== undefined && typeof data.iteratedFromGoalId !== 'string') {
+    return 'iteratedFromGoalId must be a string if provided';
+  }
+
   return null;
 }
 
@@ -166,6 +170,7 @@ function buildIteratedGoalData(goal: Goal, currentValue: number | null): Omit<Go
     badgeImageUrl: undefined,
     categoryId: goal.categoryId,
     sortOrder: goal.sortOrder,
+    iteratedFromGoalId: goal.id,
   };
 }
 

--- a/src/utils/goalIterationChains.test.ts
+++ b/src/utils/goalIterationChains.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { buildIterationChains } from './goalIterationChains';
+import type { Goal } from '../models/persistenceTypes';
+
+function makeGoal(overrides: Partial<Goal> & { id: string }): Goal {
+    return {
+        title: 'Test Goal',
+        type: 'cumulative',
+        targetValue: 25,
+        linkedHabitIds: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-15T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('buildIterationChains', () => {
+    it('returns one single-entry chain for a goal with no predecessor or successor', () => {
+        const goals = [makeGoal({ id: 'a', targetValue: 50 })];
+        const chains = buildIterationChains(goals);
+        expect(chains).toHaveLength(1);
+        expect(chains[0].head.id).toBe('a');
+        expect(chains[0].targets).toEqual([50]);
+        expect(chains[0].goals.map(g => g.id)).toEqual(['a']);
+    });
+
+    it('collapses a 3-goal chain into a single entry headed by the latest', () => {
+        const goals = [
+            makeGoal({ id: 'g1', targetValue: 25, completedAt: '2026-01-01T00:00:00.000Z' }),
+            makeGoal({ id: 'g2', targetValue: 50, iteratedFromGoalId: 'g1', completedAt: '2026-02-01T00:00:00.000Z' }),
+            makeGoal({ id: 'g3', targetValue: 100, iteratedFromGoalId: 'g2', completedAt: '2026-03-01T00:00:00.000Z' }),
+        ];
+        const chains = buildIterationChains(goals);
+        expect(chains).toHaveLength(1);
+        expect(chains[0].head.id).toBe('g3');
+        expect(chains[0].targets).toEqual([25, 50, 100]);
+        expect(chains[0].goals.map(g => g.id)).toEqual(['g1', 'g2', 'g3']);
+    });
+
+    it('treats legacy iterated goals (no backref) as independent chains', () => {
+        const goals = [
+            makeGoal({ id: 'old1', targetValue: 25 }),
+            makeGoal({ id: 'old2', targetValue: 50 }),
+        ];
+        const chains = buildIterationChains(goals);
+        expect(chains).toHaveLength(2);
+        expect(chains.flatMap(c => c.goals).map(g => g.id).sort()).toEqual(['old1', 'old2']);
+    });
+
+    it('keeps multiple independent chains separate', () => {
+        const goals = [
+            makeGoal({ id: 'a1', targetValue: 10, completedAt: '2026-01-01T00:00:00.000Z' }),
+            makeGoal({ id: 'a2', targetValue: 20, iteratedFromGoalId: 'a1', completedAt: '2026-02-01T00:00:00.000Z' }),
+            makeGoal({ id: 'b1', targetValue: 5, completedAt: '2026-03-01T00:00:00.000Z' }),
+        ];
+        const chains = buildIterationChains(goals);
+        expect(chains).toHaveLength(2);
+        const aChain = chains.find(c => c.head.id === 'a2');
+        const bChain = chains.find(c => c.head.id === 'b1');
+        expect(aChain?.targets).toEqual([10, 20]);
+        expect(bChain?.targets).toEqual([5]);
+    });
+
+    it('orders chains by head completedAt desc', () => {
+        const goals = [
+            makeGoal({ id: 'old', completedAt: '2026-01-01T00:00:00.000Z' }),
+            makeGoal({ id: 'new', completedAt: '2026-06-01T00:00:00.000Z' }),
+            makeGoal({ id: 'mid', completedAt: '2026-03-01T00:00:00.000Z' }),
+        ];
+        const chains = buildIterationChains(goals);
+        expect(chains.map(c => c.head.id)).toEqual(['new', 'mid', 'old']);
+    });
+
+    it('treats a missing predecessor reference as the chain start (no crash)', () => {
+        const goals = [
+            makeGoal({ id: 'orphan', targetValue: 75, iteratedFromGoalId: 'missing-id' }),
+        ];
+        const chains = buildIterationChains(goals);
+        expect(chains).toHaveLength(1);
+        expect(chains[0].targets).toEqual([75]);
+    });
+
+    it('does not infinite-loop on accidental cycles, and never repeats a goal within a chain', () => {
+        const goals = [
+            makeGoal({ id: 'x', iteratedFromGoalId: 'y' }),
+            makeGoal({ id: 'y', iteratedFromGoalId: 'x' }),
+        ];
+        const chains = buildIterationChains(goals);
+        for (const c of chains) {
+            const ids = new Set(c.goals.map(g => g.id));
+            expect(ids.size).toBe(c.goals.length);
+        }
+    });
+
+    it('uses 0 as the target when targetValue is undefined', () => {
+        const goals = [makeGoal({ id: 'a', targetValue: undefined })];
+        const chains = buildIterationChains(goals);
+        expect(chains[0].targets).toEqual([0]);
+    });
+});

--- a/src/utils/goalIterationChains.ts
+++ b/src/utils/goalIterationChains.ts
@@ -44,7 +44,7 @@ export function buildIterationChains(goals: Goal[]): IterationChain[] {
         while (cursor && !seen.has(cursor.id)) {
             seen.add(cursor.id);
             ordered.unshift(cursor);
-            const prevId = cursor.iteratedFromGoalId;
+            const prevId: string | undefined = cursor.iteratedFromGoalId;
             cursor = prevId ? byId.get(prevId) : undefined;
         }
 

--- a/src/utils/goalIterationChains.ts
+++ b/src/utils/goalIterationChains.ts
@@ -1,0 +1,65 @@
+import type { Goal } from '../models/persistenceTypes';
+
+/**
+ * One iteration chain — a sequence of completed cumulative goals linked
+ * via `iteratedFromGoalId`. The `head` is the most recent (latest) goal
+ * in the chain; `goals` is ordered oldest -> newest; `targets` mirrors
+ * `goals` and pulls each goal's `targetValue` (0 when undefined).
+ */
+export interface IterationChain {
+    head: Goal;
+    goals: Goal[];
+    targets: number[];
+}
+
+/**
+ * Group completed cumulative goals into iteration chains.
+ *
+ * Goals linked via `iteratedFromGoalId` collapse into a single chain
+ * keyed by the chain head (the latest iteration — the one nothing else
+ * points to). Standalone goals and legacy iterated goals (no backref)
+ * become single-entry chains. Defensive against accidental cycles.
+ *
+ * Output is sorted by head `completedAt` desc so callers can render
+ * directly without re-sorting.
+ */
+export function buildIterationChains(goals: Goal[]): IterationChain[] {
+    const byId = new Map<string, Goal>();
+    for (const g of goals) byId.set(g.id, g);
+
+    const successors = new Set<string>();
+    for (const g of goals) {
+        if (g.iteratedFromGoalId && byId.has(g.iteratedFromGoalId)) {
+            successors.add(g.iteratedFromGoalId);
+        }
+    }
+
+    const chains: IterationChain[] = [];
+    for (const g of goals) {
+        if (successors.has(g.id)) continue;
+
+        const ordered: Goal[] = [];
+        const seen = new Set<string>();
+        let cursor: Goal | undefined = g;
+        while (cursor && !seen.has(cursor.id)) {
+            seen.add(cursor.id);
+            ordered.unshift(cursor);
+            const prevId = cursor.iteratedFromGoalId;
+            cursor = prevId ? byId.get(prevId) : undefined;
+        }
+
+        chains.push({
+            head: g,
+            goals: ordered,
+            targets: ordered.map(goal => (typeof goal.targetValue === 'number' ? goal.targetValue : 0)),
+        });
+    }
+
+    chains.sort((a, b) => {
+        const at = a.head.completedAt ?? '';
+        const bt = b.head.completedAt ?? '';
+        return bt.localeCompare(at);
+    });
+
+    return chains;
+}


### PR DESCRIPTION
Previously, iterating ("extending") a cumulative goal created a new Goal
record with no link back to the goal it replaced, making the extension
history unrecoverable at read time.

Add an optional iteratedFromGoalId field on Goal and have buildIteratedGoalData
populate it. The field is server-managed: the PUT handler ignores it (patch is
built from an explicit field list), and validateGoalData enforces a string
typecheck on POST as a defensive guard. Legacy iterated goals without the
field degrade gracefully — readers will treat them as standalone.

This enables the upcoming Progressive Achievements card to show the real
target history (e.g. 25 -> 50 -> 100) instead of synthetic fractions.

https://claude.ai/code/session_01D23v23FpnK648FYsHcyTmo