### PR TITLE
types: add Goal.milestones and GoalProgress.milestoneStates

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -78,6 +78,12 @@ Base URL: `/api`
 - `PUT /goals/:id`
 - `DELETE /goals/:id`
 
+### Milestones
+
+Cumulative goals may declare intermediate stages via the optional `milestones` field on POST/PUT bodies. Each entry: `{ value: number }` (server assigns `id`). Constraints: positive number, unique, strictly less than `targetValue`, max 20 entries, only valid when `type === 'cumulative'`. Server normalizes to ascending order by `value`. PUT-replace preserves `acknowledgedAt` from existing milestones matched by `id`.
+
+`GoalProgress` responses include a parallel `milestoneStates: MilestoneState[]` whose `completed` flag is derived from HabitEntries. The full-progress path also populates `completedAtDayKey` (the first dayKey at which the running cumulative crossed the milestone value).
+
 ## Journal
 
 - `GET /journal`

--- a/docs/API.md
+++ b/docs/API.md
@@ -77,12 +77,15 @@ Base URL: `/api`
 - `GET /goals/:id`
 - `PUT /goals/:id`
 - `DELETE /goals/:id`
+- `POST /goals/:id/milestones/:milestoneId/acknowledge`
 
 ### Milestones
 
 Cumulative goals may declare intermediate stages via the optional `milestones` field on POST/PUT bodies. Each entry: `{ value: number }` (server assigns `id`). Constraints: positive number, unique, strictly less than `targetValue`, max 20 entries, only valid when `type === 'cumulative'`. Server normalizes to ascending order by `value`. PUT-replace preserves `acknowledgedAt` from existing milestones matched by `id`.
 
 `GoalProgress` responses include a parallel `milestoneStates: MilestoneState[]` whose `completed` flag is derived from HabitEntries. The full-progress path also populates `completedAtDayKey` (the first dayKey at which the running cumulative crossed the milestone value).
+
+`POST /goals/:id/milestones/:milestoneId/acknowledge` sets `acknowledgedAt = now` on the matching milestone. Idempotent: a second call preserves the original timestamp. Returns the updated goal. The frontend invokes this after the user dismisses a milestone celebration screen so the celebration does not replay.
 
 ## Journal
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -79,6 +79,17 @@ Bundle parent completion is derived from children whose membership is active on 
 
 See: `src/server/repositories/bundleMembershipRepository.ts`
 
+## Goal Milestones
+
+Cumulative goals may declare intermediate stages via `Goal.milestones`. Each entry has:
+- `id` — server-assigned UUID
+- `value` — threshold > 0 and strictly less than `Goal.targetValue`
+- `acknowledgedAt?` — ISO timestamp set after the user dismisses the per-milestone celebration
+
+Milestone *completion* is derived at read time from HabitEntries (see `src/server/utils/goalProgressUtilsV2.ts` → `computeMilestoneStates`); only the configuration above and `acknowledgedAt` are stored. The server normalizes the array to ascending order by `value` on write.
+
+`acknowledgedAt` is the only progress-adjacent field stored on the goal. It mirrors `Goal.completedAt`: derived completion remains canonical, while the acknowledgment marker keeps the celebration screen idempotent across reloads.
+
 ## DayKey Boundary
 
 DayKey utilities and validation:

--- a/docs/DOMAIN_CANON.md
+++ b/docs/DOMAIN_CANON.md
@@ -25,6 +25,7 @@ It does not replace the canonical references.
 
 4. Derived metrics are recomputable.
 - Streaks, momentum, percentages, and charts are read-model outputs.
+- Goal milestone *completion* is derived in `computeMilestoneStates` (`src/server/utils/goalProgressUtilsV2.ts`). Only milestone configuration (id, value) and `acknowledgedAt` are stored on `Goal.milestones`.
 
 ## Bundle Identity Model
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -42,6 +42,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Create/Edit Goals** — Set goals with title, type, target, deadline, category, and linked habits
 - **Goal Types: Cumulative** — Track total progress toward a numeric target (e.g., "Run 100 miles")
 - **Goal Types: One-time** — Binary milestone achievement (e.g., "Pass the B2 exam")
+- **Cumulative Goal Milestones** — Cumulative goals can declare intermediate stages (e.g., 25/50/75 within a 100 Pull-Ups goal). Milestones are server-validated to be unique, positive, and strictly less than the final target (max 20). Completion is derived from HabitEntries — only the configuration and a per-milestone `acknowledgedAt` celebration marker are stored. Each crossed milestone triggers the goal-completed celebration screen and renders as a node on the Achievements gallery's Progressive card.
 - **Linked Habits** — Connect habits that contribute to goal progress; completions auto-update progress
 - **Progress Visualization** — Real-time progress bar with milestone markers at 25/50/75%
 - **Cumulative Chart** — Line graph of total progress over time. Renders from the same server-derived contributions series as the top "currentValue" total, so the two always agree
@@ -51,7 +52,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Day-by-Day View** — Chronological list of individual contributions
 - **Goal Schedule View** — Calendar showing deadlines, forecasts, and milestones across all goals
 - **Achievement Badges** — Auto-generated badges for completed goals
-- **Achievements Gallery** — Three structured sections of completed goals: **Single** (one-time wins), **Progressive** (cumulative goals with their full iteration history rendered as connected milestone nodes — e.g. 25 → 50 → 100), and **Track** (per-track horizontal rows showing earned goal badges plus muted lock stubs for goals not yet earned). In-progress tracks appear here as soon as one goal in the track is earned.
+- **Achievements Gallery** — Three structured sections of completed goals: **Single** (one-time wins), **Progressive** (cumulative goals with iteration history *and* in-progress goals with crossed milestones, both rendered as connected milestone nodes — e.g. 25 → 50 → 100), and **Track** (per-track horizontal rows showing earned goal badges plus muted lock stubs for goals not yet earned). In-progress tracks appear here as soon as one goal in the track is earned. In-progress milestone goals appear as soon as at least one milestone is crossed.
 - **Goal Extension** — Create a continuation goal with higher target after completion. Extended goals carry an `iteratedFromGoalId` backref so the Achievements gallery can collapse the chain into a single Progressive card showing the full target history.
 - **Mark Complete** — Manually mark goals as achieved
 - **Goal Ordering** — Drag-and-drop reorder within category groups

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -75,7 +75,7 @@ HabitFlow App
 │       │   ├── Category filter
 │       │   ├── Single-goal focus mode
 │       │   └── Date detail panel (cluster inspection)
-│       ├── Achievements — Three-section gallery: Single, Progressive (with iteration-history milestone nodes), Track (horizontal rows per track with locked stubs for not-yet-earned goals)
+│       ├── Achievements — Three-section gallery: Single, Progressive (iteration-history nodes plus in-progress goals with crossed milestones, both rendered as connected node chains), Track (horizontal rows per track with locked stubs for not-yet-earned goals)
 │       ├── [+] Create Goal (→ multi-step flow)
 │       ├── Goal Detail Page (charts, entries, linked habits)
 │       ├── Edit Goal (→ modal)
@@ -111,11 +111,11 @@ HabitFlow App
 | Routines List | Page | Bottom tab "Routines" | Card list of all routines | Routines | Routine Editor, Runner, Preview |
 | Goals — All | Page | Bottom tab "Goals", "All" toggle | Collapsible category stacks with progress bars. "New Track" button in header bar next to "+" | Goals, Categories | Create Goal Flow, Goal Detail, Edit Goal Modal, Create Track Modal |
 | Goals — Schedule | Page | "Schedule" toggle on Goals | Insight calendar with deadlines, forecasts, milestones | Goals, Categories | Goal Detail, Focus Mode |
-| Goals — Achievements | Page | "Achievements" toggle on Goals (trophy icon) | Three-section accomplishments gallery — Single (one-time wins), Progressive (cumulative goals with iteration-chain milestone nodes), Track (horizontal per-track rows with locked stubs for not-yet-earned goals). Section-local "View all" expands long Single/Progressive lists | Goals, Goal Tracks | Goal Detail, Goal Track Detail |
+| Goals — Achievements | Page | "Achievements" toggle on Goals (trophy icon) | Three-section accomplishments gallery — Single (one-time wins), Progressive (iteration-chain nodes plus in-progress milestone-bearing goals with parallel completion state — completed nodes filled, future nodes outlined), Track (horizontal per-track rows with locked stubs for not-yet-earned goals). Section-local "View all" expands long Single/Progressive lists | Goals, Goal Tracks | Goal Detail, Goal Track Detail |
 | Goal Detail | Page | Click goal card / pinned goal | Charts, entries, linked habits (plus a "Removed habits still contributing" list when the goal has orphan contributions from deleted habits) for one goal | Goals, Habits, Entries | Edit Goal Modal, Goal Completed |
 | Goal Completed | Page | Auto-shown on 100% or manual | Celebratory screen with next actions | Goals | Achievements, Goal Detail, Extend |
 | Goal Track Detail | Page | Click track in Goals page | Track name, ordered goals with states, reorder, add/remove goals | Goal Tracks, Goals | Goal Detail, Goals List |
-| Create Goal (Step 1) | Modal | "+ Goal" button on Goals page | Enter goal details (title, type, target, deadline, category) | Goals, Categories | Create Goal Step 2 |
+| Create Goal (Step 1) | Modal | "+ Goal" button on Goals page | Enter goal details. For cumulative goals: title, type, **MilestoneRowList** (intermediate stages plus a pinned "Final Goal" row that holds `targetValue`), unit, deadline, category. For one-time goals: title, type, event date, category. | Goals, Categories | Create Goal Step 2 |
 | Create Goal (Step 2) | Modal | Next from Step 1 | Link habits to goal (filtered by category if selected) | Goals, Habits | Goals List (on submit) |
 | Journal | Page | Dashboard card / `?view=journal` | Free-write, templates, history tabs; auto-generated AI summary banner | Journal Entries | — |
 | Tasks | Page | Dashboard card / `?view=tasks` | Today + Inbox columns; click a task title or pencil icon to rename inline | Tasks | — |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,9 @@ import { ScheduleView } from './components/day-view/ScheduleView';
 import { DevIdentityPanel } from './components/DevIdentityPanel';
 import { DashboardPrefsProvider } from './store/DashboardPrefsContext';
 import { GoalCompletionProvider, useGoalCompletion } from './store/GoalCompletionContext';
