### PR TITLE
fix: allow extending a goal whose linked habit was soft-deleted

### DIFF
--- a/src/server/routes/__tests__/goals.deletedHabits.test.ts
+++ b/src/server/routes/__tests__/goals.deletedHabits.test.ts
@@ -14,7 +14,7 @@ import { createHabit, deleteHabit } from '../../repositories/habitRepository';
 import { createGoal } from '../../repositories/goalRepository';
 import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
 import { createHabitEntryRoute } from '../habitEntries';
-import { getGoalsWithProgress, getGoalDetailRoute, getGoalProgress, createGoalRoute } from '../goals';
+import { getGoalsWithProgress, getGoalDetailRoute, getGoalProgress, createGoalRoute, updateGoalRoute } from '../goals';
 import { requestContextMiddleware } from '../../middleware/requestContext';
 
 const TEST_HOUSEHOLD = 'test-household-goals-deleted-habits';
@@ -44,6 +44,7 @@ describe('Goal progress with deleted habits', () => {
     app.get('/api/goals/:id/detail', getGoalDetailRoute);
     app.get('/api/goals/:id/progress', getGoalProgress);
     app.post('/api/goals', createGoalRoute);
+    app.put('/api/goals/:id', updateGoalRoute);
   });
 
   afterAll(async () => {
@@ -265,5 +266,42 @@ describe('Goal progress with deleted habits', () => {
     expect(res.status).toBe(201);
     expect(res.body.goal.targetValue).toBe(1000);
     expect(res.body.goal.linkedHabitIds).toContain(habit.id);
+  });
+
+  it('iterating an already-completed goal creates the iterated goal (PUT /api/goals/:id)', async () => {
+    const cat = await createCategory({ name: 'Strength', color: '#FF00FF' }, TEST_HOUSEHOLD, TEST_USER);
+    const habit = await createHabit(
+      {
+        name: 'Pullups',
+        categoryId: cat.id,
+        goal: { type: 'number', frequency: 'daily', target: 50, unit: 'reps' },
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    const completed = await createGoal(
+      {
+        title: 'Do 500 Pullups',
+        type: 'cumulative',
+        targetValue: 500,
+        unit: 'reps',
+        linkedHabitIds: [habit.id],
+        aggregationMode: 'sum',
+        completedAt: new Date().toISOString(),
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    // Popup "Extend" path: iterate a goal that is already completed.
+    const res = await request(app)
+      .put(`/api/goals/${completed.id}`)
+      .send({ completedAt: new Date().toISOString(), iterate: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.iteratedGoal).not.toBeNull();
+    expect(res.body.iteratedGoal.targetValue).toBeGreaterThan(500);
+    expect(res.body.iteratedGoal.iteratedFromGoalId).toBe(completed.id);
   });
 });

--- a/src/server/routes/__tests__/goals.deletedHabits.test.ts
+++ b/src/server/routes/__tests__/goals.deletedHabits.test.ts
@@ -14,7 +14,7 @@ import { createHabit, deleteHabit } from '../../repositories/habitRepository';
 import { createGoal } from '../../repositories/goalRepository';
 import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
 import { createHabitEntryRoute } from '../habitEntries';
-import { getGoalsWithProgress, getGoalDetailRoute, getGoalProgress } from '../goals';
+import { getGoalsWithProgress, getGoalDetailRoute, getGoalProgress, createGoalRoute } from '../goals';
 import { requestContextMiddleware } from '../../middleware/requestContext';
 
 const TEST_HOUSEHOLD = 'test-household-goals-deleted-habits';
@@ -43,6 +43,7 @@ describe('Goal progress with deleted habits', () => {
     app.get('/api/goals-with-progress', getGoalsWithProgress);
     app.get('/api/goals/:id/detail', getGoalDetailRoute);
     app.get('/api/goals/:id/progress', getGoalProgress);
+    app.post('/api/goals', createGoalRoute);
   });
 
   afterAll(async () => {
@@ -220,5 +221,49 @@ describe('Goal progress with deleted habits', () => {
     const gwpRes = await request(app).get('/api/goals-with-progress').query({ timeZone: 'UTC' });
     const gwpGoal = gwpRes.body.goals.find((g: any) => g.goal.id === goal.id);
     expect(gwpGoal.progress.currentValue).toBe(50);
+  });
+
+  it('extending a goal whose linked habit was deleted succeeds (POST /api/goals)', async () => {
+    const cat = await createCategory({ name: 'Strength', color: '#FF00FF' }, TEST_HOUSEHOLD, TEST_USER);
+    const habit = await createHabit(
+      {
+        name: 'Pullups',
+        categoryId: cat.id,
+        goal: { type: 'number', frequency: 'daily', target: 50, unit: 'reps' },
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    const original = await createGoal(
+      {
+        title: 'Do 500 Pullups',
+        type: 'cumulative',
+        targetValue: 500,
+        unit: 'reps',
+        linkedHabitIds: [habit.id],
+        aggregationMode: 'sum',
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    // Soft-delete the linked habit, then extend the goal by reusing its
+    // linkedHabitIds (mirrors GoalDetailPage.handleExtendGoal).
+    await deleteHabit(habit.id, TEST_HOUSEHOLD, TEST_USER);
+
+    const res = await request(app).post('/api/goals').send({
+      title: 'Do 500 Pullups',
+      type: 'cumulative',
+      targetValue: 1000,
+      unit: 'reps',
+      linkedHabitIds: original.linkedHabitIds,
+      aggregationMode: 'sum',
+      iteratedFromGoalId: original.id,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.goal.targetValue).toBe(1000);
+    expect(res.body.goal.linkedHabitIds).toContain(habit.id);
   });
 });

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -883,12 +883,15 @@ export async function updateGoalRoute(req: Request, res: Response): Promise<void
         return;
       }
 
-      if (!existingGoal.completedAt) {
+      // Iterate when explicitly requested, regardless of prior completion state.
+      // The "You completed your goal!" popup extends a goal that is already
+      // completed, so gating this on `!existingGoal.completedAt` would silently
+      // skip iteration and create nothing.
+      if (req.body.iterate === true) {
         const { computeGoalProgressV2 } = await import('../utils/goalProgressUtilsV2');
         const progress = await computeGoalProgressV2(id, householdId, userId, 'UTC');
         currentValueForIteration = progress?.currentValue ?? 0;
-        // Only iterate if explicitly requested by the client
-        shouldIterateGoal = req.body.iterate === true;
+        shouldIterateGoal = true;
       }
     }
 

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -39,8 +39,12 @@ async function validateHabitIdsExist(
 ): Promise<string[]> {
   if (habitIds.length === 0) return [];
 
-  // Single batch fetch instead of N individual queries
-  const allHabits = await getHabitsByUser(householdId, userId);
+  // Single batch fetch instead of N individual queries. Include soft-deleted
+  // habits: their IDs still "exist" and their entries remain historical
+  // contributions to goal progress, so a goal (or an extended copy of one) may
+  // legitimately reference a deleted habit. Scope by household + user still
+  // rejects genuinely-nonexistent or foreign IDs.
+  const allHabits = await getHabitsByUser(householdId, userId, { includeDeleted: true });
   const existingIds = new Set(allHabits.map((h) => h.id));
 
   return habitIds.filter((id) => !existingIds.has(id));


### PR DESCRIPTION
Goal existence validation excluded soft-deleted habits, so extending a
completed cumulative goal (which copies the original goal's linkedHabitIds)
failed with "The following habit IDs do not exist" whenever a linked habit
had been deleted. Soft-deleted habits' entries still count toward goal
progress, so their IDs must validate as existing.

https://claude.ai/code/session_018wUJc1RycyF6cxCJ4evGni