### PR TITLE
Remove redundant Archive and misleading Decide Later options from goal completion page

### DIFF
--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -113,7 +113,7 @@ HabitFlow App
 | Goals — Schedule | Page | "Schedule" toggle on Goals | Insight calendar with deadlines, forecasts, milestones | Goals, Categories | Goal Detail, Focus Mode |
 | Goals — Achievements | Page | "Achievements" toggle on Goals (trophy icon) | Three-section accomplishments gallery — Single (one-time wins), Progressive (cumulative goals with iteration-chain milestone nodes), Track (horizontal per-track rows with locked stubs for not-yet-earned goals). Section-local "View all" expands long Single/Progressive lists | Goals, Goal Tracks | Goal Detail, Goal Track Detail |
 | Goal Detail | Page | Click goal card / pinned goal | Charts, entries, linked habits (plus a "Removed habits still contributing" list when the goal has orphan contributions from deleted habits) for one goal | Goals, Habits, Entries | Edit Goal Modal, Goal Completed |
-| Goal Completed | Page | Auto-shown on 100% or manual | Celebratory screen with next actions | Goals | Achievements, Goal Detail, Level Up |
+| Goal Completed | Page | Auto-shown on 100% or manual | Celebratory screen with next actions | Goals | Achievements, Goal Detail, Extend |
 | Goal Track Detail | Page | Click track in Goals page | Track name, ordered goals with states, reorder, add/remove goals | Goal Tracks, Goals | Goal Detail, Goals List |
 | Create Goal (Step 1) | Modal | "+ Goal" button on Goals page | Enter goal details (title, type, target, deadline, category) | Goals, Categories | Create Goal Step 2 |
 | Create Goal (Step 2) | Modal | Next from Step 1 | Link habits to goal (filtered by category if selected) | Goals, Habits | Goals List (on submit) |
@@ -273,7 +273,7 @@ graph TB
 | **Delete** | Goal context menu → Delete Goal Confirm Modal |
 | **Track progress** | Goal Detail Page (cumulative chart, trend chart, entry list) |
 | **Complete** | Auto-triggered at 100% → Goal Completed Page |
-| **Archive / Level Up** | Goal Completed Page actions |
+| **Extend / Repeat** | Goal Completed Page actions |
 | **View wins** | Goals page "Achievements" tab → Win Archive |
 
 ### Habit Entry / Logging

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -477,11 +477,6 @@ const HabitTrackerContent: React.FC = () => {
                 console.error('Failed to repeat goal:', err);
               }
             }}
-            onArchive={() => {
-              setCompletedGoalId(null);
-              setGoalsViewMode('achievements');
-              handleNavigate('goals');
-            }}
           />
         ) : view === 'wins' ? (
           // Legacy wins route: show achievements tab within goals

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -445,7 +445,7 @@ const HabitTrackerContent: React.FC = () => {
               setCompletedGoalId(null);
               handleNavigate('goals', { goalId });
             }}