+import { useMilestoneCelebrationWatcher } from './lib/useMilestoneCelebrationWatcher';
+import { MilestoneCelebrationModal } from './components/goals/MilestoneCelebrationModal';
+import { acknowledgeMilestone } from './lib/persistenceClient';
 
 // Retry wrapper for lazy imports — handles stale chunk failures after deployments
 function lazyRetry<T extends React.ComponentType<any>>(
@@ -200,7 +203,11 @@ const HabitTrackerContent: React.FC = () => {
 
   const [showCreateGoal, setShowCreateGoal] = useState(false);
   const [showCreateTrack, setShowCreateTrack] = useState(false);
-  const { completedGoalId, setCompletedGoalId } = useGoalCompletion();
+  const { completedGoalId, setCompletedGoalId, pendingMilestone, dismissPendingMilestone } = useGoalCompletion();
+
+  // Watch goals-with-progress for unacknowledged crossed milestones and queue
+  // their celebrations.
+  useMilestoneCelebrationWatcher();
 
   // Routine State
   const [routineEditorState, setRoutineEditorState] = useState<{
@@ -701,6 +708,19 @@ const HabitTrackerContent: React.FC = () => {
           handleNavigate('goals', { trackId });
         }}
       />
+
+      {pendingMilestone && (
+        <MilestoneCelebrationModal
+          milestone={pendingMilestone}
+          onDismiss={() => {
+            const { goalId, milestoneId } = pendingMilestone;
+            dismissPendingMilestone();
+            void acknowledgeMilestone(goalId, milestoneId).catch((err) => {
+              console.error('Failed to acknowledge milestone:', err);
+            });
+          }}
+        />
+      )}
 
       <BottomTabBar activeView={view} onNavigate={handleNavigate} />
     </div >

--- a/src/components/CreateGoalModal.tsx
+++ b/src/components/CreateGoalModal.tsx
@@ -3,6 +3,7 @@ import { X, Target, CalendarCheck, Plus, Search, Loader2, AlertCircle, Calendar,
 import { useHabitStore } from '../store/HabitContext';
 import { createGoal } from '../lib/persistenceClient';
 import { HabitCreationInlineModal } from './HabitCreationInlineModal';
+import { MilestoneRowList, type MilestoneRow } from './goals/MilestoneRowList';
 
 interface CreateGoalModalProps {
     isOpen: boolean;
@@ -22,6 +23,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
     const [unit, setUnit] = useState('');
     const [deadline, setDeadline] = useState('');
     const [categoryId, setCategoryId] = useState('');
+    const [milestoneRows, setMilestoneRows] = useState<MilestoneRow[]>([]);
 
     // Category creation state
     const [isCreatingCategory, setIsCreatingCategory] = useState(false);
@@ -51,6 +53,7 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
             setUnit('');
             setDeadline('');
             setCategoryId('');
+            setMilestoneRows([]);
             setIsCreatingCategory(false);
             setNewCategoryName('');
             setSelectedHabitIds(new Set());
@@ -78,11 +81,43 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
             );
     }, [habits, searchQuery, categoryMap, categoryId]);
 
+    // Parse and validate milestone rows
+    const parsedMilestones = useMemo(() => {
+        const targetNum = parseFloat(targetValue);
+        const targetValid = !isNaN(targetNum) && targetNum > 0;
+        const seen = new Set<number>();
+        let allValid = true;
+        const values: number[] = [];
+
+        for (const row of milestoneRows) {
+            const v = parseFloat(row.valueText);
+            if (row.valueText.trim() === '' || !Number.isFinite(v) || v <= 0) {
+                allValid = false;
+                continue;
+            }
+            if (seen.has(v)) {
+                allValid = false;
+                continue;
+            }
+            if (targetValid && v >= targetNum) {
+                allValid = false;
+                continue;
+            }
+            seen.add(v);
+            values.push(v);
+        }
+
+        return { values, allValid };
+    }, [milestoneRows, targetValue]);
+
     // Validation
     const isStep1Valid = (() => {
         if (!title.trim()) return false;
         if (type === 'cumulative') {
-            return targetValue !== '' && !isNaN(parseFloat(targetValue)) && parseFloat(targetValue) > 0;
+            const target = parseFloat(targetValue);
+            if (targetValue === '' || isNaN(target) || target <= 0) return false;
+            if (!parsedMilestones.allValid) return false;
+            return true;
         }
         return true;
     })();
@@ -156,6 +191,9 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
                 linkedHabitIds: Array.from(selectedHabitIds),
                 deadline: deadline || undefined,
                 categoryId: categoryId || undefined,
+                ...(type === 'cumulative' && parsedMilestones.values.length > 0
+                    ? { milestones: parsedMilestones.values.map((value) => ({ id: '', value })) }
+                    : {}),
             });
 
             onClose();
