### PR TITLE
Add archive/unarchive API for habits

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -19,8 +19,8 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Bundle Membership Management** — Move habits into/out of bundles; end or archive memberships
 - **Habit-Goal Linking** — Link habits to goals so completions count as goal progress. A single habit can be linked to multiple goals simultaneously (e.g., one "study session" habit contributing to a sequence of exam goals in a track).
 - **Habit-Routine Linking** — Link habits to routine steps so routine completion auto-logs habits
-- **Archiving** — Archive habits instead of deleting; soft-delete pattern
-- **Deletion with Goal Warning** — Deleting a habit linked to one or more goals surfaces a confirmation modal listing the affected goals. Historical progress on those goals is preserved — past entries continue to count — but the habit is removed from the goal's linked-habits list and can no longer be logged. Deletion is soft: the habit's name/unit is retained so orphaned historical entries can still render with their original label on goal detail pages
+- **Archiving** — Archive a habit to hide it from active tracking while preserving the habit definition and all entries. The trash icon archives by default (click twice to confirm). Restored from **Settings → View archived habits** with one click; restoration brings the habit back to its original category with full entry history intact
+- **Remove Habit Modal (goal-linked habits)** — Removing a habit linked to one or more goals opens a chooser listing affected goals and offering two paths: **Archive** (recommended, restorable) or **Delete permanently** (soft-delete, not restorable from UI). Historical goal progress is preserved either way — past entries keep contributing to the goal — but only Archive lets you bring the habit itself back without re-creating it
 - **Reordering** — Drag-and-drop to reorder habits within categories
 
 ## Routines
@@ -144,6 +144,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Gemini API Key** — Add, view, or remove AI integration key
 - **Apple Health Link** — Connect health integration (beta users)
 - **Setup Guide Reopen** — Re-trigger onboarding walkthrough
+- **View Archived Habits** — Modal listing archived habits with Restore (one-click) and Delete-permanently (two-step confirm) actions; shows count when non-empty
 - **Delete All Data** — Permanent data wipe with confirmation
 
 ## Cross-Cutting

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -138,7 +138,8 @@ HabitFlow App
 | Daily Check-in | Modal | Dashboard check-in card | Wellbeing metrics entry (sleep, mood, stress) | Wellbeing Entries |
 | Edit Goal | Modal | Goal context menu "Edit" | Modify goal title, target, deadline | Goals |
 | Delete Goal Confirm | Modal | Goal context menu "Delete" | Deletion confirmation dialog | Goals |
-| Delete Habit Confirm | Modal | Trash button on a habit that is linked to one or more goals (shown after the click-twice confirm so the user sees which goals are affected) | Lists the affected goals and explains historical progress on them is preserved before allowing deletion | Habits, Goals |
+| Remove Habit | Modal | Trash button on a habit that is linked to one or more goals (shown after the click-twice confirm so the user sees which goals are affected) | Lists the affected goals and offers two paths: **Archive** (recommended, restorable from Settings) or **Delete permanently** (soft-delete, not restorable). For unlinked habits the trash icon archives directly without opening this modal | Habits, Goals |
+| Archived Habits | Modal | Settings → "View archived habits" | Lists archived habits with Restore and Delete-permanently actions; empty state explains archive preserves entries | Habits |
 | Completed Habits | Modal | Routine runner completion | Summary of habits logged during routine | Habits, Entries |
 | Settings | Modal | Header settings icon | Preferences, API keys, data management | User config |
 | Info / Tutorial | Modal | Header info icon | App tutorial and feature explanations | — |
