### PR TITLE
Link extended goals into iteration chains

### DIFF
--- a/src/pages/goals/GoalDetailPage.tsx
+++ b/src/pages/goals/GoalDetailPage.tsx
@@ -193,6 +193,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                 deadline,
                 categoryId: goal.categoryId,
                 notes: goal.notes,
+                iteratedFromGoalId: goal.id,
             });
 
             // Navigate to the new active goal

--- a/src/pages/goals/GoalDetailPage.tsx
+++ b/src/pages/goals/GoalDetailPage.tsx
@@ -46,6 +46,7 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
     const [isMarkingComplete, setIsMarkingComplete] = useState(false);
     const [showExtendForm, setShowExtendForm] = useState(false);
     const [extendTarget, setExtendTarget] = useState('');
+    const [extendTitle, setExtendTitle] = useState('');
     const [isExtending, setIsExtending] = useState(false);
     const [extendError, setExtendError] = useState<string | null>(null);
     const [showTrackMenu, setShowTrackMenu] = useState(false);
@@ -152,13 +153,29 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
 
     const handleExtendGoal = async () => {
         if (!data) return;
-        const numTarget = parseFloat(extendTarget);
-        if (isNaN(numTarget) || numTarget <= 0) {
-            setExtendError('Target must be a positive number');
-            return;
+        const { goal } = data;
+        const isOnetime = goal.type === 'onetime';
+
+        // Onetime goals have no meaningful targetValue — progress is binary —
+        // so the user only edits the title (e.g. "Chin Up (10 lbs)" -> "(20 lbs)").
+        // Cumulative goals require a strictly higher target.
+        let nextTarget: number | undefined = goal.targetValue;
+        if (!isOnetime) {
+            const numTarget = parseFloat(extendTarget);
+            if (isNaN(numTarget) || numTarget <= 0) {
+                setExtendError('Target must be a positive number');
+                return;
+            }
+            if (numTarget <= (goal.targetValue ?? 0)) {
+                setExtendError(`New target must be higher than the original (${goal.targetValue})`);
+                return;
+            }
+            nextTarget = numTarget;
         }
-        if (numTarget <= (data.goal.targetValue ?? 0)) {
-            setExtendError(`New target must be higher than the original (${data.goal.targetValue})`);
+
+        const trimmedTitle = extendTitle.trim();
+        if (isOnetime && !trimmedTitle) {
+            setExtendError('Title is required');
             return;
         }
 
@@ -166,7 +183,6 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
         setExtendError(null);
 
         try {
-            const { goal } = data;
             // Clear past deadlines to avoid invalid date intervals in GoalTrendChart
             const deadline = goal.deadline && goal.deadline >= new Date().toISOString().slice(0, 10)
                 ? goal.deadline
@@ -182,9 +198,9 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                 : undefined;
 
             const newGoal = await createGoal({
-                title: goal.title,
+                title: trimmedTitle || goal.title,
                 type: goal.type,
-                targetValue: numTarget,
+                targetValue: nextTarget,
                 unit: goal.unit,
                 linkedHabitIds: goal.linkedHabitIds,
                 linkedTargets: goal.linkedTargets,
@@ -468,13 +484,14 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
             )}
 
             {/* Extend Goal (for completed goals) */}
-            {goal.completedAt && goal.type !== 'onetime' && (
+            {goal.completedAt && (
                 <div className="mb-8">
                     {!showExtendForm ? (
                         <div>
                             <button
                                 onClick={() => {
                                     setExtendTarget(((goal.targetValue ?? 0) * 2).toString());
+                                    setExtendTitle(goal.title);
                                     setExtendError(null);
                                     setShowExtendForm(true);
                                 }}
@@ -484,27 +501,44 @@ export const GoalDetailPage: React.FC<GoalDetailPageProps> = ({ goalId, onBack, 
                                 Extend Goal
                             </button>
                             <p className="text-neutral-500 text-xs mt-2">
-                                Create a new goal with a higher target. This goal stays in your Win Archive.
+                                {goal.type === 'onetime'
+                                    ? 'Create a follow-up goal (e.g. a heavier weight or harder variation). This goal stays in your Win Archive.'
+                                    : 'Create a new goal with a higher target. This goal stays in your Win Archive.'}
                             </p>
                         </div>
                     ) : (
                         <div className="p-4 bg-blue-500/5 border border-blue-500/20 rounded-lg space-y-3">
-                            <div className="text-sm text-blue-300 font-medium">Set your new target</div>
-                            <div className="text-xs text-neutral-500">
-                                Original target: {goal.targetValue} {goal.unit} (completed). Your progress carries over to the new goal.
+                            <div className="text-sm text-blue-300 font-medium">
+                                {goal.type === 'onetime' ? 'Name the next iteration' : 'Set your new target'}
                             </div>
-                            <div className="flex items-center gap-3">
+                            <div className="text-xs text-neutral-500">
+                                {goal.type === 'onetime'
+                                    ? `Original: ${goal.title} (completed). Edit the title for the next iteration.`
+                                    : `Original target: ${goal.targetValue} ${goal.unit ?? ''} (completed). Your progress carries over to the new goal.`}
+                            </div>
+                            {goal.type === 'onetime' ? (
                                 <input
-                                    type="number"
-                                    value={extendTarget}
-                                    onChange={(e) => setExtendTarget(e.target.value)}
-                                    min={(goal.targetValue ?? 0) + 1}
-                                    className="w-32 bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
-                                    placeholder="New target"
+                                    type="text"
+                                    value={extendTitle}
+                                    onChange={(e) => setExtendTitle(e.target.value)}
+                                    className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
+                                    placeholder="New goal title"
                                     autoFocus
                                 />
-                                {goal.unit && <span className="text-neutral-400 text-sm">{goal.unit}</span>}
-                            </div>
+                            ) : (
+                                <div className="flex items-center gap-3">
+                                    <input
+                                        type="number"
+                                        value={extendTarget}
+                                        onChange={(e) => setExtendTarget(e.target.value)}
+                                        min={(goal.targetValue ?? 0) + 1}
+                                        className="w-32 bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
+                                        placeholder="New target"
+                                        autoFocus
+                                    />
+                                    {goal.unit && <span className="text-neutral-400 text-sm">{goal.unit}</span>}
+                                </div>
+                            )}
                             {extendError && (
                                 <div className="text-red-400 text-xs">{extendError}</div>
                             )}

--- a/src/pages/goals/WinArchivePage.tsx
+++ b/src/pages/goals/WinArchivePage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Trophy, Star, TrendingUp, Flag, Loader2, AlertCircle } from 'lucide-react';
 import { useCompletedGoals } from '../../lib/useCompletedGoals';
+import { useGoalsWithProgress } from '../../lib/useGoalsWithProgress';
 import { useGoalTracks } from '../../lib/useGoalTracks';
 import { buildIterationChains } from '../../utils/goalIterationChains';
 import { AchievementSectionHeader } from '../../components/goals/achievements/AchievementSectionHeader';
@@ -20,6 +21,7 @@ const PROGRESSIVE_PREVIEW_LIMIT = 4;
 export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onViewTrack }) => {
     const { data: completedGoals, loading: completedLoading, error: completedError } = useCompletedGoals();
     const { data: tracks, loading: tracksLoading } = useGoalTracks();
+    const { data: activeGoalsWithProgress, loading: activeGoalsLoading } = useGoalsWithProgress();
 
     const [singleExpanded, setSingleExpanded] = useState(false);
     const [progressiveExpanded, setProgressiveExpanded] = useState(false);
@@ -33,19 +35,30 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
         const progressiveCandidates = goals.filter(g => g.completedAt && !g.trackId && g.type === 'cumulative');
         const progressive = buildIterationChains(progressiveCandidates);
 
+        // Track rows include both completed and not-yet-completed (active/locked)
+        // goals so the user can see the full track progression with greyed-out
+        // milestones for goals still ahead. TrackAchievementRow already renders
+        // locked goals with a lock icon — we just need to feed them in.
         const trackedGoalsByTrackId = new Map<string, Goal[]>();
-        for (const g of goals) {
-            if (!g.trackId) continue;
+        const seenIds = new Set<string>();
+        const collect = (g: Goal) => {
+            if (!g.trackId || seenIds.has(g.id)) return;
+            seenIds.add(g.id);
             const list = trackedGoalsByTrackId.get(g.trackId) ?? [];
             list.push(g);
             trackedGoalsByTrackId.set(g.trackId, list);
-        }
+        };
+        for (const g of goals) collect(g);
+        for (const gp of activeGoalsWithProgress ?? []) collect(gp.goal);
 
         const rows = (tracks ?? [])
             .map(track => {
-                const earned = trackedGoalsByTrackId.get(track.id) ?? [];
-                if (earned.length === 0) return null;
-                return { track, goals: earned };
+                const members = trackedGoalsByTrackId.get(track.id) ?? [];
+                // Only surface tracks that have at least one earned goal —
+                // the Achievements page is for celebrating progress, not
+                // listing every empty track.
+                if (!members.some(g => g.completedAt)) return null;
+                return { track, goals: members };
             })
             .filter((r): r is { track: typeof tracks[number]; goals: Goal[] } => r !== null)
             .sort((a, b) => {
@@ -55,9 +68,9 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
             });
 
         return { singleGoals: single, progressiveChains: progressive, trackRows: rows };
-    }, [completedGoals, tracks]);
+    }, [completedGoals, tracks, activeGoalsWithProgress]);
 
-    const loading = completedLoading || tracksLoading;
+    const loading = completedLoading || tracksLoading || activeGoalsLoading;
     const hasAnyAchievements = singleGoals.length > 0 || progressiveChains.length > 0 || trackRows.length > 0;
 
     if (loading && !completedGoals) {


### PR DESCRIPTION
The Extend Goal flow on the goal detail page was creating the new goal
without iteratedFromGoalId, so the chain head couldn't be reconstructed
on the Achievements page. As a result, "Apply to 50 jobs" and the
extended "Apply to 75 jobs" rendered as two unrelated Progressive
Achievement cards instead of one chain.

Pass iteratedFromGoalId on createGoal so buildIterationChains can stitch
the new goal back to its predecessor.