@@ -243,56 +281,55 @@ export const CreateGoalModal: React.FC<CreateGoalModalProps> = ({ isOpen, onClos
 
                             {/* Conditional Fields */}
                             {type !== 'onetime' ? (
-                                <div className="flex items-end gap-3">
-                                    <div className="flex-1 space-y-2">
-                                        <label className="block text-sm font-medium text-neutral-400">Target Value</label>
-                                        <input
-                                            type="number"
-                                            value={targetValue}
-                                            onChange={(e) => setTargetValue(e.target.value)}
-                                            className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
-                                            placeholder="e.g., 100"
-                                            min="0.01"
-                                            step="0.01"
-                                        />
+                                <>
+                                    <MilestoneRowList
+                                        targetValueText={targetValue}
+                                        onTargetChange={setTargetValue}
+                                        unit={unit}
+                                        milestones={milestoneRows}
+                                        onChange={setMilestoneRows}
+                                        disabled={isSubmitting}
+                                    />
+
+                                    <div className="flex items-end gap-3">
+                                        <div className="flex-1 space-y-2">
+                                            <label className="block text-sm font-medium text-neutral-400">
+                                                Unit <span className="text-neutral-500 font-normal">(Optional)</span>
+                                            </label>
+                                            <input
+                                                type="text"
+                                                value={unit}
+                                                onChange={(e) => setUnit(e.target.value)}
+                                                className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
+                                                placeholder="e.g., miles, sessions"
+                                            />
+                                        </div>
+                                        <div className="relative">
+                                            <button
+                                                type="button"
+                                                onClick={() => deadlineInputRef.current?.showPicker()}
+                                                className={`min-h-[48px] min-w-[48px] flex items-center justify-center rounded-xl border transition-all ${
+                                                    deadline
+                                                        ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
+                                                        : 'bg-neutral-900/50 border-white/10 text-neutral-400 hover:border-white/20 hover:text-white'
+                                                }`}
+                                                aria-label={deadline ? `Deadline: ${deadline}` : 'Set deadline'}
+                                                title={deadline ? `Deadline: ${deadline}` : 'Set deadline'}
+                                            >
+                                                <Calendar size={20} />
+                                            </button>
+                                            <input
+                                                ref={deadlineInputRef}
+                                                type="date"
+                                                value={deadline}
+                                                onChange={(e) => setDeadline(e.target.value)}
+                                                className="absolute inset-0 opacity-0 w-full h-full cursor-pointer"
+                                                min={new Date().toISOString().split('T')[0]}
+                                                aria-label="Deadline date"
+                                            />
+                                        </div>
                                     </div>
-                                    <div className="flex-1 space-y-2">
-                                        <label className="block text-sm font-medium text-neutral-400">
-                                            Unit <span className="text-neutral-500 font-normal">(Optional)</span>
-                                        </label>
-                                        <input
-                                            type="text"
-                                            value={unit}
-                                            onChange={(e) => setUnit(e.target.value)}
-                                            className="w-full bg-neutral-900/50 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
-                                            placeholder="e.g., miles, sessions"
-                                        />
-                                    </div>
-                                    <div className="relative">
-                                        <button
-                                            type="button"
-                                            onClick={() => deadlineInputRef.current?.showPicker()}
-                                            className={`min-h-[48px] min-w-[48px] flex items-center justify-center rounded-xl border transition-all ${
-                                                deadline
-                                                    ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
-                                                    : 'bg-neutral-900/50 border-white/10 text-neutral-400 hover:border-white/20 hover:text-white'
-                                            }`}
-                                            aria-label={deadline ? `Deadline: ${deadline}` : 'Set deadline'}
-                                            title={deadline ? `Deadline: ${deadline}` : 'Set deadline'}
-                                        >
-                                            <Calendar size={20} />
-                                        </button>
-                                        <input
-                                            ref={deadlineInputRef}
-                                            type="date"
-                                            value={deadline}
-                                            onChange={(e) => setDeadline(e.target.value)}
-                                            className="absolute inset-0 opacity-0 w-full h-full cursor-pointer"
-                                            min={new Date().toISOString().split('T')[0]}
-                                            aria-label="Deadline date"
-                                        />
-                                    </div>
-                                </div>
+                                </>
                             ) : (
                                 <div className="flex items-center gap-3">
                                     <span className="text-sm text-neutral-400">Event Date</span>

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -371,7 +371,7 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                 <ul className="mt-1.5 space-y-1.5">
                   <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
                     <Target size={13} className="text-emerald-400 mt-0.5 shrink-0" />
-                    <span><span className="font-semibold text-emerald-400">Cumulative</span> — Track total progress toward a target number (e.g., "Run 100 miles").</span>
+                    <span><span className="font-semibold text-emerald-400">Cumulative</span> — Track total progress toward a target number (e.g., "Run 100 miles"). You can add intermediate <span className="font-semibold text-emerald-400">milestones</span> (e.g., 25/50/75 within a 100 Pull-Ups goal). Each crossed milestone shows a celebration screen and lands on the Achievements gallery as its own stage.</span>
                   </li>
                   <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
                     <CalendarCheck size={13} className="text-emerald-400 mt-0.5 shrink-0" />

--- a/src/components/goals/EditGoalModal.tsx
+++ b/src/components/goals/EditGoalModal.tsx
@@ -5,6 +5,7 @@ import { useHabitStore } from '../../store/HabitContext';
 import type { GoalWithProgress } from '../../models/persistenceTypes';
 import { invalidateGoalCaches } from '../../lib/goalDataCache';
 import { AddHabitModal } from '../AddHabitModal';
+import { MilestoneRowList, makeMilestoneRowKey, type MilestoneRow } from './MilestoneRowList';
 
 interface EditGoalModalProps {
     isOpen: boolean;
@@ -29,6 +30,13 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
     const [unit, setUnit] = useState(goal.unit || '');
     const [selectedHabitIds, setSelectedHabitIds] = useState<string[]>(goal.linkedHabitIds);
     const [deadline, setDeadline] = useState(goal.deadline || '');
+    const [milestoneRows, setMilestoneRows] = useState<MilestoneRow[]>(() =>
+        (goal.milestones ?? []).map((m) => ({
+            rowKey: makeMilestoneRowKey(),
+            serverId: m.id,
+            valueText: m.value.toString(),
+        })),
+    );
 
     // Category State
     const [categoryId, setCategoryId] = useState(goal.categoryId || '');
@@ -54,6 +62,13 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
             setSelectedHabitIds(goal.linkedHabitIds);
             setDeadline(goal.deadline || '');
             setCategoryId(goal.categoryId || '');
+            setMilestoneRows(
+                (goal.milestones ?? []).map((m) => ({
+                    rowKey: makeMilestoneRowKey(),
+                    serverId: m.id,
+                    valueText: m.value.toString(),
+                })),
+            );
             setError(null);
             setHabitSearch('');
             setFilterByGoalCategory(true);
@@ -120,6 +135,36 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
             return;
         }
 
+        // Build the milestones payload for cumulative goals. Preserve serverId
+        // (round-trip) so the backend can match by id and carry acknowledgedAt.
+        let milestonesPayload: Array<{ id: string; value: number }> | undefined;
+        if (goal.type === 'cumulative') {
+            const seen = new Set<number>();
+            const built: Array<{ id: string; value: number }> = [];
+            for (const row of milestoneRows) {
+                if (row.valueText.trim() === '') {
+                    setError('Milestone values cannot be empty');
+                    return;
+                }
+                const v = parseFloat(row.valueText);
+                if (!Number.isFinite(v) || v <= 0) {
+                    setError('Milestone values must be positive numbers');
+                    return;
+                }
+                if (v >= numTarget) {
+                    setError('Each milestone must be less than the final target');
+                    return;
+                }
+                if (seen.has(v)) {
+                    setError('Milestone values must be unique');
+                    return;
+                }
+                seen.add(v);
+                built.push({ id: row.serverId ?? '', value: v });
+            }
+            milestonesPayload = built;
+        }
+
         // Event date is optional for one-time goals
         // No validation needed
 
@@ -146,6 +191,7 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                 linkedHabitIds: selectedHabitIds,
                 deadline: deadline || undefined,
                 categoryId: categoryId || undefined,
+                ...(milestonesPayload !== undefined ? { milestones: milestonesPayload } : {}),
             });
 
             // Invalidate cache
@@ -308,54 +354,46 @@ export const EditGoalModal: React.FC<EditGoalModalProps> = ({
                             />
                         </div>
 
-                        {/* Target & Deadline Params */}
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            {/* Target - Only for cumulative or frequency number goals */}
-                            {goal.type !== 'onetime' && (
-                                <>
-                                    <div>
-                                        <label className="block text-sm font-medium text-neutral-300 mb-2">
-                                            Target Value
-                                        </label>
-                                        <input
-                                            type="number"
-                                            value={targetValue}
-                                            onChange={(e) => {
-                                                const newVal = e.target.value;
-                                                const oldVal = targetValue;
-                                                // Auto-update title if it contains the old target number
-                                                if (oldVal && newVal && oldVal !== newVal) {
-                                                    const regex = new RegExp(`\\b${oldVal}\\b`);
-                                                    if (regex.test(title)) {
-                                                        setTitle(title.replace(regex, newVal));
-                                                    }
-                                                }
-                                                setTargetValue(newVal);
-                                            }}
-                                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
-                                            min="1"
-                                            step="any"
-                                        />
-                                    </div>
+                        {/* Milestones (cumulative only) — folds in Target Value as the Final Goal row */}
+                        {goal.type !== 'onetime' && (
+                            <MilestoneRowList
+                                targetValueText={targetValue}
+                                onTargetChange={(newVal) => {
+                                    const oldVal = targetValue;
+                                    if (oldVal && newVal && oldVal !== newVal) {
+                                        const regex = new RegExp(`\\b${oldVal}\\b`);
+                                        if (regex.test(title)) {
+                                            setTitle(title.replace(regex, newVal));
+                                        }
+                                    }
+                                    setTargetValue(newVal);
+                                }}
+                                unit={unit}
+                                milestones={milestoneRows}
+                                onChange={setMilestoneRows}
+                                disabled={isSubmitting}
+                            />
+                        )}
 
-                                    {/* Unit */}
-                                    <div>
-                                        <label className="block text-sm font-medium text-neutral-300 mb-2">
-                                            Unit Label
-                                        </label>
-                                        <input
-                                            type="text"
-                                            value={unit}
-                                            onChange={(e) => setUnit(e.target.value)}
-                                            className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
-                                            placeholder="e.g., books, miles"
-                                        />
-                                    </div>
-                                </>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            {/* Unit (cumulative goals only) */}
+                            {goal.type !== 'onetime' && (
+                                <div>
+                                    <label className="block text-sm font-medium text-neutral-300 mb-2">
+                                        Unit Label
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={unit}
+                                        onChange={(e) => setUnit(e.target.value)}
+                                        className="w-full bg-neutral-800 border border-white/10 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-emerald-500"
+                                        placeholder="e.g., books, miles"
+                                    />
+                                </div>
                             )}
 
                             {/* Deadline */}
-                            <div className={goal.type === 'onetime' ? "sm:col-span-2" : "sm:col-span-2"}>
+                            <div className={goal.type === 'onetime' ? 'sm:col-span-2' : ''}>
                                 <label className="block text-sm font-medium text-neutral-300 mb-2">
                                     {goal.type === 'onetime' ? 'Event Date (Optional)' : 'Deadline (Optional)'}
                                 </label>

--- a/src/components/goals/MilestoneCelebrationModal.tsx
+++ b/src/components/goals/MilestoneCelebrationModal.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { Sparkles, X } from 'lucide-react';
+import { CelebratoryBadgeIcon } from './CelebratoryBadgeIcon';
+import type { PendingMilestone } from '../../store/GoalCompletionContext';
+
+interface MilestoneCelebrationModalProps {
+    milestone: PendingMilestone;
+    onDismiss: () => void;
+}
+
+/**
+ * Full-screen celebration shown when a user crosses an intermediate milestone.
+ * Mirrors the visual language of GoalCompletedPage (badge + sparkles + confetti)
+ * but tailored to a single milestone — no Extend/Repeat actions, just dismiss.
+ */
+export const MilestoneCelebrationModal: React.FC<MilestoneCelebrationModalProps> = ({
+    milestone,
+    onDismiss,
+}) => {
+    const [showConfetti, setShowConfetti] = useState(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => setShowConfetti(false), 3000);
+        return () => clearTimeout(timer);
+    }, []);
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm overflow-hidden">
+            {showConfetti && (
+                <div className="fixed inset-0 pointer-events-none">
+                    {Array.from({ length: 50 }).map((_, i) => (
+                        <div
+                            key={i}
+                            className="absolute milestone-confetti-particle"
+                            style={{
+                                left: `${Math.random() * 100}%`,
+                                top: '-10px',
+                                width: `${Math.random() * 10 + 5}px`,
+                                height: `${Math.random() * 10 + 5}px`,
+                                backgroundColor: ['#10b981', '#f59e0b', '#3b82f6', '#ef4444', '#a855f7'][
+                                    Math.floor(Math.random() * 5)
+                                ],
+                                animationDelay: `${Math.random() * 2}s`,
+                                animationDuration: `${Math.random() * 2 + 2}s`,
+                            }}
+                        />
+                    ))}
+                </div>
+            )}
+
+            <button
+                onClick={onDismiss}
+                aria-label="Dismiss celebration"
+                className="absolute top-6 right-6 min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-300 hover:text-white"
+            >
+                <X size={24} />
+            </button>
+
+            <div className="relative w-full max-w-lg mx-auto px-6 text-center">
+                <div className="mb-8 flex justify-center">
+                    <div className="relative">
+                        <div
+                            className="w-32 h-32 animate-bounce"
+                            style={{ filter: 'drop-shadow(0 0 20px rgba(16, 185, 129, 0.4))' }}
+                        >
+                            <CelebratoryBadgeIcon
+                                goalId={milestone.goalId}
+                                badgeImageUrl={milestone.badgeImageUrl}
+                                size={64}
+                            />
+                        </div>
+                        <Sparkles
+                            className="absolute -top-4 -right-4 text-emerald-400 animate-pulse"
+                            size={40}
+                        />
+                        <Sparkles
+                            className="absolute -bottom-4 -left-4 text-blue-400 animate-pulse"
+                            size={40}
+                            style={{ animationDelay: '0.5s' }}
+                        />
+                    </div>
+                </div>
+
+                <p className="text-sm uppercase tracking-widest text-emerald-400 font-semibold mb-3">
+                    Milestone Reached
+                </p>
+                <h1 className="text-4xl sm:text-5xl font-bold text-white mb-3">
+                    {milestone.value}
+                    {milestone.unit ? ` ${milestone.unit}` : ''}
+                </h1>
+                <p className="text-lg text-neutral-300 mb-8">
+                    on your way to <span className="text-emerald-400 font-semibold">{milestone.goalTitle}</span>
+                </p>
+
+                <button
+                    onClick={onDismiss}
+                    className="px-8 py-3 bg-emerald-500 hover:bg-emerald-400 text-neutral-900 font-semibold rounded-lg transition-colors"
+                >
+                    Keep Going
+                </button>
+            </div>
+
+            <style>{`
+                @keyframes milestone-confetti-fall {
+                    0% { transform: translateY(0) rotate(0deg); opacity: 1; }
+                    100% { transform: translateY(100dvh) rotate(720deg); opacity: 0; }
+                }
+                .milestone-confetti-particle {
+                    animation: milestone-confetti-fall linear forwards;
+                    border-radius: 2px;
+                }
+            `}</style>
+        </div>
+    );
+};

--- a/src/components/goals/MilestoneRowList.tsx
+++ b/src/components/goals/MilestoneRowList.tsx
@@ -1,0 +1,316 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    verticalListSortingStrategy,
+    useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Trash2, Plus } from 'lucide-react';
+
+export interface MilestoneRow {
+    /** Local-only id used for React keys and dnd-kit. Distinct from server-assigned `Goal.milestones[i].id`. */
+    rowKey: string;
+    /** Optional server-assigned id, present only when editing an existing goal. */
+    serverId?: string;
+    valueText: string;
+}
+
+export interface MilestoneRowListProps {
+    targetValueText: string;
+    onTargetChange: (next: string) => void;
+    unit: string;
+    milestones: MilestoneRow[];
+    onChange: (next: MilestoneRow[]) => void;
+    /** Disable interactivity — used during submission. */
+    disabled?: boolean;
+    /** Maximum number of intermediate milestones (excludes the Final Goal row). */
+    maxMilestones?: number;
+}
+
+const DEFAULT_MAX = 20;
+
+interface RowProps {
+    row: MilestoneRow;
+    index: number;
+    unit: string;
+    invalid: boolean;
+    onValueChange: (value: string) => void;
+    onValueBlur: () => void;
+    onRemove: () => void;
+    disabled: boolean;
+}
+
+const SortableMilestoneRow: React.FC<RowProps> = ({
+    row,
+    index,
+    unit,
+    invalid,
+    onValueChange,
+    onValueBlur,
+    onRemove,
+    disabled,
+}) => {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: row.rowKey,
+        disabled,
+    });
+
+    const style: React.CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className="flex items-center gap-3 py-2"
+        >
+            <button
+                type="button"
+                {...attributes}
+                {...listeners}
+                aria-label={`Reorder milestone ${index + 1}`}
+                className="text-neutral-500 hover:text-neutral-300 cursor-grab disabled:cursor-not-allowed"
+                disabled={disabled}
+            >
+                <GripVertical size={16} />
+            </button>
+
+            <input
+                type="number"
+                inputMode="decimal"
+                value={row.valueText}
+                onChange={(e) => onValueChange(e.target.value)}
+                onBlur={onValueBlur}
+                disabled={disabled}
+                className={`w-24 bg-neutral-900/50 border rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-1 transition-all ${
+                    invalid
+                        ? 'border-red-500/50 focus:border-red-500/70 focus:ring-red-500/30'
+                        : 'border-white/10 focus:border-emerald-500/50 focus:ring-emerald-500/50'
+                }`}
+                min="0"
+                step="any"
+                placeholder="e.g., 25"
+            />
+
+            <span className="flex-1 text-neutral-400 text-sm truncate">
+                {unit || ' '}
+            </span>
+
+            <span className="text-neutral-500 text-sm whitespace-nowrap">
+                Milestone {index + 1}
+            </span>
+
+            <button
+                type="button"
+                onClick={onRemove}
+                disabled={disabled}
+                aria-label={`Remove milestone ${index + 1}`}
+                className="text-neutral-500 hover:text-red-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+                <Trash2 size={16} />
+            </button>
+        </div>
+    );
+};
+
+let nextRowKeySeed = 0;
+export function makeMilestoneRowKey(): string {
+    nextRowKeySeed += 1;
+    return `ms-row-${Date.now()}-${nextRowKeySeed}`;
+}
+
+export const MilestoneRowList: React.FC<MilestoneRowListProps> = ({
+    targetValueText,
+    onTargetChange,
+    unit,
+    milestones,
+    onChange,
+    disabled = false,
+    maxMilestones = DEFAULT_MAX,
+}) => {
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
+
+    const targetValueNum = useMemo(() => {
+        const n = parseFloat(targetValueText);
+        return Number.isFinite(n) ? n : null;
+    }, [targetValueText]);
+
+    const finalGoalCount = useMemo(() => {
+        return milestones.length + 1; // intermediate + final goal
+    }, [milestones.length]);
+
+    const valueValidity = useMemo(() => {
+        return milestones.map((row) => {
+            const v = parseFloat(row.valueText);
+            if (row.valueText.trim() === '' || !Number.isFinite(v)) return { valid: false, parsed: null as number | null };
+            if (v <= 0) return { valid: false, parsed: v };
+            if (targetValueNum !== null && v >= targetValueNum) return { valid: false, parsed: v };
+            return { valid: true, parsed: v };
+        });
+    }, [milestones, targetValueNum]);
+
+    const duplicateValues = useMemo(() => {
+        const seen = new Map<number, number>();
+        const dupes = new Set<number>();
+        valueValidity.forEach(({ parsed }, idx) => {
+            if (parsed === null) return;
+            if (seen.has(parsed)) {
+                dupes.add(idx);
+                dupes.add(seen.get(parsed)!);
+            } else {
+                seen.set(parsed, idx);
+            }
+        });
+        return dupes;
+    }, [valueValidity]);
+
+    const handleValueChange = useCallback(
+        (index: number, value: string) => {
+            const next = milestones.slice();
+            next[index] = { ...next[index], valueText: value };
+            onChange(next);
+        },
+        [milestones, onChange],
+    );
+
+    const sortAscending = useCallback(() => {
+        const sorted = milestones.slice().sort((a, b) => {
+            const av = parseFloat(a.valueText);
+            const bv = parseFloat(b.valueText);
+            const aValid = Number.isFinite(av);
+            const bValid = Number.isFinite(bv);
+            if (!aValid && !bValid) return 0;
+            if (!aValid) return 1; // empty rows sink to bottom
+            if (!bValid) return -1;
+            return av - bv;
+        });
+        // Skip onChange if order didn't change to avoid render loops
+        const sameOrder = sorted.every((row, i) => row.rowKey === milestones[i].rowKey);
+        if (!sameOrder) onChange(sorted);
+    }, [milestones, onChange]);
+
+    const handleRemove = useCallback(
+        (index: number) => {
+            const next = milestones.slice();
+            next.splice(index, 1);
+            onChange(next);
+        },
+        [milestones, onChange],
+    );
+
+    const handleAdd = useCallback(() => {
+        if (milestones.length >= maxMilestones) return;
+        onChange([...milestones, { rowKey: makeMilestoneRowKey(), valueText: '' }]);
+    }, [milestones, onChange, maxMilestones]);
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            const { active, over } = event;
+            if (!over || active.id === over.id) return;
+            const oldIndex = milestones.findIndex((m) => m.rowKey === active.id);
+            const newIndex = milestones.findIndex((m) => m.rowKey === over.id);
+            if (oldIndex === -1 || newIndex === -1) return;
+            onChange(arrayMove(milestones, oldIndex, newIndex));
+        },
+        [milestones, onChange],
+    );
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-baseline justify-between">
+                <label className="block text-sm font-medium text-neutral-400">Milestones</label>
+                <div className="text-xs text-neutral-500">
+                    {milestones.length === 0
+                        ? 'No intermediate milestones'
+                        : `${milestones.length} ${milestones.length === 1 ? 'milestone' : 'milestones'}`}
+                    {' · '}
+                    Final goal: {' '}
+                    <span className="text-emerald-400">
+                        {targetValueText.trim() || '—'}
+                        {unit ? ` ${unit}` : ''}
+                    </span>
+                </div>
+            </div>
+
+            <div className="rounded-xl border border-white/10 bg-neutral-900/40 px-3 py-1 divide-y divide-white/5">
+                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                    <SortableContext
+                        items={milestones.map((m) => m.rowKey)}
+                        strategy={verticalListSortingStrategy}
+                    >
+                        {milestones.map((row, idx) => (
+                            <SortableMilestoneRow
+                                key={row.rowKey}
+                                row={row}
+                                index={idx}
+                                unit={unit}
+                                invalid={!valueValidity[idx].valid || duplicateValues.has(idx)}
+                                onValueChange={(v) => handleValueChange(idx, v)}
+                                onValueBlur={sortAscending}
+                                onRemove={() => handleRemove(idx)}
+                                disabled={disabled}
+                            />
+                        ))}
+                    </SortableContext>
+                </DndContext>
+
+                {/* Final Goal row (pinned, derived from targetValueText) */}
+                <div className="flex items-center gap-3 py-2">
+                    <span className="w-4" aria-hidden />
+                    <input
+                        type="number"
+                        inputMode="decimal"
+                        value={targetValueText}
+                        onChange={(e) => onTargetChange(e.target.value)}
+                        disabled={disabled}
+                        className="w-24 bg-neutral-900/50 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50 transition-all"
+                        min="0.01"
+                        step="any"
+                        placeholder="e.g., 100"
+                        aria-label="Final goal target value"
+                    />
+                    <span className="flex-1 text-neutral-400 text-sm truncate">{unit || ' '}</span>
+                    <span className="px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-400 text-xs font-medium whitespace-nowrap">
+                        Final Goal
+                    </span>
+                    <span className="w-4" aria-hidden />
+                </div>
+            </div>
+
+            <button
+                type="button"
+                onClick={handleAdd}
+                onBlur={sortAscending}
+                disabled={disabled || milestones.length >= maxMilestones}
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 border border-dashed border-white/15 rounded-xl text-neutral-300 hover:bg-neutral-800/30 hover:border-emerald-500/40 hover:text-emerald-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Add milestone"
+            >
+                <Plus size={18} />
+                <span className="font-medium">Add Milestone</span>
+                {milestones.length >= maxMilestones && (
+                    <span className="text-xs text-neutral-500 ml-2">(max {maxMilestones})</span>
+                )}
+            </button>
+
+            {/* Final goal row included in the count summary */}
+            <p className="sr-only">{finalGoalCount} stages including final goal</p>
+        </div>
+    );
+};

