### PR TITLE
fix: allow extending a goal whose linked habit no longer exists

### DIFF
--- a/src/server/routes/__tests__/goals.deletedHabits.test.ts
+++ b/src/server/routes/__tests__/goals.deletedHabits.test.ts
@@ -268,6 +268,52 @@ describe('Goal progress with deleted habits', () => {
     expect(res.body.goal.linkedHabitIds).toContain(habit.id);
   });
 
+  it('extending a goal whose linked habit no longer exists at all succeeds (POST /api/goals)', async () => {
+    // A goal can carry a reference to a habit that was hard-deleted (or otherwise
+    // no longer exists even among soft-deleted habits). The source goal is allowed
+    // to keep that ref, so extending it must not be blocked by strict validation.
+    const original = await createGoal(
+      {
+        title: 'Do 500 Pullups',
+        type: 'cumulative',
+        targetValue: 500,
+        unit: 'reps',
+        linkedHabitIds: ['4d364a40-d4f8-4636-82a7-f5a27391004b'],
+        aggregationMode: 'sum',
+      },
+      TEST_HOUSEHOLD,
+      TEST_USER
+    );
+
+    const res = await request(app).post('/api/goals').send({
+      title: 'Do 500 Pullups',
+      type: 'cumulative',
+      targetValue: 1000,
+      unit: 'reps',
+      linkedHabitIds: original.linkedHabitIds,
+      aggregationMode: 'sum',
+      iteratedFromGoalId: original.id,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.goal.targetValue).toBe(1000);
+    expect(res.body.goal.linkedHabitIds).toContain('4d364a40-d4f8-4636-82a7-f5a27391004b');
+  });
+
+  it('creating a NON-iterated goal with a nonexistent habit still fails (POST /api/goals)', async () => {
+    // Guard: the iteration carve-out must not weaken validation for ordinary creates.
+    const res = await request(app).post('/api/goals').send({
+      title: 'Bogus goal',
+      type: 'cumulative',
+      targetValue: 100,
+      linkedHabitIds: ['00000000-0000-0000-0000-000000000000'],
+      aggregationMode: 'sum',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toContain('do not exist');
+  });
+
   it('iterating an already-completed goal creates the iterated goal (PUT /api/goals/:id)', async () => {
     const cat = await createCategory({ name: 'Strength', color: '#FF00FF' }, TEST_HOUSEHOLD, TEST_USER);
     const habit = await createHabit(

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -476,7 +476,20 @@ export async function createGoalRoute(req: Request, res: Response): Promise<void
 
     const { householdId, userId } = getRequestIdentity(req);
 
-    const invalidHabitIds = await validateHabitIdsExist(req.body.linkedHabitIds, householdId, userId);
+    // When extending/iterating an existing goal, the new goal inherits the
+    // source goal's linkedHabitIds. Those refs are allowed to point at habits
+    // that no longer exist (even hard-deleted ones): the source goal was
+    // permitted to keep them — the PATCH path only validates newly-added IDs —
+    // and their entries remain historical contributions to progress. Validate
+    // only the IDs that aren't already on the source goal, mirroring updateGoalRoute.
+    let habitIdsToValidate: string[] = req.body.linkedHabitIds;
+    if (req.body.iteratedFromGoalId) {
+      const sourceGoal = await getGoalById(req.body.iteratedFromGoalId, householdId, userId);
+      const inheritedIds = new Set(sourceGoal?.linkedHabitIds ?? []);
+      habitIdsToValidate = req.body.linkedHabitIds.filter((hid: string) => !inheritedIds.has(hid));
+    }
+
+    const invalidHabitIds = await validateHabitIdsExist(habitIdsToValidate, householdId, userId);
     if (invalidHabitIds.length > 0) {
       res.status(400).json({
         error: {


### PR DESCRIPTION
When extending/iterating a completed goal, the new goal inherits the
source goal's linkedHabitIds. createGoalRoute validated all of them
strictly via validateHabitIdsExist, so if a previously-linked habit had
been hard-deleted (gone even among soft-deleted habits), the extension
failed with "The following habit IDs do not exist".

The source goal was permitted to keep that stale ref — updateGoalRoute
only validates newly-added IDs — and its entries remain historical
contributions to progress. Mirror that here: when iteratedFromGoalId is
present, validate only the IDs that aren't already on the source goal.

https://claude.ai/code/session_01AsPD71wDzzL11jQ87GYqCu