### PR TITLE
Route Today-view trash and stale TrackerGrid modal through archive flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,7 @@ function buildUrlForRoute(route: AppRoute, params: Record<string, string> = {}):
 }
 
 const HabitTrackerContent: React.FC = () => {
-  const { categories, habits, logs, toggleHabit, updateLog, deleteHabit, lastPersistenceError, clearPersistenceError, potentialEvidence, loading } = useHabitStore();
+  const { categories, habits, logs, toggleHabit, updateLog, lastPersistenceError, clearPersistenceError, potentialEvidence, loading } = useHabitStore();
   const [activeCategoryId, setActiveCategoryId] = useState<string>('');
   const UNCATEGORIZED_ID = '__uncategorized__';
 
@@ -567,7 +567,6 @@ const HabitTrackerContent: React.FC = () => {
                 setIsModalOpen(true);
               }}
               onViewHistory={(habit) => setHistoryHabit(habit)}
-              onDeleteHabit={deleteHabit}
             />
           )
         ) : view === 'dashboard' ? (

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -1371,37 +1371,6 @@ export const TrackerGrid = ({
                 </div>
             </DndContext>
 
-            {/* Delete Confirmation Modal */}
-            {deleteConfirmId && (
-                <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-                    <div className="bg-neutral-900 border border-white/10 rounded-xl p-6 w-full max-w-sm shadow-xl">
-                        <h3 className="text-lg font-bold text-white mb-2">Delete Habit?</h3>
-                        <p className="text-neutral-400 mb-6 text-sm">
-                            Are you sure you want to delete this habit? This action cannot be undone and all history will be lost.
-                        </p>
-                        <div className="flex gap-3 justify-end">
-                            <button
-                                onClick={() => setDeleteConfirmId(null)}
-                                className="px-4 py-2 text-sm font-medium text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                onClick={async () => {
-                                    if (deleteConfirmId) {
-                                        await deleteHabit(deleteConfirmId);
-                                        setDeleteConfirmId(null);
-                                    }
-                                }}
-                                className="px-4 py-2 text-sm font-medium text-white bg-red-500/10 text-red-500 hover:bg-red-500/20 border border-red-500/20 rounded-lg transition-colors"
-                            >
-                                Delete
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
-
             {/* Modals */}
             <NumericInputPopover
                 isOpen={popoverState.isOpen}

--- a/src/components/day-view/DayCategorySection.tsx
+++ b/src/components/day-view/DayCategorySection.tsx
@@ -27,7 +27,8 @@ interface DayCategorySectionProps {
     onAddToBundle?: (habit: Habit) => void;
     onViewHistory?: (habit: Habit) => void;
     onEditHabit?: (habit: Habit) => void;
-    onDeleteHabit?: (id: string) => Promise<void>;
+    /** Whether HabitGridCells in this section show the trash/archive button. */
+    showRemove?: boolean;
     allHabitsLookup: Map<string, Habit>;
     onUpdateHabitEntry: (habitId: string, dateKey: string, data: any) => Promise<void>;
     deleteHabitEntryByKey: (habitId: string, dateKey: string) => Promise<void>;
@@ -45,7 +46,7 @@ export const DayCategorySection = ({
     onAddToBundle,
     onViewHistory,
     onEditHabit,
-    onDeleteHabit,
+    showRemove,
     allHabitsLookup,
     onUpdateHabitEntry,
     deleteHabitEntryByKey,
@@ -206,7 +207,7 @@ export const DayCategorySection = ({
                                 onAddToBundle={onAddToBundle}
                                 onViewHistory={onViewHistory}
                                 onEditHabit={onEditHabit}
-                                onDeleteHabit={onDeleteHabit}
+                                showRemove={showRemove}
                                 subHabits={subHabits}
                                 subHabitStatuses={subHabitStatuses}
                                 habitStatus={status}

--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -81,10 +81,9 @@ interface DayViewProps {
     onAddHabit?: () => void;
     onEditHabit?: (habit: Habit) => void;
     onViewHistory?: (habit: Habit) => void;
-    onDeleteHabit?: (id: string) => Promise<void>;
 }
 
-export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit }: DayViewProps = {}) => {
+export const DayView = ({ onAddHabit, onEditHabit, onViewHistory }: DayViewProps = {}) => {
     const {
         habits,
         categories,
@@ -426,7 +425,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
                                                 onAddToBundle={(h) => setBundlePickerHabit(h)}
                                                 onViewHistory={onViewHistory}
                                                 onEditHabit={onEditHabit}
-                                                onDeleteHabit={onDeleteHabit}
+                                    showRemove
                                                 allHabitsLookup={allHabitsLookup}
                                                 onUpdateHabitEntry={upsertHabitEntry}
                                                 deleteHabitEntryByKey={deleteHabitEntryByKey}
@@ -449,7 +448,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory, onDeleteHabit 
                                     onAddToBundle={(h) => setBundlePickerHabit(h)}
                                     onViewHistory={onViewHistory}
                                     onEditHabit={onEditHabit}
-                                    onDeleteHabit={onDeleteHabit}
+                                    showRemove
                                     allHabitsLookup={allHabitsLookup}
                                     onUpdateHabitEntry={upsertHabitEntry}
                                     deleteHabitEntryByKey={deleteHabitEntryByKey}

--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -1,6 +1,10 @@
+import { useState, useMemo } from 'react';
 import { Check, CheckCheck, Target, Hash, Pin, PinOff, ListTodo, Layers, FolderInput, Trophy, Clock, Calendar, Shield, Repeat, Activity, History, Pencil, Trash2 } from 'lucide-react';
 import type { Habit, DayLog } from '../../types';
 import { cn } from '../../utils/cn';
+import { useHabitStore } from '../../store/HabitContext';
+import { useGoalsWithProgress } from '../../lib/useGoalsWithProgress';
+import { DeleteHabitConfirmModal } from '../DeleteHabitConfirmModal';
 
 interface DayViewHabitStatus {
     habit: Habit;
@@ -25,7 +29,12 @@ interface HabitGridCellProps {
     onAddToBundle?: (habit: Habit) => void;
     onViewHistory?: (habit: Habit) => void;
     onEditHabit?: (habit: Habit) => void;
-    onDeleteHabit?: (id: string) => Promise<void>;
+    /**
+     * Whether the trash button is shown. The remove flow itself (archive
+     * default + Remove Habit modal for goal-linked habits) is handled
+     * internally so this view stays consistent with the All-tab tracker.
+     */
+    showRemove?: boolean;
 
     // Bundle Props
     subHabits?: Habit[];
@@ -53,7 +62,7 @@ export const HabitGridCell = ({
     onAddToBundle,
     onViewHistory,
     onEditHabit,
-    onDeleteHabit,
+    showRemove,
     subHabits,
     subHabitStatuses,
     onSubHabitToggle,
@@ -64,6 +73,27 @@ export const HabitGridCell = ({
     log,
     childStatusMap
 }: HabitGridCellProps) => {
+    const { archiveHabit, deleteHabit } = useHabitStore();
+    const { data: goalsWithProgress } = useGoalsWithProgress();
+    const [showRemoveModal, setShowRemoveModal] = useState(false);
+
+    // Resolve the goals (if any) that link to this habit so the modal can
+    // surface them. Computed lazily — `goalsWithProgress` may be undefined
+    // during initial load.
+    const linkedGoalTitles = useMemo(() => {
+        if (!goalsWithProgress) return [];
+        return goalsWithProgress
+            .filter(gwp => gwp.goal.linkedHabitIds?.includes(habit.id))
+            .map(gwp => gwp.goal.title);
+    }, [goalsWithProgress, habit.id]);
+
+    const handleRemoveClick = () => {
+        // Always open the modal so the user sees Archive (default) vs
+        // Delete permanently. For unlinked habits the modal hides the
+        // goal-warning section automatically.
+        setShowRemoveModal(true);
+    };
+
     const isChecklistBundle = habit.type === 'bundle' && habit.bundleType === 'checklist';
     const isChoiceBundle = habit.type === 'bundle' && habit.bundleType === 'choice';
     const isQuantity = habit.goal?.type === 'number';
@@ -368,15 +398,11 @@ export const HabitGridCell = ({
                         >
                             {habit.pinned ? <PinOff size={12} /> : <Pin size={12} />}
                         </button>
-                        {onDeleteHabit && (
+                        {showRemove && (
                             <button
-                                onClick={async () => {
-                                    if (confirm(`Delete "${habit.name}"? This cannot be undone.`)) {
-                                        await onDeleteHabit(habit.id);
-                                    }
-                                }}
-                                className="p-1.5 rounded-md transition-colors text-neutral-500 hover:text-red-400 hover:bg-white/5"
-                                title="Delete Habit"
+                                onClick={handleRemoveClick}
+                                className="p-1.5 rounded-md transition-colors text-neutral-500 hover:text-amber-400 hover:bg-white/5"
+                                title="Archive Habit"
                             >
                                 <Trash2 size={12} />
                             </button>
@@ -384,6 +410,21 @@ export const HabitGridCell = ({
                     </div>
                 </div>
             )}
+
+            <DeleteHabitConfirmModal
+                isOpen={showRemoveModal}
+                onClose={() => setShowRemoveModal(false)}
+                onArchive={async () => {
+                    await archiveHabit(habit.id);
+                    setShowRemoveModal(false);
+                }}
+                onDelete={async () => {
+                    await deleteHabit(habit.id);
+                    setShowRemoveModal(false);
+                }}
+                habitName={habit.name}
+                linkedGoalTitles={linkedGoalTitles}
+            />
         </div>
     );
 };


### PR DESCRIPTION
Two delete paths still bypassed the new archive-default flow:

1. Today (day) view: HabitGridCell used window.confirm("Delete X? This
   cannot be undone.") and called the raw deleteHabit. The user-visible
   bug from the screenshot — no archive option, misleading "cannot be
   undone" copy.

2. All-tab tracker: TrackerGrid still rendered an old bottom-sheet
   "Delete Habit?" modal whose Delete button called raw deleteHabit
   directly. With the trash icon now setting deleteConfirmId on the
   first click (for the click-twice arming UI), this stale modal was
   popping up immediately and bypassing the goal-link warning + the
   new archive flow entirely.

Both now route through the same Remove Habit modal: Archive (default,
restorable from Settings) and Delete permanently (soft-delete, kept
for goal progress but not restorable). HabitGridCell pulls archive +
goal-linkage data from the store directly so the prop chain
(App → DayView → DayCategorySection → HabitGridCell) drops the
onDeleteHabit prop in favor of a `showRemove` boolean.