--- a/src/components/goals/achievements/MilestoneNodes.tsx
+++ b/src/components/goals/achievements/MilestoneNodes.tsx
@@ -1,26 +1,40 @@
 import React from 'react';
 
 interface MilestoneNodesProps {
-    /** Each entry is one node label (e.g. [25, 50, 100]). All nodes are rendered as completed. */
+    /** Each entry is one node label (e.g. [25, 50, 100]). */
     targets: number[];
+    /**
+     * Optional parallel array of completion flags. When omitted, every node is
+     * rendered as completed (used by iteration-chain history). When provided,
+     * incomplete nodes are rendered as outlined placeholders.
+     */
+    completed?: boolean[];
 }
 
-export const MilestoneNodes: React.FC<MilestoneNodesProps> = ({ targets }) => {
+export const MilestoneNodes: React.FC<MilestoneNodesProps> = ({ targets, completed }) => {
     if (targets.length === 0) return null;
 
     return (
         <div className="flex items-center w-full" role="list" aria-label="Milestone targets">
             {targets.map((value, idx) => {
                 const isLast = idx === targets.length - 1;
+                const isCompleted = completed ? completed[idx] !== false : true;
+                const nodeClass = isCompleted
+                    ? 'bg-emerald-500/15 border-emerald-500 text-emerald-400'
+                    : 'bg-transparent border-emerald-500/30 text-emerald-500/50';
+                const connectorClass = isCompleted
+                    ? 'bg-emerald-500/40'
+                    : 'bg-emerald-500/15';
                 return (
                     <React.Fragment key={`${idx}-${value}`}>
                         <div
                             role="listitem"
-                            className="flex-shrink-0 w-7 h-7 rounded-full bg-emerald-500/15 border-2 border-emerald-500 text-emerald-400 text-[10px] font-semibold flex items-center justify-center"
+                            aria-label={`Milestone ${value}${isCompleted ? ' (completed)' : ''}`}
+                            className={`flex-shrink-0 w-7 h-7 rounded-full border-2 text-[10px] font-semibold flex items-center justify-center transition-colors ${nodeClass}`}
                         >
                             {value}
                         </div>
-                        {!isLast && <div className="flex-1 h-px bg-emerald-500/40 mx-1" aria-hidden />}
+                        {!isLast && <div className={`flex-1 h-px mx-1 ${connectorClass}`} aria-hidden />}
                     </React.Fragment>
                 );
             })}

--- a/src/components/goals/achievements/ProgressiveAchievementCard.tsx
+++ b/src/components/goals/achievements/ProgressiveAchievementCard.tsx
@@ -9,6 +9,13 @@ interface ProgressiveAchievementCardProps {
     chain: IterationChain;
     onClick?: (goalId: string) => void;
     animationDelayMs?: number;
+    /**
+     * Optional parallel array of completion flags for each node in `chain.targets`.
+     * Used by milestone-bearing goals where some milestones may not yet be reached.
+     * For iteration chains (the original use case), omit this — all nodes render
+     * as completed.
+     */
+    completed?: boolean[];
 }
 
 function formatCompletedDate(completedAt: string): string {
@@ -23,6 +30,7 @@ export const ProgressiveAchievementCard: React.FC<ProgressiveAchievementCardProp
     chain,
     onClick,
     animationDelayMs,
+    completed,
 }) => {
     const { head, targets } = chain;
     const milestoneLabel = head.targetValue
@@ -57,7 +65,7 @@ export const ProgressiveAchievementCard: React.FC<ProgressiveAchievementCardProp
                 </div>
             </div>
             <div className="px-1 sm:px-2">
-                <MilestoneNodes targets={targets} />
+                <MilestoneNodes targets={targets} completed={completed} />
             </div>
             {head.completedAt && (
                 <div className="flex items-center justify-end gap-1 mt-3 text-neutral-500 text-[10px] sm:text-xs">

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -968,6 +968,19 @@ export async function updateGoal(
 }
 
 /**
+ * Acknowledge a goal milestone — marks the celebration as dismissed so it
+ * doesn't replay on reload.
+ */
+export async function acknowledgeMilestone(goalId: string, milestoneId: string): Promise<Goal> {
+  const response = await apiRequest<{ goal: Goal }>(
+    `/goals/${goalId}/milestones/${milestoneId}/acknowledge`,
+    { method: 'POST' },
+  );
+  invalidateGoalCaches(goalId);
+  return response.goal;
+}
+
+/**
  * Mark a goal as completed by setting completedAt to the current timestamp.
  * 
  * @param id - Goal ID

--- a/src/lib/useMilestoneCelebrationWatcher.ts
+++ b/src/lib/useMilestoneCelebrationWatcher.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useGoalsWithProgress } from './useGoalsWithProgress';
+import { useGoalCompletion, type PendingMilestone } from '../store/GoalCompletionContext';
+
+/**
+ * Watches goals-with-progress for milestones that have been crossed but never
+ * acknowledged, and enqueues them as celebrations. The context dedupes by
+ * milestoneId so re-fetches before the server-side acknowledgedAt arrives don't
+ * re-trigger.
+ */
+export function useMilestoneCelebrationWatcher(): void {
+    const { data: goalsWithProgress } = useGoalsWithProgress();
+    const { enqueuePendingMilestones } = useGoalCompletion();
+
+    useEffect(() => {
+        if (!goalsWithProgress || goalsWithProgress.length === 0) return;
+
+        const pending: PendingMilestone[] = [];
+        for (const { goal, progress } of goalsWithProgress) {
+            const states = progress.milestoneStates;
+            if (!states || states.length === 0) continue;
+            const milestonesById = new Map((goal.milestones ?? []).map((m) => [m.id, m]));
+            for (const state of states) {
+                if (!state.completed) continue;
+                if (state.acknowledgedAt) continue;
+                if (milestonesById.get(state.id)?.acknowledgedAt) continue;
+                pending.push({
+                    goalId: goal.id,
+                    milestoneId: state.id,
+                    value: state.value,
+                    unit: goal.unit,
+                    goalTitle: goal.title,
+                    badgeImageUrl: goal.badgeImageUrl,
+                });
+            }
+        }
+
+        if (pending.length > 0) {
+            enqueuePendingMilestones(pending);
+        }
+    }, [goalsWithProgress, enqueuePendingMilestones]);
+}

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -1104,6 +1104,32 @@ export interface Goal {
      * and for goals iterated before this field existed (legacy data).
      */
     iteratedFromGoalId?: string;
+
+    /**
+     * Optional intermediate stages for cumulative goals. Each milestone is a
+     * checkpoint value strictly less than `targetValue`; completion is derived
+     * from HabitEntries (see `computeMilestoneStates`). Only milestone
+     * configuration and the `acknowledgedAt` celebration marker are stored.
+     * Server normalizes to ascending order by `value`. Only valid when
+     * `type === 'cumulative'`.
+     */
+    milestones?: GoalMilestone[];
+}
+
+/**
+ * Intermediate stage within a cumulative goal. Completion is derived; only
+ * `acknowledgedAt` is stored, mirroring how `Goal.completedAt` is stored to
+ * keep the celebration screen idempotent.
+ */
+export interface GoalMilestone {
+    /** Server-assigned UUID */
+    id: string;
+
+    /** Threshold value (must be > 0 and < parent Goal.targetValue) */
+    value: number;
+
+    /** ISO 8601 timestamp set when the user dismisses the milestone celebration */
+    acknowledgedAt?: string;
 }
 
 /** Goals stored as an array */
@@ -1195,6 +1221,34 @@ export interface GoalProgress {
 
     /** Whether the goal has an inactivity warning (≥4 days with no progress in last 7 days) */
     inactivityWarning: boolean;
+
+    /**
+     * Derived state for each configured milestone, ordered to match
+     * `Goal.milestones`. Present only when the goal has milestones.
+     * `completedAtDayKey` is populated only by the full-progress path.
+     */
+    milestoneStates?: MilestoneState[];
+}
+
+/**
+ * Derived state for a single milestone. Completion is computed at read time
+ * from HabitEntries; only `acknowledgedAt` is stored on the parent goal.
+ */
+export interface MilestoneState {
+    /** Matches `GoalMilestone.id` */
+    id: string;
+
+    /** Threshold value (mirrored from `GoalMilestone.value` for client convenience) */
+    value: number;
+
+    /** True when the running cumulative has crossed `value` */
+    completed: boolean;
+
+    /** First dayKey at which `running >= value`. Only set on the full-progress path. */
+    completedAtDayKey?: string;
+
+    /** Mirrored from `GoalMilestone.acknowledgedAt` */
+    acknowledgedAt?: string;
 }
 
 /**

--- a/src/pages/goals/WinArchivePage.tsx
+++ b/src/pages/goals/WinArchivePage.tsx
@@ -3,7 +3,7 @@ import { Trophy, Star, TrendingUp, Flag, Loader2, AlertCircle } from 'lucide-rea
 import { useCompletedGoals } from '../../lib/useCompletedGoals';
 import { useGoalsWithProgress } from '../../lib/useGoalsWithProgress';
 import { useGoalTracks } from '../../lib/useGoalTracks';
-import { buildIterationChains } from '../../utils/goalIterationChains';
+import { buildIterationChains, type IterationChain } from '../../utils/goalIterationChains';
 import { AchievementSectionHeader } from '../../components/goals/achievements/AchievementSectionHeader';
 import { SingleAchievementCard } from '../../components/goals/achievements/SingleAchievementCard';
 import { ProgressiveAchievementCard } from '../../components/goals/achievements/ProgressiveAchievementCard';
@@ -26,7 +26,7 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
     const [singleExpanded, setSingleExpanded] = useState(false);
     const [progressiveExpanded, setProgressiveExpanded] = useState(false);
 
-    const { singleGoals, progressiveChains, trackRows } = useMemo(() => {
+    const { singleGoals, progressiveChains, milestoneCards, trackRows } = useMemo(() => {
         const goals = completedGoals ?? [];
         const single = goals
             .filter(g => g.completedAt && !g.trackId && g.type === 'onetime')
@@ -34,6 +34,40 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
 
         const progressiveCandidates = goals.filter(g => g.completedAt && !g.trackId && g.type === 'cumulative');
         const progressive = buildIterationChains(progressiveCandidates);
+
+        // Surface in-progress cumulative goals that have crossed at least one
+        // milestone. Each appears as a Progressive-style card whose nodes are
+        // the milestone values + the final target, with completion flags.
+        type MilestoneCard = { chain: IterationChain; completed: boolean[] };
+        const milestone: MilestoneCard[] = [];
+        for (const gp of activeGoalsWithProgress ?? []) {
+            const { goal, progress } = gp;
+            if (goal.trackId) continue;
+            if (goal.type !== 'cumulative') continue;
+            const ms = goal.milestones ?? [];
+            if (ms.length === 0) continue;
+            const states = progress.milestoneStates ?? [];
+            const anyCompleted = states.some(s => s.completed);
+            if (!anyCompleted) continue;
+
+            const sorted = ms.slice().sort((a, b) => a.value - b.value);
+            const target = goal.targetValue ?? 0;
+            const targets = [...sorted.map(m => m.value), target];
+            const stateById = new Map(states.map(s => [s.id, s]));
+            const completedFlags = [
+                ...sorted.map(m => stateById.get(m.id)?.completed === true),
+                !!goal.completedAt,
+            ];
+            milestone.push({
+                chain: { head: goal, goals: [goal], targets },
+                completed: completedFlags,
+            });
+        }
+        milestone.sort((a, b) => {
+            const at = a.chain.head.completedAt ?? a.chain.head.createdAt;
+            const bt = b.chain.head.completedAt ?? b.chain.head.createdAt;
+            return (bt ?? '').localeCompare(at ?? '');
+        });
 
         // Track rows include both completed and not-yet-completed (active/locked)
         // goals so the user can see the full track progression with greyed-out
@@ -67,11 +101,11 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
                 return bt.localeCompare(at);
             });
 
-        return { singleGoals: single, progressiveChains: progressive, trackRows: rows };
+        return { singleGoals: single, progressiveChains: progressive, milestoneCards: milestone, trackRows: rows };
     }, [completedGoals, tracks, activeGoalsWithProgress]);
 
     const loading = completedLoading || tracksLoading || activeGoalsLoading;
-    const hasAnyAchievements = singleGoals.length > 0 || progressiveChains.length > 0 || trackRows.length > 0;
+    const hasAnyAchievements = singleGoals.length > 0 || progressiveChains.length > 0 || milestoneCards.length > 0 || trackRows.length > 0;
 
     if (loading && !completedGoals) {
         return (
@@ -104,6 +138,7 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
 
     const visibleSingles = singleExpanded ? singleGoals : singleGoals.slice(0, SINGLE_PREVIEW_LIMIT);
     const visibleProgressives = progressiveExpanded ? progressiveChains : progressiveChains.slice(0, PROGRESSIVE_PREVIEW_LIMIT);
+    const hasProgressiveContent = progressiveChains.length > 0 || milestoneCards.length > 0;
 
     return (
         <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
@@ -163,8 +198,8 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
                             onViewAll={() => setProgressiveExpanded(v => !v)}
                             viewAllLabel={progressiveExpanded ? 'Show less' : 'View all'}
                         />
-                        {progressiveChains.length === 0 ? (
-                            <p className="text-xs sm:text-sm text-neutral-500 italic pl-1">Complete a cumulative goal to see it here.</p>
+                        {!hasProgressiveContent ? (
+                            <p className="text-xs sm:text-sm text-neutral-500 italic pl-1">Complete a cumulative goal or cross a milestone to see it here.</p>
                         ) : (
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
                                 {visibleProgressives.map((chain, idx) => (
@@ -173,6 +208,15 @@ export const WinArchivePage: React.FC<WinArchivePageProps> = ({ onViewGoal, onVi
                                         chain={chain}
                                         onClick={onViewGoal}
                                         animationDelayMs={idx * 40}
+                                    />
+                                ))}
+                                {milestoneCards.map(({ chain, completed }, idx) => (
+                                    <ProgressiveAchievementCard
+                                        key={`milestone-${chain.head.id}`}
+                                        chain={chain}
+                                        completed={completed}
+                                        onClick={onViewGoal}
+                                        animationDelayMs={(visibleProgressives.length + idx) * 40}
                                     />
                                 ))}
                             </div>

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -15,7 +15,7 @@ import { getWellbeingEntriesRoute, upsertWellbeingEntriesRoute, deleteWellbeingE
 import { seedDemoEmotionalWellbeingRoute, resetDemoEmotionalWellbeingRoute } from './routes/devDemoEmotionalWellbeing';
 import { getRoutinesRoute, getRoutineRoute, createRoutineRoute, updateRoutineRoute, deleteRoutineRoute, submitRoutineRoute, uploadRoutineImageRoute, uploadRoutineImageMiddleware, getRoutineImageRoute, deleteRoutineImageRoute } from './routes/routines';
 import { getRoutineLogs } from './routes/routineLogs';
-import { getGoals, getGoal, getGoalProgress, getGoalsWithProgress, getCompletedGoals, createGoalRoute, updateGoalRoute, deleteGoalRoute, reorderGoalsRoute, getGoalDetailRoute } from './routes/goals';
+import { getGoals, getGoal, getGoalProgress, getGoalsWithProgress, getCompletedGoals, createGoalRoute, updateGoalRoute, deleteGoalRoute, reorderGoalsRoute, getGoalDetailRoute, acknowledgeMilestoneRoute } from './routes/goals';
 import { getGoalTracks, createGoalTrackRoute, getGoalTrackRoute, updateGoalTrackRoute, deleteGoalTrackRoute, addGoalToTrack, removeGoalFromTrack, reorderTrackGoals, reorderGoalTracksRoute } from './routes/goalTracks';
 import { getProgressOverview } from './routes/progress';
 import { getIntegrityReport, dedupHabits, recoverHabits, remapOrphanedCategories } from './routes/admin';
@@ -195,6 +195,7 @@ export function createApp(): Express {
   app.get('/api/goals/:id', getGoal);
   app.put('/api/goals/:id', updateGoalRoute);
   app.delete('/api/goals/:id', deleteGoalRoute);
+  app.post('/api/goals/:id/milestones/:milestoneId/acknowledge', acknowledgeMilestoneRoute);
   app.get('/api/goal-tracks', getGoalTracks);
   app.post('/api/goal-tracks', createGoalTrackRoute);
   app.patch('/api/goal-tracks/reorder', reorderGoalTracksRoute);

--- a/src/server/routes/__tests__/goals.create.test.ts
+++ b/src/server/routes/__tests__/goals.create.test.ts
@@ -172,4 +172,149 @@ describe('Goal Create Routes', () => {
             expect(response.body.error.message).toMatch(/countMode/);
         });
     });
+
+    describe('POST /api/goals - Milestones', () => {
+        it('should create a cumulative goal with valid milestones', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: '100 Pull-Ups',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    unit: 'pull-ups',
+                    linkedHabitIds: [],
+                    milestones: [{ value: 25 }, { value: 50 }, { value: 75 }],
+                })
+                .expect(201);
+
+            expect(response.body.goal.milestones).toHaveLength(3);
+            expect(response.body.goal.milestones.map((m: { value: number }) => m.value)).toEqual([25, 50, 75]);
+            for (const milestone of response.body.goal.milestones) {
+                expect(typeof milestone.id).toBe('string');
+                expect(milestone.id.length).toBeGreaterThan(0);
+                expect(milestone.acknowledgedAt).toBeUndefined();
+            }
+        });
+
+        it('should normalize milestones into ascending order', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Sorted',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: [{ value: 75 }, { value: 25 }, { value: 50 }],
+                })
+                .expect(201);
+
+            expect(response.body.goal.milestones.map((m: { value: number }) => m.value)).toEqual([25, 50, 75]);
+        });
+
+        it('should drop client-supplied acknowledgedAt on create', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Fresh Goal',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: [{ value: 25, acknowledgedAt: '2025-01-01T00:00:00.000Z' }],
+                })
+                .expect(201);
+
+            expect(response.body.goal.milestones[0].acknowledgedAt).toBeUndefined();
+        });
+
+        it('should accept an empty milestones array', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'No milestones',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: [],
+                })
+                .expect(201);
+
+            expect(response.body.goal.milestones).toEqual([]);
+        });
+
+        it('should reject milestones on a onetime goal', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Bad onetime',
+                    type: 'onetime',
+                    targetValue: 1,
+                    linkedHabitIds: [],
+                    milestones: [{ value: 1 }],
+                })
+                .expect(400);
+
+            expect(response.body.error.message).toMatch(/cumulative/);
+        });
+
+        it('should reject duplicate milestone values', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Dups',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: [{ value: 25 }, { value: 25 }],
+                })
+                .expect(400);
+
+            expect(response.body.error.message).toMatch(/unique/);
+        });
+
+        it('should reject milestone values >= targetValue', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Over',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: [{ value: 100 }],
+                })
+                .expect(400);
+
+            expect(response.body.error.message).toMatch(/less than targetValue/);
+        });
+
+        it('should reject more than 20 milestones', async () => {
+            const tooMany = Array.from({ length: 21 }, (_, i) => ({ value: i + 1 }));
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Too many',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: tooMany,
+                })
+                .expect(400);
+
+            expect(response.body.error.message).toMatch(/at most 20/);
+        });
+
+        it('should reject non-positive milestone values', async () => {
+            const response = await request(app)
+                .post('/api/goals')
+                .send({
+                    title: 'Zero',
+                    type: 'cumulative',
+                    targetValue: 100,
+                    linkedHabitIds: [],
+                    milestones: [{ value: 0 }],
+                })
+                .expect(400);
+
+            expect(response.body.error.message).toMatch(/positive/);
+        });
+    });
 });

--- a/src/server/routes/__tests__/goals.milestones.update.test.ts
+++ b/src/server/routes/__tests__/goals.milestones.update.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for milestone configuration on PUT /goals/:id.
+ *
+ * Covers:
+ * - Replacing the milestones array
+ * - Clearing milestones via empty array
+ * - Preserving acknowledgedAt on existing milestones across PUT-replace
+ * - Rejecting type change to onetime when milestones are present
+ * - Rejecting targetValue lowered below an existing milestone
+ * - Rejecting milestones added on a onetime goal
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import { updateGoalRoute } from '../goals';
+import { createGoal, getGoalById, updateGoal } from '../../repositories/goalRepository';
+import { MONGO_COLLECTIONS } from '../../../models/persistenceTypes';
+
+const HOUSEHOLD = 'test-household-goals-milestones';
+const USER = 'test-user-goals-milestones';
+
+let app: Express;
+
+describe('PUT /api/goals/:id — milestones', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).householdId = HOUSEHOLD;
+      (req as any).userId = USER;
+      next();
+    });
+    app.put('/api/goals/:id', updateGoalRoute);
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await db.collection(MONGO_COLLECTIONS.GOALS).deleteMany({ householdId: HOUSEHOLD, userId: USER });
+  });
+
+  async function makeCumulativeGoal(milestones?: Array<{ id: string; value: number; acknowledgedAt?: string }>) {
+    return createGoal(
+      {
+        title: '100 Pull-Ups',
+        type: 'cumulative',
+        targetValue: 100,
+        linkedHabitIds: [],
+        ...(milestones ? { milestones } : {}),
+      },
+      HOUSEHOLD,
+      USER,
+    );
+  }
+
+  it('replaces the milestones array on PUT', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm-old', value: 30 }]);
+
+    const res = await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ milestones: [{ value: 25 }, { value: 50 }, { value: 75 }] })
+      .expect(200);
+
+    expect(res.body.goal.milestones).toHaveLength(3);
+    expect(res.body.goal.milestones.map((m: { value: number }) => m.value)).toEqual([25, 50, 75]);
+  });
+
+  it('clears milestones when given an empty array', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm1', value: 25 }, { id: 'm2', value: 50 }]);
+
+    await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ milestones: [] })
+      .expect(200);
+
+    const persisted = await getGoalById(goal.id, HOUSEHOLD, USER);
+    expect(persisted?.milestones).toEqual([]);
+  });
+
+  it('preserves acknowledgedAt across PUT-replace by id', async () => {
+    const ackTime = '2025-04-15T12:00:00.000Z';
+    const goal = await makeCumulativeGoal([
+      { id: 'm-25', value: 25, acknowledgedAt: ackTime },
+      { id: 'm-50', value: 50 },
+    ]);
+
+    // Frontend re-sends milestones without acknowledgedAt — server merges from existing.
+    const res = await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({
+        milestones: [
+          { id: 'm-25', value: 25 },
+          { id: 'm-50', value: 50 },
+          { value: 75 },
+        ],
+      })
+      .expect(200);
+
+    const ms = res.body.goal.milestones;
+    expect(ms.find((m: { id: string }) => m.id === 'm-25').acknowledgedAt).toBe(ackTime);
+    expect(ms.find((m: { id: string }) => m.id === 'm-50').acknowledgedAt).toBeUndefined();
+    expect(ms.find((m: { value: number }) => m.value === 75).id).toBeDefined();
+  });
+
+  it('drops acknowledgedAt for milestones removed from the array', async () => {
+    const goal = await makeCumulativeGoal([
+      { id: 'm-25', value: 25, acknowledgedAt: '2025-04-15T00:00:00.000Z' },
+      { id: 'm-50', value: 50 },
+    ]);
+
+    await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ milestones: [{ id: 'm-50', value: 50 }] })
+      .expect(200);
+
+    const persisted = await getGoalById(goal.id, HOUSEHOLD, USER);
+    expect(persisted?.milestones).toHaveLength(1);
+    expect(persisted?.milestones?.[0].id).toBe('m-50');
+  });
+
+  it('rejects switching to onetime when milestones are present', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm', value: 50 }]);
+
+    const res = await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ type: 'onetime' })
+      .expect(400);
+
+    expect(res.body.error.message).toMatch(/Clear milestones first/);
+  });
+
+  it('allows switching to onetime when milestones are simultaneously cleared', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm', value: 50 }]);
+
+    await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ type: 'onetime', milestones: [] })
+      .expect(200);
+  });
+
+  it('rejects targetValue lowered below an existing milestone', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm', value: 75 }]);
+
+    const res = await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ targetValue: 60 })
+      .expect(400);
+
+    expect(res.body.error.message).toMatch(/below existing milestone/);
+  });
+
+  it('allows targetValue change when milestones are simultaneously adjusted', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm', value: 75 }]);
+
+    await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ targetValue: 60, milestones: [{ value: 30 }] })
+      .expect(200);
+  });
+
+  it('returns 404 when updating milestones on a non-existent goal', async () => {
+    await request(app)
+      .put('/api/goals/does-not-exist')
+      .send({ milestones: [{ value: 25 }] })
+      .expect(404);
+  });
+
+  it('rejects milestones on an existing onetime goal', async () => {
+    const goal = await createGoal(
+      {
+        title: 'Pass Exam',
+        type: 'onetime',
+        linkedHabitIds: [],
+      },
+      HOUSEHOLD,
+      USER,
+    );
+
+    const res = await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ milestones: [{ value: 1 }] })
+      .expect(400);
+
+    expect(res.body.error.message).toMatch(/cumulative/);
+  });
+
+  it('normalizes milestones to ascending order on PUT', async () => {
+    const goal = await makeCumulativeGoal();
+
+    const res = await request(app)
+      .put(`/api/goals/${goal.id}`)
+      .send({ milestones: [{ value: 75 }, { value: 25 }, { value: 50 }] })
+      .expect(200);
+
+    expect(res.body.goal.milestones.map((m: { value: number }) => m.value)).toEqual([25, 50, 75]);
+  });
+
+  // Touch updateGoal so the import is used (silences noUnusedVars in some configs).
+  it('preserves milestones on a no-op direct update', async () => {
+    const goal = await makeCumulativeGoal([{ id: 'm', value: 25 }]);
+    const updated = await updateGoal(goal.id, HOUSEHOLD, USER, { notes: 'test' });
+    expect(updated?.milestones).toHaveLength(1);
+  });
+});

--- a/src/server/routes/__tests__/goals.milestones.update.test.ts
+++ b/src/server/routes/__tests__/goals.milestones.update.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
-import { updateGoalRoute } from '../goals';
+import { updateGoalRoute, acknowledgeMilestoneRoute } from '../goals';
 import { createGoal, getGoalById, updateGoal } from '../../repositories/goalRepository';
 import { MONGO_COLLECTIONS } from '../../../models/persistenceTypes';
 
@@ -35,6 +35,7 @@ describe('PUT /api/goals/:id — milestones', () => {
       next();
     });
     app.put('/api/goals/:id', updateGoalRoute);
+    app.post('/api/goals/:id/milestones/:milestoneId/acknowledge', acknowledgeMilestoneRoute);
   });
 
   afterAll(async () => {
@@ -207,5 +208,60 @@ describe('PUT /api/goals/:id — milestones', () => {
     const goal = await makeCumulativeGoal([{ id: 'm', value: 25 }]);
     const updated = await updateGoal(goal.id, HOUSEHOLD, USER, { notes: 'test' });
     expect(updated?.milestones).toHaveLength(1);
+  });
+
+  describe('POST /api/goals/:id/milestones/:milestoneId/acknowledge', () => {
+    it('sets acknowledgedAt on the matching milestone', async () => {
+      const goal = await makeCumulativeGoal([
+        { id: 'm-25', value: 25 },
+        { id: 'm-50', value: 50 },
+      ]);
+
+      const before = Date.now();
+      const res = await request(app)
+        .post(`/api/goals/${goal.id}/milestones/m-25/acknowledge`)
+        .expect(200);
+      const after = Date.now();
+
+      const ack = res.body.goal.milestones.find((m: { id: string }) => m.id === 'm-25');
+      expect(ack.acknowledgedAt).toBeDefined();
+      const ackTime = Date.parse(ack.acknowledgedAt);
+      expect(ackTime).toBeGreaterThanOrEqual(before);
+      expect(ackTime).toBeLessThanOrEqual(after);
+
+      // Other milestones untouched
+      const other = res.body.goal.milestones.find((m: { id: string }) => m.id === 'm-50');
+      expect(other.acknowledgedAt).toBeUndefined();
+    });
+
+    it('is idempotent — preserves the original acknowledgedAt on repeat call', async () => {
+      const goal = await makeCumulativeGoal([{ id: 'm', value: 25 }]);
+
+      const first = await request(app)
+        .post(`/api/goals/${goal.id}/milestones/m/acknowledge`)
+        .expect(200);
+      const firstAck = first.body.goal.milestones[0].acknowledgedAt;
+      expect(firstAck).toBeDefined();
+
+      // Second call should not change the timestamp
+      await new Promise((r) => setTimeout(r, 10));
+      const second = await request(app)
+        .post(`/api/goals/${goal.id}/milestones/m/acknowledge`)
+        .expect(200);
+      expect(second.body.goal.milestones[0].acknowledgedAt).toBe(firstAck);
+    });
+
+    it('returns 404 when the goal does not exist', async () => {
+      await request(app)
+        .post('/api/goals/no-goal/milestones/m/acknowledge')
+        .expect(404);
+    });
+
+    it('returns 404 when the milestone id is unknown', async () => {
+      const goal = await makeCumulativeGoal([{ id: 'm-25', value: 25 }]);
+      await request(app)
+        .post(`/api/goals/${goal.id}/milestones/wrong-id/acknowledge`)
+        .expect(404);
+    });
   });
 });

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -1272,3 +1272,72 @@ export async function deleteGoalRoute(req: Request, res: Response): Promise<void
     });
   }
 }
+
+/**
+ * Acknowledge a milestone celebration.
+ *
+ * POST /api/goals/:id/milestones/:milestoneId/acknowledge
+ *
+ * Sets `acknowledgedAt = now` on the matching milestone. Idempotent — calling
+ * twice returns the goal unchanged with the original acknowledgedAt preserved.
+ */
+export async function acknowledgeMilestoneRoute(req: Request, res: Response): Promise<void> {
+  try {
+    const { id, milestoneId } = req.params;
+    if (!id || !milestoneId) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'Goal ID and milestone ID are required' },
+      });
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+    const existing = await getGoalById(id, householdId, userId);
+    if (!existing) {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: 'Goal not found' },
+      });
+      return;
+    }
+
+    const milestones = existing.milestones ?? [];
+    const targetIndex = milestones.findIndex((m) => m.id === milestoneId);
+    if (targetIndex === -1) {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: 'Milestone not found' },
+      });
+      return;
+    }
+
+    // Idempotent: do not overwrite an existing acknowledgedAt.
+    if (milestones[targetIndex].acknowledgedAt) {
+      res.status(200).json({ goal: existing });
+      return;
+    }
+
+    const updatedMilestones: GoalMilestone[] = milestones.map((m, idx) =>
+      idx === targetIndex ? { ...m, acknowledgedAt: new Date().toISOString() } : m,
+    );
+
+    const goal = await updateGoal(id, householdId, userId, { milestones: updatedMilestones });
+    if (!goal) {
+      res.status(404).json({
+        error: { code: 'NOT_FOUND', message: 'Goal not found' },
+      });
+      return;
+    }
+
+    invalidateUserCaches(userId);
+    res.status(200).json({ goal });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Error acknowledging milestone:', errorMessage);
+    res.status(500).json({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to acknowledge milestone',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      },
+    });
+  }
+}

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
 import {
   createGoal,
   getGoalsByUser,
@@ -19,7 +20,7 @@ import {
 import { getHabitsByUser, linkHabitsToGoal, unlinkHabitsFromGoal } from '../repositories/habitRepository';
 // getHabitEntriesByUser removed — entries are now fetched filtered by habit ID in computeGoalsWithProgressFromData
 import { computeGoalProgressV2, computeGoalListProgress } from '../utils/goalProgressUtilsV2';
-import type { Goal } from '../../models/persistenceTypes';
+import type { Goal, GoalMilestone } from '../../models/persistenceTypes';
 import { getRequestIdentity } from '../middleware/identity';
 import { generateBadgeForGoal, backfillGoalBadges } from '../services/badgeGenerationService';
 import { invalidateUserCaches } from '../lib/cacheInstances';
@@ -134,6 +135,73 @@ function validateGoalData(data: any): string | null {
   }
 
   return null;
+}
+
+const MAX_MILESTONES = 20;
+
+/**
+ * Validate a raw milestones payload and return a normalized array (sorted
+ * ascending by value, server-assigned IDs where missing). Returns either
+ * `{ error }` for a 400 message or `{ milestones }` for the normalized list.
+ *
+ * `effectiveType` and `effectiveTargetValue` are the values the goal will have
+ * after the operation completes — for PUT, callers must merge in patch + existing.
+ *
+ * When `acknowledgedAt` is present on an input entry, it is preserved as-is;
+ * the dedicated POST /goals/:id/milestones/:mid/acknowledge route is the
+ * primary writer, but PUT-replace round-tripping must not silently lose marks.
+ */
+function validateAndNormalizeMilestones(
+  raw: unknown,
+  effectiveType: 'cumulative' | 'onetime',
+  effectiveTargetValue: number | undefined,
+): { error: string | null; milestones?: GoalMilestone[] } {
+  if (raw === null) return { error: null, milestones: [] };
+  if (!Array.isArray(raw)) return { error: 'milestones must be an array' };
+  if (raw.length === 0) return { error: null, milestones: [] };
+  if (effectiveType !== 'cumulative') {
+    return { error: 'milestones are only allowed on cumulative goals' };
+  }
+  if (typeof effectiveTargetValue !== 'number' || !(effectiveTargetValue > 0)) {
+    return { error: 'milestones require a positive targetValue' };
+  }
+  if (raw.length > MAX_MILESTONES) {
+    return { error: `at most ${MAX_MILESTONES} milestones are allowed` };
+  }
+
+  const seen = new Set<number>();
+  const normalized: GoalMilestone[] = [];
+  for (const m of raw as Array<Record<string, unknown>>) {
+    if (!m || typeof m !== 'object') {
+      return { error: 'each milestone must be an object' };
+    }
+    const value = m.value;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      return { error: 'each milestone.value must be a positive finite number' };
+    }
+    if (value >= effectiveTargetValue) {
+      return { error: 'each milestone.value must be strictly less than targetValue' };
+    }
+    if (seen.has(value)) {
+      return { error: 'milestone values must be unique' };
+    }
+    seen.add(value);
+
+    const entry: GoalMilestone = {
+      id: typeof m.id === 'string' && m.id.length > 0 ? m.id : randomUUID(),
+      value,
+    };
+    if (m.acknowledgedAt !== undefined && m.acknowledgedAt !== null) {
+      if (typeof m.acknowledgedAt !== 'string') {
+        return { error: 'milestone.acknowledgedAt must be a string if provided' };
+      }
+      entry.acknowledgedAt = m.acknowledgedAt;
+    }
+    normalized.push(entry);
+  }
+
+  normalized.sort((a, b) => a.value - b.value);
+  return { error: null, milestones: normalized };
 }
 
 function buildIteratedGoalData(goal: Goal, currentValue: number | null): Omit<Goal, 'id' | 'createdAt'> {
@@ -415,6 +483,24 @@ export async function createGoalRoute(req: Request, res: Response): Promise<void
       return;
     }
 