@@ -153,7 +154,7 @@ These surfaces are only visible to users with the Apple Health feature enabled (
 | Health Suggestion Banner | Inline Component | Auto-shown in Day View when pending suggestions exist | Accept/dismiss health-based habit suggestions | Health Suggestions, Habits, Entries |
 | Apple Health Page | Full Page (`?view=health`) | Settings → Apple Health | Create health-tracked habits, manage connected habits, configure rules | Habits, Health Rules |
 
-**Total: 15 pages + 16 modals + 2 feature-gated surfaces = 33 distinct UI surfaces**
+**Total: 15 pages + 17 modals + 2 feature-gated surfaces = 34 distinct UI surfaces**
 
 ---
 
@@ -245,6 +246,9 @@ graph TB
 | **Analyze** | Dashboard heatmap, category completion rows |
 | **Assign Category** | Add Habit Modal (creation) or Category Picker Modal |
 | **Link to Goal** | Add Habit Modal or Create Goal Flow (Step 2) |
+| **Archive** | Tracker → trash icon (click twice). Goal-linked habits open the Remove Habit modal first |
+| **Restore** | Settings → View archived habits → Restore |
+| **Delete permanently** | Goal-linked: Remove Habit modal → "Delete permanently". Archived habit: Settings → View archived habits → trash icon → confirm |
 
 ### Routine
 

--- a/src/components/ArchivedHabitsModal.tsx
+++ b/src/components/ArchivedHabitsModal.tsx
@@ -1,0 +1,206 @@
+import React, { useMemo, useState } from 'react';
+import { Archive, ArchiveRestore, Trash2, Loader2, AlertTriangle } from 'lucide-react';
+import { useHabitStore } from '../store/HabitContext';
+
+interface ArchivedHabitsModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+/**
+ * Lists habits the user has archived and lets them restore the habit back
+ * to active tracking, or delete it permanently. Empty state appears when
+ * no habits are archived.
+ *
+ * The list is built by filtering `habits` from HabitContext for the
+ * `archived === true` predicate. The same predicate is what every active
+ * view filters out via `!h.archived`, so an archived habit is invisible
+ * everywhere else until it's restored.
+ */
+export const ArchivedHabitsModal: React.FC<ArchivedHabitsModalProps> = ({ isOpen, onClose }) => {
+    const { habits, categories, unarchiveHabit, deleteHabit } = useHabitStore();
+    const [busyId, setBusyId] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+    const archivedHabits = useMemo(
+        () => habits.filter(h => h.archived === true && !h.deletedAt),
+        [habits]
+    );
+
+    const categoryById = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const c of categories) map.set(c.id, c.name);
+        return map;
+    }, [categories]);
+
+    if (!isOpen) return null;
+
+    const handleRestore = async (id: string) => {
+        setBusyId(id);
+        setError(null);
+        try {
+            await unarchiveHabit(id);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to restore habit');
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    const handleDelete = async (id: string) => {
+        setBusyId(id);
+        setError(null);
+        try {
+            await deleteHabit(id);
+            setPendingDeleteId(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to delete habit');
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    const formatArchivedDate = (iso?: string) => {
+        if (!iso) return '';
+        try {
+            const d = new Date(iso);
+            return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        } catch {
+            return '';
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-[110]">
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+            <div className="absolute inset-0 overflow-y-auto modal-scroll p-4">
+                <div
+                    className="relative bg-neutral-900 border border-white/10 rounded-xl shadow-xl max-w-lg w-full mx-auto my-8 sm:my-16"
+                    role="dialog"
+                    aria-labelledby="archived-habits-title"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <div className="p-4 border-b border-white/5 flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                            <Archive size={18} className="text-emerald-400" />
+                            <h2 id="archived-habits-title" className="text-lg font-semibold text-white">
+                                Archived Habits
+                            </h2>
+                            {archivedHabits.length > 0 && (
+                                <span className="text-xs text-neutral-500">({archivedHabits.length})</span>
+                            )}
+                        </div>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="p-2 text-neutral-400 hover:text-white rounded-lg hover:bg-white/5"
+                            aria-label="Close"
+                        >
+                            ✕
+                        </button>
+                    </div>
+
+                    <div className="p-4">
+                        {error && (
+                            <div className="mb-3 p-3 bg-red-500/10 border border-red-500/40 rounded-lg flex items-start gap-2">
+                                <AlertTriangle className="text-red-400 flex-shrink-0 mt-0.5" size={14} />
+                                <div className="text-sm text-red-300">{error}</div>
+                            </div>
+                        )}
+
+                        {archivedHabits.length === 0 ? (
+                            <div className="text-center py-10">
+                                <Archive size={28} className="mx-auto text-neutral-600 mb-3" />
+                                <div className="text-sm text-neutral-300 mb-1">No archived habits</div>
+                                <p className="text-xs text-neutral-500 max-w-xs mx-auto">
+                                    When you archive a habit it will appear here. Archived habits keep all their entries and can be restored at any time.
+                                </p>
+                            </div>
+                        ) : (
+                            <ul className="space-y-2">
+                                {archivedHabits.map((habit) => {
+                                    const isBusy = busyId === habit.id;
+                                    const isConfirmingDelete = pendingDeleteId === habit.id;
+                                    const categoryName = habit.categoryId ? categoryById.get(habit.categoryId) : '';
+                                    const archivedOn = formatArchivedDate(habit.archivedAt);
+                                    return (
+                                        <li
+                                            key={habit.id}
+                                            className="rounded-lg bg-neutral-800/50 border border-white/5 p-3"
+                                        >
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div className="min-w-0 flex-1">
+                                                    <div className="text-sm font-medium text-white truncate">{habit.name}</div>
+                                                    <div className="mt-0.5 text-[11px] text-neutral-500 flex items-center gap-1.5 flex-wrap">
+                                                        {categoryName && <span>{categoryName}</span>}
+                                                        {categoryName && archivedOn && <span aria-hidden>•</span>}
+                                                        {archivedOn && <span>Archived {archivedOn}</span>}
+                                                    </div>
+                                                </div>
+                                                <div className="flex items-center gap-1.5 flex-shrink-0">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleRestore(habit.id)}
+                                                        disabled={isBusy}
+                                                        className="px-2.5 py-1.5 rounded-md bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25 border border-emerald-500/30 text-xs flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                                                        title="Restore to active habits"
+                                                    >
+                                                        {isBusy ? (
+                                                            <Loader2 size={12} className="animate-spin" />
+                                                        ) : (
+                                                            <ArchiveRestore size={12} />
+                                                        )}
+                                                        Restore
+                                                    </button>
+                                                    {!isConfirmingDelete ? (
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => setPendingDeleteId(habit.id)}
+                                                            disabled={isBusy}
+                                                            className="p-1.5 rounded-md text-neutral-500 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                                                            title="Delete permanently"
+                                                        >
+                                                            <Trash2 size={12} />
+                                                        </button>
+                                                    ) : (
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => handleDelete(habit.id)}
+                                                            disabled={isBusy}
+                                                            className="px-2.5 py-1.5 rounded-md bg-red-500/15 text-red-300 hover:bg-red-500/25 border border-red-500/40 text-xs flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                                                            title="Click to confirm permanent delete"
+                                                        >
+                                                            {isBusy ? (
+                                                                <Loader2 size={12} className="animate-spin" />
+                                                            ) : (
+                                                                <Trash2 size={12} />
+                                                            )}
+                                                            Confirm delete
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            {isConfirmingDelete && (
+                                                <div className="mt-2 text-[11px] text-red-300/90 flex items-center justify-between gap-2">
+                                                    <span>Permanent. Past entries stay attached to any linked goal but the habit cannot be restored.</span>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => setPendingDeleteId(null)}
+                                                        className="text-neutral-400 hover:text-white underline underline-offset-2"
+                                                    >
+                                                        cancel
+                                                    </button>
+                                                </div>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/DeleteHabitConfirmModal.tsx
+++ b/src/components/DeleteHabitConfirmModal.tsx
@@ -1,69 +1,88 @@
 import React from 'react';
-import { X, AlertTriangle, Loader2, Target } from 'lucide-react';
+import { X, AlertTriangle, Loader2, Target, Archive, Trash2 } from 'lucide-react';
 
-interface DeleteHabitConfirmModalProps {
+interface RemoveHabitModalProps {
     isOpen: boolean;
     onClose: () => void;
-    onConfirm: () => Promise<void>;
+    onArchive: () => Promise<void>;
+    onDelete: () => Promise<void>;
     habitName: string;
+    /** When non-empty, the habit is linked to one or more goals — modal explains the goal impact. */
     linkedGoalTitles: string[];
 }
 
 /**
- * Confirmation modal for deleting a habit that is linked to one or more goals.
+ * Confirmation modal shown when removing a habit.
  *
- * This modal surfaces the link to the user — deleting a habit without warning
- * was a trust issue because goals continued to reference the now-missing habit
- * silently. We explicitly tell the user:
- *   1. Which goals are affected, by title.
- *   2. That historical progress on those goals is PRESERVED — past entries
- *      continue to count toward progress even after the habit is deleted.
- *   3. That the habit will no longer appear in the goal's habit list and
- *      can't be logged going forward.
+ * Offers two paths:
+ *  - **Archive** (default, recommended): hides the habit from active views
+ *    but preserves the habit definition and all entries. Restorable from
+ *    Settings → View Archived Habits. Used when a user has finished a
+ *    short-term habit (e.g. "watch 10 tutorials") but may want to revive it.
+ *  - **Delete permanently**: removes the habit from active views as a soft
+ *    delete. Past entries continue to count toward goal progress, but the
+ *    habit cannot be restored from the UI without re-creating it.
  *
- * For habits that are NOT linked to any goal, the caller keeps the lighter
- * "click trash twice to confirm" flow — this modal is only shown when there's
- * actually a linkage the user should know about.
+ * For habits linked to one or more goals, the modal also surfaces the
+ * affected goal titles so the user knows what gets disconnected.
  */
-export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = ({
+export const DeleteHabitConfirmModal: React.FC<RemoveHabitModalProps> = ({
     isOpen,
     onClose,
-    onConfirm,
+    onArchive,
+    onDelete,
     habitName,
     linkedGoalTitles,
 }) => {
-    const [isDeleting, setIsDeleting] = React.useState(false);
+    const [busy, setBusy] = React.useState<'archive' | 'delete' | null>(null);
     const [error, setError] = React.useState<string | null>(null);
 
     if (!isOpen) return null;
 
-    const handleConfirm = async () => {
-        setIsDeleting(true);
+    const handleArchive = async () => {
+        setBusy('archive');
         setError(null);
         try {
-            await onConfirm();
+            await onArchive();
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to archive habit';
+            setError(errorMessage);
+            console.error('Error archiving habit:', err);
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    const handleDelete = async () => {
+        setBusy('delete');
+        setError(null);
+        try {
+            await onDelete();
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : 'Failed to delete habit';
             setError(errorMessage);
             console.error('Error deleting habit:', err);
         } finally {
-            setIsDeleting(false);
+            setBusy(null);
         }
     };
 
     const handleCancel = () => {
+        if (busy) return;
         setError(null);
         onClose();
     };
+
+    const hasLinkedGoals = linkedGoalTitles.length > 0;
 
     return (
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
             <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Delete Habit</h3>
+                    <h3 className="text-xl font-bold text-white">Remove Habit</h3>
                     <button
                         onClick={handleCancel}
-                        disabled={isDeleting}
+                        disabled={!!busy}
                         className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-400 hover:text-white transition-colors disabled:opacity-50 -mr-2"
                         aria-label="Close"
                     >
@@ -72,29 +91,72 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
                 </div>
 
                 <div className="space-y-4">
-                    {/* Warning */}
-                    <div className="p-4 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-start gap-3">
-                        <AlertTriangle className="text-amber-400 flex-shrink-0 mt-0.5" size={20} />
-                        <div className="flex-1">
-                            <div className="text-amber-400 font-medium mb-1">This habit is linked to a goal</div>
-                            <div className="text-white text-sm">
-                                Deleting <span className="font-semibold">"{habitName}"</span> will remove it from the following goal{linkedGoalTitles.length === 1 ? '' : 's'}. Past entries continue to count toward goal progress — historical progress is preserved — but you won't be able to log new entries for this habit.
+                    {/* Lead-in explaining the choice */}
+                    <p className="text-sm text-neutral-300">
+                        What would you like to do with <span className="font-semibold text-white">"{habitName}"</span>?
+                    </p>
+
+                    {/* Goal-linkage notice (only when linked) */}
+                    {hasLinkedGoals && (
+                        <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-start gap-3">
+                            <AlertTriangle className="text-amber-400 flex-shrink-0 mt-0.5" size={16} />
+                            <div className="flex-1 text-xs text-amber-100/90">
+                                This habit is linked to {linkedGoalTitles.length === 1 ? 'a goal' : `${linkedGoalTitles.length} goals`}. Past entries continue to count toward goal progress either way.
                             </div>
                         </div>
-                    </div>
+                    )}
 
                     {/* Linked goals list */}
-                    <div className="p-3 bg-neutral-800/50 rounded-lg">
-                        <div className="text-neutral-400 text-xs mb-2">Linked goal{linkedGoalTitles.length === 1 ? '' : 's'}</div>
-                        <ul className="space-y-1.5">
-                            {linkedGoalTitles.map((title, idx) => (
-                                <li key={idx} className="flex items-center gap-2 text-white text-sm">
-                                    <Target size={14} className="text-emerald-400 flex-shrink-0" />
-                                    <span className="truncate">{title}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
+                    {hasLinkedGoals && (
+                        <div className="p-3 bg-neutral-800/50 rounded-lg">
+                            <div className="text-neutral-400 text-xs mb-2">Linked goal{linkedGoalTitles.length === 1 ? '' : 's'}</div>
+                            <ul className="space-y-1.5">
+                                {linkedGoalTitles.map((title, idx) => (
+                                    <li key={idx} className="flex items-center gap-2 text-white text-sm">
+                                        <Target size={14} className="text-emerald-400 flex-shrink-0" />
+                                        <span className="truncate">{title}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {/* Archive option (recommended) */}
+                    <button
+                        type="button"
+                        onClick={handleArchive}
+                        disabled={!!busy}
+                        className="w-full text-left p-4 rounded-lg bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-start gap-3"
+                    >
+                        <Archive className="text-emerald-400 flex-shrink-0 mt-0.5" size={18} />
+                        <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                                <span className="text-emerald-300 font-medium text-sm">Archive habit</span>
+                                <span className="text-[10px] uppercase tracking-wider text-emerald-400/70">Recommended</span>
+                            </div>
+                            <div className="text-xs text-neutral-300 mt-1">
+                                Hide from active tracking. The habit and all its entries are preserved and you can restore it any time from Settings.
+                            </div>
+                        </div>
+                        {busy === 'archive' && <Loader2 className="animate-spin text-emerald-400 flex-shrink-0 mt-0.5" size={16} />}
+                    </button>
+
+                    {/* Delete permanently option (destructive) */}
+                    <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={!!busy}
+                        className="w-full text-left p-4 rounded-lg bg-red-500/5 border border-red-500/30 hover:bg-red-500/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-start gap-3"
+                    >
+                        <Trash2 className="text-red-400 flex-shrink-0 mt-0.5" size={18} />
+                        <div className="flex-1">
+                            <div className="text-red-300 font-medium text-sm">Delete permanently</div>
+                            <div className="text-xs text-neutral-300 mt-1">
+                                Remove the habit from your list. Past entries are kept so historical goal progress is preserved, but the habit cannot be restored from the UI.
+                            </div>
+                        </div>
+                        {busy === 'delete' && <Loader2 className="animate-spin text-red-400 flex-shrink-0 mt-0.5" size={16} />}
+                    </button>
 
                     {/* Error display */}
                     {error && (
@@ -106,30 +168,14 @@ export const DeleteHabitConfirmModal: React.FC<DeleteHabitConfirmModalProps> = (
                         </div>
                     )}
 
-                    {/* Buttons */}
-                    <div className="flex items-center gap-3 pt-2">
+                    <div className="pt-2">
                         <button
                             type="button"
                             onClick={handleCancel}
-                            disabled={isDeleting}
-                            className="flex-1 px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            disabled={!!busy}
+                            className="w-full px-4 py-2 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             Cancel
-                        </button>
-                        <button
-                            type="button"
-                            onClick={handleConfirm}
-                            disabled={isDeleting}
-                            className="flex-1 px-4 py-2 bg-red-500 hover:bg-red-400 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                        >
-                            {isDeleting ? (
-                                <>
-                                    <Loader2 className="animate-spin" size={16} />
-                                    Deleting...
-                                </>
-                            ) : (
-                                'Delete Habit'
-                            )}
                         </button>
                     </div>
                 </div>

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -322,6 +322,24 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
 
               <div className="border-b border-white/5" />
 
+              {/* Removing habits — Archive vs Delete */}
+              <div className="pl-3 border-l-2 border-emerald-500/40">
+                <p className="text-sm text-neutral-200">
+                  <span className="font-bold text-emerald-400">Removing a habit</span>
+                </p>
+                <p className="text-sm text-neutral-300 mt-1">The trash icon archives a habit by default — useful when you've finished a short-term habit (like "watch 10 tutorials") but might want to bring it back later.</p>
+                <ul className="mt-2 space-y-1.5">
+                  <li className="text-xs text-neutral-400 pl-2">
+                    <span className="font-semibold text-emerald-300">Archive</span> — Hidden from active tracking. The habit and all its entries are kept. Restore from <span className="text-neutral-300">Settings → View archived habits</span>. Click the trash icon twice to archive (one click for "are you sure", second to confirm).
+                  </li>
+                  <li className="text-xs text-neutral-400 pl-2">
+                    <span className="font-semibold text-red-300">Delete permanently</span> — Available from the Remove Habit modal (shown for goal-linked habits) and from the Archived Habits view. Past entries continue to count toward goal progress, but the habit cannot be restored from the UI.
+                  </li>
+                </ul>
+              </div>
+
+              <div className="border-b border-white/5" />
+
               {/* Routine Variants */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
                 <p className="text-sm text-neutral-200">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useCallback } from 'react';
 import { useAuth } from '../store/AuthContext';
+import { useHabitStore } from '../store/HabitContext';
 import { getGeminiApiKey, setGeminiApiKey } from '../lib/geminiClient';
 import { deleteAllUserData, isHealthFeatureEnabled } from '../lib/persistenceClient';
-import { Eye, EyeOff, Sparkles, Activity, ChevronRight } from 'lucide-react';
+import { Eye, EyeOff, Sparkles, Activity, ChevronRight, Archive } from 'lucide-react';
+import { ArchivedHabitsModal } from './ArchivedHabitsModal';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -12,11 +14,14 @@ interface SettingsModalProps {
 
 export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProps) {
   const { user } = useAuth();
+  const { habits } = useHabitStore();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [geminiKey, setGeminiKey] = useState(() => getGeminiApiKey());
   const [showGeminiKey, setShowGeminiKey] = useState(false);
   const [geminiKeySaved, setGeminiKeySaved] = useState(false);
+  const [showArchivedHabits, setShowArchivedHabits] = useState(false);
+  const archivedCount = habits.filter(h => h.archived === true && !h.deletedAt).length;
   const handleReopenGuide = useCallback(() => {
     try { localStorage.removeItem('hf_setup_guide_dismissed'); } catch { /* noop */ }
     window.dispatchEvent(new Event('habitflow:reopen-setup-guide'));
@@ -83,6 +88,25 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
               >
                 <Sparkles size={16} className="text-emerald-400 flex-shrink-0" />
                 Reopen setup guide
+              </button>
+            </section>
+
+            {/* Habits */}
+            <section>
+              <h3 className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-2">
+                Habits
+              </h3>
+              <button
+                type="button"
+                onClick={() => setShowArchivedHabits(true)}
+                className="w-full px-4 py-2.5 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 hover:bg-neutral-700 text-sm text-left flex items-center gap-2"
+              >
+                <Archive size={16} className="text-emerald-400 flex-shrink-0" />
+                <span className="flex-1">View archived habits</span>
+                {archivedCount > 0 && (
+                  <span className="text-[11px] text-neutral-400">{archivedCount}</span>
+                )}
+                <ChevronRight size={16} className="text-neutral-500" />
               </button>
             </section>
 
@@ -236,6 +260,10 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
           </div>
         </div>
       </div>
+      <ArchivedHabitsModal
+        isOpen={showArchivedHabits}
+        onClose={() => setShowArchivedHabits(false)}
+      />
     </div>
   );
 }

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -158,7 +158,7 @@ const HabitActionButtons = ({
                             await onDelete(habit.id);
                             setDeleteConfirmId(null);
                         } catch (error) {
-                            console.error('Failed to delete habit:', error);
+                            console.error('Failed to remove habit:', error);
                         }
                     } else {
                         setDeleteConfirmId(habit.id);
@@ -168,10 +168,10 @@ const HabitActionButtons = ({
                 className={cn(
                     "p-1.5 rounded-lg transition-all",
                     deleteConfirmId === habit.id
-                        ? "bg-red-500/20 text-red-400 opacity-100"
-                        : "hover:bg-neutral-800 text-neutral-500 hover:text-red-400"
+                        ? "bg-amber-500/20 text-amber-400 opacity-100"
+                        : "hover:bg-neutral-800 text-neutral-500 hover:text-amber-400"
                 )}
-                title={deleteConfirmId === habit.id ? "Click again to delete" : "Delete Habit"}
+                title={deleteConfirmId === habit.id ? "Click again to archive" : "Archive Habit"}
             >
                 <Trash2 size={14} />
             </button>
@@ -796,6 +796,7 @@ export const TrackerGrid = ({
     const childLookupHabits = allHabits ?? habits;
     const {
         deleteHabit,
+        archiveHabit,
         reorderHabits,
         toggleHabit,
         upsertHabitEntry,
@@ -874,43 +875,44 @@ export const TrackerGrid = ({
 
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
     const [deleteMode, setDeleteMode] = useState(false);
-    // Pending confirmation for deleting a habit that is linked to one or more
-    // goals. Shown via DeleteHabitConfirmModal after the user clicks trash twice
-    // — the modal surfaces affected goals so the user understands what gets
-    // disconnected (historical progress is still preserved by design).
+    // Pending confirmation for removing a habit that is linked to one or more
+    // goals. Shown via the Remove Habit modal after the user clicks trash twice —
+    // the modal surfaces affected goals and offers Archive (default) or Delete
+    // permanently. Historical goal progress is preserved either way.
     const [pendingDeleteHabit, setPendingDeleteHabit] = useState<{
         habit: Habit;
         linkedGoalTitles: string[];
     } | null>(null);
 
     /**
-     * Wrapper around deleteHabit that surfaces a confirmation modal when the
-     * habit is linked to any goal. Used in place of the raw deleteHabit when
-     * passing down to child rows.
+     * Wrapper invoked from the trash icon. Archives by default — the safer
+     * action that preserves the habit and entries. For habits linked to a
+     * goal, opens a modal that lets the user choose Archive vs Delete
+     * permanently and surfaces affected goals.
      *
-     * - Unlinked habit → delete immediately (existing "click-twice" flow in
+     * - Unlinked habit → archive immediately (the "click-twice" flow in
      *   HabitActionButtons still protects against accidental clicks).
-     * - Linked habit → open DeleteHabitConfirmModal listing affected goals.
+     * - Linked habit → open Remove Habit modal listing affected goals.
      *   Returns a resolved Promise so the child's click-twice state resets.
      */
     const handleDeleteHabitRequest = useCallback(async (id: string): Promise<void> => {
         const habit = habits.find(h => h.id === id);
         if (!habit) {
-            await deleteHabit(id);
+            await archiveHabit(id);
             return;
         }
         const linkedGoals = (goalsWithProgress || []).filter(gwp =>
             gwp.goal.linkedHabitIds?.includes(id)
         );
         if (linkedGoals.length === 0) {
-            await deleteHabit(id);
+            await archiveHabit(id);
             return;
         }
         setPendingDeleteHabit({
             habit,
             linkedGoalTitles: linkedGoals.map(gwp => gwp.goal.title),
         });
-    }, [habits, goalsWithProgress, deleteHabit]);
+    }, [habits, goalsWithProgress, archiveHabit]);
 
     const [historyModalHabitId, setHistoryModalHabitId] = useState<string | null>(null);
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -1577,11 +1579,18 @@ export const TrackerGrid = ({
                 habitName={bundlePickerHabit?.name ?? ''}
             />
 
-            {/* Delete Habit Confirmation Modal (shown only for habits linked to goals) */}
+            {/* Remove Habit modal (shown only for habits linked to goals).
+                Offers Archive (default) or Delete permanently — both preserve
+                historical goal progress; only Archive can be restored from UI. */}
             <DeleteHabitConfirmModal
                 isOpen={!!pendingDeleteHabit}
                 onClose={() => setPendingDeleteHabit(null)}
-                onConfirm={async () => {
+                onArchive={async () => {
+                    if (!pendingDeleteHabit) return;
+                    await archiveHabit(pendingDeleteHabit.habit.id);
+                    setPendingDeleteHabit(null);
+                }}
+                onDelete={async () => {
                     if (!pendingDeleteHabit) return;
                     await deleteHabit(pendingDeleteHabit.habit.id);
                     setPendingDeleteHabit(null);

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -512,7 +512,7 @@ export async function updateHabit(
 
 /**
  * Delete a habit.
- * 
+ *
  * @param id - Habit ID
  * @returns Promise<void>
  * @throws Error if API request fails or habit not found
@@ -522,6 +522,27 @@ export async function deleteHabit(id: string): Promise<void> {
   await apiRequest<{ message: string }>(`/habits/${id}`, {
     method: 'DELETE',
   });
+}
+
+/**
+ * Archive a habit (user-initiated). Hides it from active views but keeps
+ * entries intact. Restorable via `unarchiveHabit`.
+ */
+export async function archiveHabit(id: string): Promise<Habit> {
+  const response = await apiRequest<{ habit: Habit }>(`/habits/${id}/archive`, {
+    method: 'POST',
+  });
+  return response.habit;
+}
+
+/**
+ * Restore a habit from archive.
+ */
+export async function unarchiveHabit(id: string): Promise<Habit> {
+  const response = await apiRequest<{ habit: Habit }>(`/habits/${id}/unarchive`, {
+    method: 'POST',
+  });
+  return response.habit;
 }
 
 /**

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -122,6 +122,19 @@ export interface Habit {
     archived: boolean;
 
     /**
+     * ISO 8601 timestamp of when the habit was archived. Set together with
+     * `archived: true`. Cleared on unarchive.
+     */
+    archivedAt?: string;
+
+    /**
+     * Why the habit is archived. Distinguishes user-driven archive (which
+     * persists until the user restores it) from system-driven archive caused
+     * by category deletion (which is auto-recovered on the next session).
+     */
+    archivedReason?: 'user' | 'category_deleted';
+
+    /**
      * Soft delete marker (ISO 8601). When set, the habit is removed from
      * active views but the document is retained so historical entries keep
      * a resolvable name/unit for goal progress displays.

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -8,7 +8,7 @@ import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import type { Express, Request, Response } from 'express';
 import { getCategories, createCategoryRoute, getCategory, updateCategoryRoute, deleteCategoryRoute, reorderCategoriesRoute } from './routes/categories';
-import { getHabits, createHabitRoute, getHabit, updateHabitRoute, deleteHabitRoute, reorderHabitsRoute, unlinkBundleChildRoute, convertToBundleRoute } from './routes/habits';
+import { getHabits, createHabitRoute, getHabit, updateHabitRoute, deleteHabitRoute, reorderHabitsRoute, unlinkBundleChildRoute, convertToBundleRoute, archiveHabitRoute, unarchiveHabitRoute } from './routes/habits';
 import { getDaySummary } from './routes/daySummary';
 import { getWellbeingLogs, upsertWellbeingLogRoute, getWellbeingLogRoute, deleteWellbeingLogRoute } from './routes/wellbeingLogs';
 import { getWellbeingEntriesRoute, upsertWellbeingEntriesRoute, deleteWellbeingEntryRoute } from './routes/wellbeingEntries';
@@ -144,6 +144,8 @@ export function createApp(): Express {
   app.delete('/api/habits/:id', deleteHabitRoute);
   app.post('/api/habits/:id/unlink-child', unlinkBundleChildRoute);
   app.post('/api/habits/:id/convert-to-bundle', convertToBundleRoute);
+  app.post('/api/habits/:id/archive', archiveHabitRoute);
+  app.post('/api/habits/:id/unarchive', unarchiveHabitRoute);
 
   // Apple Health integration (feature-gated)
   app.use('/api/health', requireHealthFeature, healthRoutes);

--- a/src/server/repositories/habitRepository.ts
+++ b/src/server/repositories/habitRepository.ts
@@ -191,6 +191,63 @@ export async function updateHabit(
 }
 
 /**
+ * Archive a habit (user-initiated). Sets `archived: true` plus archive
+ * metadata so the habit is hidden from active views but can be restored
+ * later with all entries intact.
+ *
+ * Uses `archivedReason: 'user'` to distinguish from category-deletion
+ * archives, which the GET /api/habits self-heal logic auto-restores.
+ */
+export async function archiveHabit(
+  id: string,
+  householdId: string,
+  userId: string
+): Promise<Habit | null> {
+  const db = await getDb();
+  const collection = db.collection(COLLECTION_NAME);
+
+  const result = await collection.findOneAndUpdate(
+    scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
+    {
+      $set: {
+        archived: true,
+        archivedAt: new Date().toISOString(),
+        archivedReason: 'user',
+      },
+    },
+    { returnDocument: 'after' }
+  );
+
+  if (!result) return null;
+  return stripScope(result);
+}
+
+/**
+ * Restore a habit from archive. Sets `archived: false` and unsets the
+ * archive metadata so the habit re-appears in active views.
+ */
+export async function unarchiveHabit(
+  id: string,
+  householdId: string,
+  userId: string
+): Promise<Habit | null> {
+  const db = await getDb();
+  const collection = db.collection(COLLECTION_NAME);
+
+  const result = await collection.findOneAndUpdate(
+    scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
+    {
+      $set: { archived: false },
+      $unset: { archivedAt: '', archivedReason: '' },
+    },
+    { returnDocument: 'after' }
+  );
+
+  if (!result) return null;
+  return stripScope(result);
+}
+
+/**
  * Soft-delete a habit. Sets `deletedAt`; the document is retained so that
  * orphaned entries (which still contribute to goal progress) can display
  * the habit's original name and unit in historical views.

--- a/src/server/routes/habits.ts
+++ b/src/server/routes/habits.ts
@@ -81,8 +81,9 @@ export async function getHabits(req: Request, res: Response): Promise<void> {
           const invalidCategoryId = !!h.categoryId && !categoryIds.has(h.categoryId);
           // Also recover habits that are archived but have NO archivedReason —
           // these were stranded by a bug where uncategorizeHabitsByCategory cleared
-          // archivedReason without setting archived: false.
-          const archivedWithoutReason = h.archived === true && !(h as any).archivedReason;
+          // archivedReason without setting archived: false. User-driven archives
+          // always set archivedReason: 'user', so they are preserved here.
+          const archivedWithoutReason = h.archived === true && !h.archivedReason;
           return missingCategoryId || invalidCategoryId || archivedWithoutReason;
         });
 

--- a/src/server/routes/habits.ts
+++ b/src/server/routes/habits.ts
@@ -13,6 +13,8 @@ import {
   getHabitById,
   updateHabit,
   deleteHabit,
+  archiveHabit,
+  unarchiveHabit,
   reorderHabits,
   recoverCategoryDeletedHabits,
 } from '../repositories/habitRepository';
@@ -290,7 +292,8 @@ export async function updateHabitRoute(req: Request, res: Response): Promise<voi
   try {
     const { id } = req.params;
     const {
-      name, categoryId, goal, description, archived, assignedDays, scheduledTime, durationMinutes,
+      name, categoryId, goal, description, archived, archivedAt, archivedReason,
+      assignedDays, scheduledTime, durationMinutes,
       nonNegotiable, nonNegotiableDays, deadline, type, subHabitIds, bundleParentId, order,
       bundleType, bundleOptions,
       pinned, timeEstimate,
@@ -310,6 +313,10 @@ export async function updateHabitRoute(req: Request, res: Response): Promise<voi
     if (goal !== undefined) patch.goal = goal;
     if (description !== undefined) patch.description = description;
     if (archived !== undefined) patch.archived = archived;
+    // Allow callers to clear archive metadata by sending null, or set it by
+    // sending an ISO string / valid reason. Undefined means "leave as-is".
+    if (archivedAt !== undefined) patch.archivedAt = archivedAt === null ? undefined : archivedAt;
+    if (archivedReason !== undefined) patch.archivedReason = archivedReason === null ? undefined : archivedReason;
     if (assignedDays !== undefined) patch.assignedDays = assignedDays;
     if (scheduledTime !== undefined) patch.scheduledTime = scheduledTime;
     if (durationMinutes !== undefined) patch.durationMinutes = durationMinutes;
@@ -455,8 +462,82 @@ export async function deleteHabitRoute(req: Request, res: Response): Promise<voi
 }
 
 /**
+ * Archive a habit (user-initiated). Hides it from active views but keeps
+ * all entries intact so it can be restored later via /unarchive.
+ *
+ * POST /api/habits/:id/archive
+ */
+export async function archiveHabitRoute(req: Request, res: Response): Promise<void> {
+  try {
+    const { id } = req.params;
+    if (!id) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Habit ID is required' } });
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+    const habit = await archiveHabit(id, householdId, userId);
+
+    if (!habit) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Habit not found' } });
+      return;
+    }
+
+    invalidateUserCaches(userId);
+    res.status(200).json({ habit });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Error archiving habit:', errorMessage);
+    res.status(500).json({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to archive habit',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      },
+    });
+  }
+}
+
+/**
+ * Restore a habit from archive. Returns it to active views with all entries
+ * intact.
+ *
+ * POST /api/habits/:id/unarchive
+ */
+export async function unarchiveHabitRoute(req: Request, res: Response): Promise<void> {
+  try {
+    const { id } = req.params;
+    if (!id) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Habit ID is required' } });
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+    const habit = await unarchiveHabit(id, householdId, userId);
+
+    if (!habit) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Habit not found' } });
+      return;
+    }
+
+    invalidateUserCaches(userId);
+    res.status(200).json({ habit });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Error unarchiving habit:', errorMessage);
+    res.status(500).json({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to unarchive habit',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      },
+    });
+  }
+}
+
+/**
  * Reorder habits.
- * 
+ *
  * PATCH /api/habits/reorder
  */
 export async function reorderHabitsRoute(req: Request, res: Response): Promise<void> {

--- a/src/store/HabitContext.tsx
+++ b/src/store/HabitContext.tsx
@@ -12,6 +12,8 @@ import {
     saveHabit,
     updateHabit as updateHabitApi, // Reserved for future use
     deleteHabit as deleteHabitApi,
+    archiveHabit as archiveHabitApi,
+    unarchiveHabit as unarchiveHabitApi,
     fetchDaySummary,
 
     fetchWellbeingEntries,
@@ -41,6 +43,8 @@ interface HabitContextType {
     toggleHabit: (habitId: string, date: string) => Promise<void>;
     updateLog: (habitId: string, date: string, value: number) => Promise<void>;
     deleteHabit: (id: string) => Promise<void>;
+    archiveHabit: (id: string) => Promise<Habit>;
+    unarchiveHabit: (id: string) => Promise<Habit>;
     deleteCategory: (id: string) => Promise<void>;
     importHabits: (
         categories: Omit<Category, 'id'>[],
@@ -638,6 +642,30 @@ export const HabitProvider: React.FC<{
         }
     };
 
+    const archiveHabit = async (id: string): Promise<Habit> => {
+        try {
+            const updatedHabit = await archiveHabitApi(id);
+            setHabits(prev => prev.map(h => h.id === id ? updatedHabit : h));
+            return updatedHabit;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            console.error('Failed to archive habit:', errorMessage);
+            throw error;
+        }
+    };
+
+    const unarchiveHabit = async (id: string): Promise<Habit> => {
+        try {
+            const updatedHabit = await unarchiveHabitApi(id);
+            setHabits(prev => prev.map(h => h.id === id ? updatedHabit : h));
+            return updatedHabit;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            console.error('Failed to unarchive habit:', errorMessage);
+            throw error;
+        }
+    };
+
     const deleteCategory = async (id: string) => {
         try {
             await deleteCategoryApi(id);
@@ -928,6 +956,8 @@ export const HabitProvider: React.FC<{
         updateHabitEntry: updateHabitEntryContext,
         deleteHabitEntry: deleteHabitEntryContext,
         deleteHabit,
+        archiveHabit,
+        unarchiveHabit,
         deleteCategory,
         importHabits,
         reorderCategories,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,12 @@ export interface Habit {
     linkedGoalId?: string; // Optional parent Goal ID
     linkedRoutineIds?: string[]; // Optional linked Routines
     archived: boolean;
+    /** ISO 8601 timestamp of when the habit was archived. Set on user archive, cleared on restore. */
+    archivedAt?: string;
+    /** Why the habit is archived. 'user' = user-driven (persists); 'category_deleted' = system (auto-recovered). */
+    archivedReason?: 'user' | 'category_deleted';
+    /** Soft delete marker. Backend filters these out of the active list, so frontend rarely sees it set. */
+    deletedAt?: string;
     createdAt: string;
 
     // Bundle fields


### PR DESCRIPTION
Introduces a user-driven archive state for habits: hide from active views
without losing entries, with a path back via unarchive.

- Adds typed `archivedAt` and `archivedReason` fields to Habit so the
  existing untyped Mongo storage is now first-class. `archivedReason: 'user'`
  distinguishes user archives from category-deletion archives, which prevents
  the GET /api/habits self-heal in routes/habits.ts:83 from auto-restoring
  a user-archived habit.
- Adds `archiveHabit`/`unarchiveHabit` repository helpers that use `$unset`
  on restore so archive metadata is removed cleanly (matches the pattern in
  recoverCategoryDeletedHabits).
- Adds POST /api/habits/:id/archive and /unarchive routes.
- Wires `archiveHabit`/`unarchiveHabit` through persistenceClient and
  HabitContext so UI can call them like `deleteHabit`.

UI changes follow in subsequent commits.