-            onLevelUp={async (goalId) => {
+            onExtend={async (goalId) => {
               try {
                 const result = await iterateGoal(goalId);
                 setCompletedGoalId(null);
@@ -455,7 +455,7 @@ const HabitTrackerContent: React.FC = () => {
                   handleNavigate('goals');
                 }
               } catch (err) {
-                console.error('Failed to level up goal:', err);
+                console.error('Failed to extend goal:', err);
               }
             }}
             onRepeat={async (goalId) => {

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -981,7 +981,7 @@ export async function markGoalAsCompleted(id: string): Promise<Goal> {
 
 /**
  * Mark a goal as completed AND create an iterated follow-up goal with a higher target.
- * Used when the user explicitly chooses "Level Up" after completion.
+ * Used when the user explicitly chooses "Extend" after completion.
  *
  * @param id - Goal ID
  * @returns Promise with the updated goal and the new iterated goal

--- a/src/pages/goals/GoalCompletedPage.tsx
+++ b/src/pages/goals/GoalCompletedPage.tsx
@@ -30,7 +30,7 @@ interface GoalCompletedPageProps {
     onBack?: () => void;
     onViewGoalDetail?: (goalId: string) => void;
     onViewWinArchive?: () => void;
-    onLevelUp?: (goalId: string) => void;
+    onExtend?: (goalId: string) => void;
     onRepeat?: (goalId: string) => void;
 }
 
@@ -47,7 +47,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
     onBack,
     onViewGoalDetail,
     onViewWinArchive,
-    onLevelUp,
+    onExtend,
     onRepeat,
 }) => {
     // Check caches first — only fetch detail as fallback
@@ -232,12 +232,12 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                         </p>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                             <button
-                                onClick={() => onLevelUp?.(goalId)}
+                                onClick={() => onExtend?.(goalId)}
                                 className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-emerald-500/30 transition-all text-left"
                             >
                                 <div className="flex items-center gap-2 mb-1">
                                     <TrendingUp size={16} className="text-emerald-400" />
-                                    <span className="text-emerald-400 font-medium">Level Up</span>
+                                    <span className="text-emerald-400 font-medium">Extend</span>
                                 </div>
                                 <div className="text-neutral-500 text-xs">
                                     Raise the target and keep pushing

--- a/src/pages/goals/GoalCompletedPage.tsx
+++ b/src/pages/goals/GoalCompletedPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { Trophy, Sparkles, TrendingUp, RotateCcw, Archive, Clock } from 'lucide-react';
+import { Trophy, Sparkles, TrendingUp, RotateCcw } from 'lucide-react';
 import { useGoalDetail } from '../../lib/useGoalDetail';
 import { format, parseISO, differenceInDays } from 'date-fns';
 import { Loader2 } from 'lucide-react';
@@ -32,7 +32,6 @@ interface GoalCompletedPageProps {
     onViewWinArchive?: () => void;
     onLevelUp?: (goalId: string) => void;
     onRepeat?: (goalId: string) => void;
-    onArchive?: (goalId: string) => void;
 }
 
 /**
@@ -50,7 +49,6 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
     onViewWinArchive,
     onLevelUp,
     onRepeat,
-    onArchive,
 }) => {
     // Check caches first — only fetch detail as fallback
     const cachedGoal = useMemo(() => findGoalInCache(goalId), [goalId]);
@@ -230,7 +228,7 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                     <div className="max-w-lg mx-auto mt-12 pt-8 border-t border-white/10">
                         <h3 className="text-lg font-semibold text-white mb-2">What feels right next?</h3>
                         <p className="text-neutral-400 text-sm mb-6">
-                            Choose how you want to continue — or come back to this later.
+                            Choose how you want to continue.
                         </p>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                             <button
@@ -255,33 +253,6 @@ export const GoalCompletedPage: React.FC<GoalCompletedPageProps> = ({
                                 </div>
                                 <div className="text-neutral-500 text-xs">
                                     Same target, fresh start
-                                </div>
-                            </button>
-                            <button
-                                onClick={() => {
-                                    onArchive?.(goalId);
-                                    if (onBack) onBack();
-                                }}
-                                className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-yellow-500/30 transition-all text-left"
-                            >
-                                <div className="flex items-center gap-2 mb-1">
-                                    <Archive size={16} className="text-yellow-400" />
-                                    <span className="text-yellow-400 font-medium">Archive</span>
-                                </div>
-                                <div className="text-neutral-500 text-xs">
-                                    Save to Win Archive, done for now
-                                </div>
-                            </button>
-                            <button
-                                onClick={onBack}
-                                className="p-4 bg-neutral-800/50 border border-white/10 rounded-xl hover:bg-neutral-800 hover:border-white/20 transition-all text-left"
-                            >
-                                <div className="flex items-center gap-2 mb-1">
-                                    <Clock size={16} className="text-neutral-300" />
-                                    <span className="text-neutral-300 font-medium">Decide Later</span>
-                                </div>
-                                <div className="text-neutral-500 text-xs">
-                                    Come back to this anytime
                                 </div>
                             </button>
                         </div>

--- a/src/server/routes/__tests__/goals.create.test.ts
+++ b/src/server/routes/__tests__/goals.create.test.ts
@@ -134,7 +134,7 @@ describe('Goal Create Routes', () => {
     });
 
     // Regression: legacy goals stored with countMode/aggregationMode = null were
-    // tripping validation on Repeat / Level Up / Extend, which forwards the
+    // tripping validation on Repeat / Extend, which forwards the
     // original goal's mode fields verbatim. Validator now treats null the same
     // as undefined (i.e. "fall through to defaults").
     describe('POST /api/goals - legacy null mode fields', () => {


### PR DESCRIPTION
The celebration page renders after completedAt is already set, so the goal is
already in the Win Archive by the time the user sees these options. Archive's
handler was byte-identical to View Win Archive (the green button at the top),
and Decide Later's "come back to this anytime" was a broken promise — there
is no pendingDecision state on Goal, so the button just dismissed the screen
while the goal silently went to the archive.