+    let normalizedMilestones: GoalMilestone[] | undefined;
+    if (req.body.milestones !== undefined) {
+      const result = validateAndNormalizeMilestones(
+        req.body.milestones,
+        req.body.type,
+        req.body.targetValue,
+      );
+      if (result.error) {
+        res.status(400).json({
+          error: { code: 'VALIDATION_ERROR', message: result.error },
+        });
+        return;
+      }
+      // Drop any client-supplied acknowledgedAt on create — the goal hasn't
+      // existed yet, so no celebration could have been dismissed.
+      normalizedMilestones = (result.milestones ?? []).map(({ id, value }) => ({ id, value }));
+    }
+
     // Set default aggregationMode and countMode if not provided
     const aggregationMode = req.body.aggregationMode || (req.body.type === 'cumulative' ? 'sum' : 'count');
     const countMode = req.body.countMode || (aggregationMode === 'count' ? 'distinctDays' : undefined);
@@ -456,6 +542,7 @@ export async function createGoalRoute(req: Request, res: Response): Promise<void
         badgeImageUrl: req.body.badgeImageUrl?.trim(),
         categoryId: req.body.categoryId,
         sortOrder,
+        ...(normalizedMilestones !== undefined ? { milestones: normalizedMilestones } : {}),
       },
       householdId,
       userId
@@ -690,6 +777,62 @@ export async function updateGoalRoute(req: Request, res: Response): Promise<void
       patch.sortOrder = req.body.sortOrder;
     }
 
+    // Milestones: validate against the goal's effective type/targetValue after
+    // applying the patch, and merge acknowledgedAt from existing milestones by
+    // id so the celebration marker survives PUT-replace round-trips.
+    if (req.body.milestones !== undefined) {
+      const { householdId: hid, userId: uid } = getRequestIdentity(req);
+      const existingForMilestones = await getGoalById(id, hid, uid);
+      if (!existingForMilestones) {
+        res.status(404).json({
+          error: { code: 'NOT_FOUND', message: 'Goal not found' },
+        });
+        return;
+      }
+
+      const effectiveType = (patch.type ?? existingForMilestones.type) as 'cumulative' | 'onetime';
+      const effectiveTargetValue = patch.targetValue ?? existingForMilestones.targetValue;
+
+      const result = validateAndNormalizeMilestones(
+        req.body.milestones,
+        effectiveType,
+        effectiveTargetValue,
+      );
+      if (result.error) {
+        res.status(400).json({
+          error: { code: 'VALIDATION_ERROR', message: result.error },
+        });
+        return;
+      }
+
+      const existingById = new Map(
+        (existingForMilestones.milestones ?? []).map((m) => [m.id, m]),
+      );
+      const merged = (result.milestones ?? []).map((m) => {
+        const prior = existingById.get(m.id);
+        if (prior?.acknowledgedAt && !m.acknowledgedAt) {
+          return { ...m, acknowledgedAt: prior.acknowledgedAt };
+        }
+        return m;
+      });
+      patch.milestones = merged;
+    } else if (patch.type === 'onetime') {
+      // Type is being switched to onetime; existing milestones (if any) become
+      // invalid. Reject so the user explicitly clears them rather than silently
+      // dropping celebration history.
+      const { householdId: hid, userId: uid } = getRequestIdentity(req);
+      const existingForTypeChange = await getGoalById(id, hid, uid);
+      if (existingForTypeChange?.milestones && existingForTypeChange.milestones.length > 0) {
+        res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Cannot switch to onetime while milestones are configured. Clear milestones first.',
+          },
+        });
+        return;
+      }
+    }
+
     if (Object.keys(patch).length === 0) {
       res.status(400).json({
         error: {
@@ -698,6 +841,24 @@ export async function updateGoalRoute(req: Request, res: Response): Promise<void
         },
       });
       return;
+    }
+
+    // If targetValue is being lowered without an explicit milestones patch,
+    // ensure existing milestones still respect `value < targetValue`.
+    if (patch.targetValue !== undefined && patch.milestones === undefined) {
+      const { householdId: hid, userId: uid } = getRequestIdentity(req);
+      const existingForTargetCheck = await getGoalById(id, hid, uid);
+      const ms = existingForTargetCheck?.milestones ?? [];
+      const violating = ms.find((m) => m.value >= patch.targetValue!);
+      if (violating) {
+        res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `Cannot set targetValue at or below existing milestone (${violating.value}). Adjust milestones first.`,
+          },
+        });
+        return;
+      }
     }
 
     const { householdId, userId } = getRequestIdentity(req);

--- a/src/server/utils/goalProgressUtilsV2.test.ts
+++ b/src/server/utils/goalProgressUtilsV2.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeFullGoalProgressV2 } from './goalProgressUtilsV2';
+import { computeFullGoalProgressV2, computeMilestoneStates } from './goalProgressUtilsV2';
 import type { Goal, Habit } from '../../models/persistenceTypes';
 import type { EntryView } from '../services/truthQuery';
 
@@ -764,6 +764,205 @@ describe('goalProgressUtilsV2', () => {
 
       // Should count days, not sum values
       expect(progress.currentValue).toBe(2); // 2 distinct dayKeys
+    });
+  });
+
+  describe('computeMilestoneStates', () => {
+    function makeEntries(values: Array<{ dayKey: string; value: number }>): EntryView[] {
+      return values.map(({ dayKey, value }, i) => ({
+        habitId: 'habit-1',
+        dayKey: dayKey as EntryView['dayKey'],
+        timestampUtc: `${dayKey}T10:0${i}:00.000Z`,
+        value,
+        source: 'manual',
+        provenance: {},
+        deletedAt: null,
+        conflict: false,
+      }));
+    }
+
+    it('marks milestones completed when currentValue crosses their threshold (sum aggregation)', () => {
+      const entries = makeEntries([
+        { dayKey: '2025-01-01', value: 10 },
+        { dayKey: '2025-01-02', value: 20 },
+        { dayKey: '2025-01-05', value: 30 },
+      ]);
+
+      const states = computeMilestoneStates({
+        milestones: [
+          { id: 'a', value: 25 },
+          { id: 'b', value: 50 },
+          { id: 'c', value: 75 },
+        ],
+        currentValue: 60,
+        entries,
+        aggregationMode: 'sum',
+        countMode: 'distinctDays',
+      });
+
+      expect(states.map((s) => s.completed)).toEqual([true, true, false]);
+      expect(states[0].completedAtDayKey).toBe('2025-01-02'); // 10+20=30 >= 25
+      expect(states[1].completedAtDayKey).toBe('2025-01-05'); // 30+30=60 >= 50
+      expect(states[2].completedAtDayKey).toBeUndefined();
+    });
+
+    it('returns empty when goal has no milestones', () => {
+      const states = computeMilestoneStates({
+        milestones: undefined,
+        currentValue: 100,
+        entries: [],
+        aggregationMode: 'sum',
+        countMode: 'distinctDays',
+      });
+      expect(states).toEqual([]);
+    });
+
+    it('preserves input ordering of milestones', () => {
+      const entries = makeEntries([{ dayKey: '2025-01-01', value: 100 }]);
+      const states = computeMilestoneStates({
+        milestones: [
+          { id: 'b', value: 50 },
+          { id: 'a', value: 25 },
+          { id: 'c', value: 75 },
+        ],
+        currentValue: 100,
+        entries,
+        aggregationMode: 'sum',
+        countMode: 'distinctDays',
+      });
+      expect(states.map((s) => s.id)).toEqual(['b', 'a', 'c']);
+      expect(states.every((s) => s.completed)).toBe(true);
+    });
+
+    it('mirrors acknowledgedAt onto the state', () => {
+      const ackTime = '2025-04-15T00:00:00.000Z';
+      const states = computeMilestoneStates({
+        milestones: [
+          { id: 'a', value: 25, acknowledgedAt: ackTime },
+          { id: 'b', value: 50 },
+        ],
+        currentValue: 30,
+        entries: makeEntries([{ dayKey: '2025-01-01', value: 30 }]),
+        aggregationMode: 'sum',
+        countMode: 'distinctDays',
+      });
+      expect(states[0].acknowledgedAt).toBe(ackTime);
+      expect(states[1].acknowledgedAt).toBeUndefined();
+    });
+
+    it('crosses milestones via boolean target multipliers', () => {
+      const habit: Habit = {
+        id: 'habit-1',
+        categoryId: 'cat-1',
+        name: 'Pull-ups',
+        goal: { type: 'boolean', frequency: 'daily', target: 25 },
+        archived: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+      };
+      const habitMap = new Map<string, Habit>([['habit-1', habit]]);
+
+      const entries: EntryView[] = [
+        {
+          habitId: 'habit-1', dayKey: '2025-01-01' as EntryView['dayKey'],
+          timestampUtc: '2025-01-01T00:00:00.000Z', value: 1,
+          source: 'manual', provenance: {}, deletedAt: null, conflict: false,
+        },
+        {
+          habitId: 'habit-1', dayKey: '2025-01-02' as EntryView['dayKey'],
+          timestampUtc: '2025-01-02T00:00:00.000Z', value: 1,
+          source: 'manual', provenance: {}, deletedAt: null, conflict: false,
+        },
+      ];
+
+      const states = computeMilestoneStates({
+        milestones: [{ id: 'a', value: 40 }],
+        currentValue: 50, // 2 entries × target 25
+        entries,
+        aggregationMode: 'sum',
+        countMode: 'distinctDays',
+        habitMap,
+      });
+
+      expect(states[0].completed).toBe(true);
+      expect(states[0].completedAtDayKey).toBe('2025-01-02');
+    });
+
+    it('count/distinctDays: completion at the day the cumulative day count crosses', () => {
+      const entries = makeEntries([
+        { dayKey: '2025-01-01', value: 1 },
+        { dayKey: '2025-01-02', value: 1 },
+        { dayKey: '2025-01-02', value: 1 }, // duplicate day, no increment
+        { dayKey: '2025-01-04', value: 1 },
+      ]);
+
+      const states = computeMilestoneStates({
+        milestones: [{ id: 'a', value: 2 }, { id: 'b', value: 5 }],
+        currentValue: 3,
+        entries,
+        aggregationMode: 'count',
+        countMode: 'distinctDays',
+      });
+
+      expect(states[0].completed).toBe(true);
+      expect(states[0].completedAtDayKey).toBe('2025-01-02');
+      expect(states[1].completed).toBe(false);
+    });
+
+    it('list path (entries=null) returns completion flag without completedAtDayKey', () => {
+      const states = computeMilestoneStates({
+        milestones: [{ id: 'a', value: 25 }, { id: 'b', value: 75 }],
+        currentValue: 50,
+        entries: null,
+        aggregationMode: 'sum',
+        countMode: 'distinctDays',
+      });
+
+      expect(states[0]).toMatchObject({ id: 'a', completed: true });
+      expect(states[0].completedAtDayKey).toBeUndefined();
+      expect(states[1]).toMatchObject({ id: 'b', completed: false });
+    });
+
+    it('full progress includes milestoneStates when goal has milestones', () => {
+      const goal: Goal = {
+        id: 'goal-1',
+        title: '100 Pull-Ups',
+        type: 'cumulative',
+        targetValue: 100,
+        linkedHabitIds: ['habit-1'],
+        aggregationMode: 'sum',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        milestones: [{ id: 'm1', value: 25 }, { id: 'm2', value: 75 }],
+      };
+
+      const entryViews: EntryView[] = [
+        {
+          habitId: 'habit-1', dayKey: '2025-01-10' as EntryView['dayKey'],
+          timestampUtc: '2025-01-10T10:00:00.000Z', value: 30,
+          source: 'manual', provenance: {}, deletedAt: null, conflict: false,
+        },
+      ];
+
+      const progress = computeFullGoalProgressV2(goal, entryViews, undefined, 'UTC');
+      expect(progress.milestoneStates).toHaveLength(2);
+      expect(progress.milestoneStates![0]).toMatchObject({
+        id: 'm1', completed: true, completedAtDayKey: '2025-01-10',
+      });
+      expect(progress.milestoneStates![1].completed).toBe(false);
+    });
+
+    it('full progress omits milestoneStates when goal has none', () => {
+      const goal: Goal = {
+        id: 'goal-1',
+        title: 'No milestones',
+        type: 'cumulative',
+        targetValue: 100,
+        linkedHabitIds: ['habit-1'],
+        aggregationMode: 'sum',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      };
+
+      const progress = computeFullGoalProgressV2(goal, [], undefined, 'UTC');
+      expect(progress.milestoneStates).toBeUndefined();
     });
   });
 });

--- a/src/server/utils/goalProgressUtilsV2.ts
+++ b/src/server/utils/goalProgressUtilsV2.ts
@@ -13,9 +13,87 @@ import { getMembershipsByParent } from '../repositories/bundleMembershipReposito
 import { aggregateHabitEntryTotals } from '../repositories/habitEntryRepository';
 import { getEntryViewsForHabits, getRecentEntryViewsForHabits, buildEntryViewsFromEntries } from '../services/truthQuery';
 import { getAggregationMode, getCountMode, unitsMatch } from './goalLinkSemantics';
-import type { Goal, GoalProgress, Habit, HabitEntry, GoalProgressWarning } from '../../models/persistenceTypes';
+import type { Goal, GoalProgress, Habit, HabitEntry, GoalProgressWarning, MilestoneState } from '../../models/persistenceTypes';
 import type { EntryView } from '../services/truthQuery';
 import type { DayKey } from '../../domain/time/dayKey';
+
+/**
+ * Compute derived state for each goal milestone.
+ *
+ * `completed` is taken from `currentValue >= milestone.value` so it always
+ * agrees with the headline progress bar. `completedAtDayKey` (the first dayKey
+ * at which the running cumulative crossed the threshold) is computed only when
+ * `entries` is provided — the list path passes `null` to skip the walk.
+ *
+ * The returned array preserves the input ordering of `milestones`; ascending
+ * order is enforced by the route layer on write.
+ */
+export function computeMilestoneStates(input: {
+  milestones: Goal['milestones'];
+  currentValue: number;
+  /** Pass `null` from cheap paths (list view) to skip the entry walk. */
+  entries: EntryView[] | null;
+  aggregationMode: 'sum' | 'count';
+  countMode: 'distinctDays' | 'entries';
+  habitMap?: Map<string, Habit>;
+}): MilestoneState[] {
+  const { milestones, currentValue, entries, aggregationMode, countMode, habitMap } = input;
+  if (!milestones || milestones.length === 0) return [];
+
+  const crossingByValue = new Map<number, string>();
+
+  if (entries && entries.length > 0) {
+    const sorted = entries.slice().sort((a, b) => {
+      if (a.dayKey !== b.dayKey) return a.dayKey < b.dayKey ? -1 : 1;
+      return (a.timestampUtc || '').localeCompare(b.timestampUtc || '');
+    });
+
+    const sortedMilestones = milestones.slice().sort((a, b) => a.value - b.value);
+    const distinctDays = new Set<string>();
+    let running = 0;
+    let nextIdx = 0;
+
+    for (const entry of sorted) {
+      if (aggregationMode === 'sum') {
+        let inc = entry.value ?? 0;
+        if (habitMap) {
+          const habit = habitMap.get(entry.habitId);
+          if (habit?.goal.type === 'boolean') {
+            inc = habit.goal.target ?? 1;
+          }
+        }
+        running += inc;
+      } else if (countMode === 'entries') {
+        running += 1;
+      } else {
+        if (distinctDays.has(entry.dayKey)) continue;
+        distinctDays.add(entry.dayKey);
+        running = distinctDays.size;
+      }
+
+      while (
+        nextIdx < sortedMilestones.length &&
+        running >= sortedMilestones[nextIdx].value
+      ) {
+        crossingByValue.set(sortedMilestones[nextIdx].value, entry.dayKey);
+        nextIdx++;
+      }
+      if (nextIdx >= sortedMilestones.length) break;
+    }
+  }
+
+  return milestones.map((m) => {
+    const state: MilestoneState = {
+      id: m.id,
+      value: m.value,
+      completed: currentValue >= m.value,
+    };
+    const crossingDay = crossingByValue.get(m.value);
+    if (crossingDay) state.completedAtDayKey = crossingDay;
+    if (m.acknowledgedAt) state.acknowledgedAt = m.acknowledgedAt;
+    return state;
+  });
+}
 
 /**
  * Get date string in YYYY-MM-DD format for N days ago.
@@ -264,6 +342,15 @@ export function computeFullGoalProgressV2(
 
   const inactivityWarning = !goal.completedAt && daysWithoutProgress >= 4;
 
+  const milestoneStates = computeMilestoneStates({
+    milestones: goal.milestones,
+    currentValue,
+    entries: filteredEntries,
+    aggregationMode,
+    countMode,
+    habitMap,
+  });
+
   return {
     currentValue,
     percent,
@@ -271,6 +358,7 @@ export function computeFullGoalProgressV2(
     lastThirtyDays: lastThirtyDaysData,
     inactivityWarning,
     warnings: warnings.length > 0 ? warnings : undefined,
+    ...(milestoneStates.length > 0 ? { milestoneStates } : {}),
   };
 }
 
@@ -675,6 +763,17 @@ export async function computeGoalListProgress(
     const daysWithoutProgress = lastSevenDaysData.filter(day => !day.hasProgress).length;
     const inactivityWarning = !goal.completedAt && daysWithoutProgress >= 4;
 
+    // List path: skip the per-entry walk; completion derives from currentValue.
+    // No completedAtDayKey is set here — only the full path computes timestamps.
+    const milestoneStates = computeMilestoneStates({
+      milestones: goal.milestones,
+      currentValue,
+      entries: null,
+      aggregationMode,
+      countMode,
+      habitMap,
+    });
+
     results.push({
       goal,
       progress: {
@@ -684,6 +783,7 @@ export async function computeGoalListProgress(
         lastThirtyDays: lastThirtyDaysData,
         inactivityWarning,
         warnings: warnings.length > 0 ? warnings : undefined,
+        ...(milestoneStates.length > 0 ? { milestoneStates } : {}),
       },
     });
   }

--- a/src/store/GoalCompletionContext.tsx
+++ b/src/store/GoalCompletionContext.tsx
@@ -4,14 +4,30 @@ import type { ReactNode } from 'react';
 /**
  * Goal Completion Context
  *
- * Holds the id of the goal whose celebration screen should be shown next.
- * Sits above HabitProvider so HabitContext can dispatch into it when a server-side
- * entry mutation reports a newly-completed goal, and below the consumer
- * (HabitTrackerContent) which renders the GoalCompletedPage.
+ * Holds the id of the goal whose celebration screen should be shown next, and
+ * a queue of pending milestone celebrations. Sits above HabitProvider so
+ * HabitContext can dispatch into it when a server-side entry mutation reports
+ * a newly-completed goal, and below the consumer (HabitTrackerContent) which
+ * renders the celebration UI.
  */
+export interface PendingMilestone {
+    goalId: string;
+    milestoneId: string;
+    value: number;
+    unit?: string;
+    goalTitle: string;
+    badgeImageUrl?: string;
+}
+
 interface GoalCompletionContextValue {
     completedGoalId: string | null;
     setCompletedGoalId: (id: string | null) => void;
+
+    pendingMilestone: PendingMilestone | null;
+    /** Add new pending milestones to the queue. Deduped by milestoneId. */
+    enqueuePendingMilestones: (next: PendingMilestone[]) => void;
+    /** Pop the head of the queue. */
+    dismissPendingMilestone: () => void;
 }
 
 const GoalCompletionContext = createContext<GoalCompletionContextValue | undefined>(undefined);
@@ -21,7 +37,34 @@ export const GoalCompletionProvider = ({ children }: { children: ReactNode }) =>
     const setCompletedGoalId = useCallback((id: string | null) => {
         setCompletedGoalIdState(id);
     }, []);
-    const value = useMemo(() => ({ completedGoalId, setCompletedGoalId }), [completedGoalId, setCompletedGoalId]);
+
+    const [pendingMilestones, setPendingMilestones] = useState<PendingMilestone[]>([]);
+
+    const enqueuePendingMilestones = useCallback((next: PendingMilestone[]) => {
+        if (next.length === 0) return;
+        setPendingMilestones((current) => {
+            const seen = new Set(current.map((m) => m.milestoneId));
+            const additions = next.filter((m) => !seen.has(m.milestoneId));
+            if (additions.length === 0) return current;
+            return [...current, ...additions];
+        });
+    }, []);
+
+    const dismissPendingMilestone = useCallback(() => {
+        setPendingMilestones((current) => current.slice(1));
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            completedGoalId,
+            setCompletedGoalId,
+            pendingMilestone: pendingMilestones[0] ?? null,
+            enqueuePendingMilestones,
+            dismissPendingMilestone,
+        }),
+        [completedGoalId, setCompletedGoalId, pendingMilestones, enqueuePendingMilestones, dismissPendingMilestone],
+    );
+
     return (
         <GoalCompletionContext.Provider value={value}>
             {children}


### PR DESCRIPTION
Introduces optional milestone configuration on cumulative goals: an array of
{id, value, acknowledgedAt?} entries strictly less than targetValue.
Completion remains derived; only configuration and the celebration
acknowledgment marker are stored. GoalProgress carries a parallel
milestoneStates array for client consumption.

https://claude.ai/code/session_0151xRW4TnLweUfdCipVbA8h