### PR TITLE
Add sleep analytics wellbeing metric keys

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -105,6 +105,16 @@ Canonical inventory of all user-facing features. Keep this document in sync with
   - **By Category view** — Per-category mini heatmap with 7d / 14d / 30d / 90d toggle
 - **Routine Analytics** — Completion frequency, variant usage, timing stats
 - **Goal Analytics** — Completion rates, progress velocity
+- **Sleep Analytics** (Sleep tab) — Dedicated sleep dashboard answering "Am I becoming more consistent at sleeping ~10 PM–6 AM with high quality and less reliance on sleep aids?"
+  - **Apple Watch Sleep Score** — Manually-entered overall score (0-100) plus bedtime / duration / interruption sub-scores (the primary signal)
+  - **Headline metrics** — Average duration, latency, bedtime, wake time, sleep quality (0-10), each with sample size and period-over-period trend
+  - **Sleep Consistency Score** — Rewards similar bedtime AND wake clock times night-to-night (circular std-dev), independent of how long you sleep
+  - **Sleep Independence** — Sleep-aid-free nights, current/longest aid-free streak, percent aid-free, and trend
+  - **Trend charts** — Bedtime & wake vs target reference lines (10 PM / 6 AM), and duration vs target
+  - **Correlation engine** — Ranks tracked behaviors (phone in bed, blue light, wind-down, late eating, caffeine, plus any habit) by their measured effect on sleep outcomes, framed as correlation (Cohen's d, sample-size guards), never causation
+  - **Weekly summary & achievements** — Per-week duration/latency/on-target/aid-free/energy rollups and milestone cards
+  - **Configurable targets** — User-set target bedtime / wake / duration (default 10 PM / 6 AM / 8h)
+  - Data captured via a dedicated **Sleep entry form** on the Daily Check-in (morning), stored as wellbeing entries
 
 ## AI Features (Gemini BYOK)
 

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -139,7 +139,8 @@ HabitFlow App
 | Routine Editor | Modal | "+ Routine" or edit routine | Create/edit routines with variants; step list navigates to dedicated Step Editor panel | Routines, Habits |
 | Routine Runner | Modal | "Play" button on routine card | Step-by-step routine execution with timers | Routines, Habits, Entries |
 | Routine Preview | Modal | Preview button on routine card | Read-only routine view before starting | Routines |
-| Daily Check-in | Modal | Dashboard check-in card | Wellbeing metrics entry (sleep, mood, stress) | Wellbeing Entries |
+| Daily Check-in | Modal | Dashboard check-in card | Wellbeing metrics entry (sleep, mood, stress); morning tab has a "Log Sleep" entry point | Wellbeing Entries |
+| Log Sleep | Modal | "Log Sleep" button on Daily Check-in morning tab | Apple Watch sleep score + sub-scores, bedtime/wake pickers, duration, quality, last-night habit toggles, and configurable sleep targets | Wellbeing Entries, Dashboard Prefs |
 | Edit Goal | Modal | Goal context menu "Edit" | Modify goal title, target, deadline | Goals |
 | Delete Goal Confirm | Modal | Goal context menu "Delete" | Deletion confirmation dialog | Goals |
 | Remove Habit | Modal | Trash button on a habit that is linked to one or more goals (shown after the click-twice confirm so the user sees which goals are affected) | Lists the affected goals and offers two paths: **Archive** (recommended, restorable from Settings) or **Delete permanently** (soft-delete, not restorable). For unlinked habits the trash icon archives directly without opening this modal | Habits, Goals |
@@ -300,6 +301,7 @@ graph TB
 | **Goal progress charts** | Goal Detail Page (cumulative, trend, weekly summary) |
 | **Wellbeing trends** | Wellbeing History Page |
 | **Weekly summary** | Dashboard weekly summary card |
+| **Sleep analytics** | Analytics Page → Sleep tab (Habits / Routines / Goals / Sleep) — Apple Watch score, consistency, independence, bedtime/wake & duration trends, correlation factors, weekly summary, achievements |
 
 ### Category
 

--- a/docs/reference/V1/00_DATA_CONTRACT_WELLBEING_KEYS.md
+++ b/docs/reference/V1/00_DATA_CONTRACT_WELLBEING_KEYS.md
@@ -148,10 +148,10 @@ Added for the Sleep Analytics dashboard. All are captured via the dedicated **Sl
 
 | Key | Type / encoding | Notes |
 |---|---|---|
-| `appleSleepScore` | `number` 0-100 | Apple Watch overall Sleep Score (PRIMARY signal) |
-| `appleSleepBedtimeScore` | `number` 0-100 | Apple Watch bedtime sub-score |
-| `appleSleepDurationScore` | `number` 0-100 | Apple Watch duration sub-score |
-| `appleSleepInterruptionScore` | `number` 0-100 | Apple Watch interruption sub-score |
+| `appleSleepScore` | `number` 0-100 | Apple Watch overall Sleep Score (PRIMARY signal). Equals the sum of the three sub-scores below. |
+| `appleSleepBedtimeScore` | `number` 0-25 | Apple Watch bedtime sub-score (weighted component) |
+| `appleSleepDurationScore` | `number` 0-50 | Apple Watch duration sub-score (weighted component) |
+| `appleSleepInterruptionScore` | `number` 0-25 | Apple Watch interruption sub-score (weighted component) |
 | `sleepBedtimeMinutes` | `number` 0..1439 | Clock time fell asleep, **minutes-after-noon** (see below) |
 | `sleepWakeMinutes` | `number` 0..1439 | Clock time woke, **minutes-after-noon** |
 | `sleepDurationMinutes` | `number` minutes | Total time asleep (e.g. 408 = 6h48m) |

--- a/docs/reference/V1/00_DATA_CONTRACT_WELLBEING_KEYS.md
+++ b/docs/reference/V1/00_DATA_CONTRACT_WELLBEING_KEYS.md
@@ -135,6 +135,58 @@ These keys were added as an **additive superset** to support multiple personas w
 - **Derived**: No
 - **Stability Status**: **LOCKED**
 
+---
+
+## Sleep Analytics Keys (LOCKED)
+
+Added for the Sleep Analytics dashboard. All are captured via the dedicated **SleepEntryForm**
+(launched from the Daily Check-in morning tab), persisted as `WellbeingEntry` records with
+`timeOfDay:'morning'` and `source:'checkin'`. They are **not** part of `WellbeingSession` and are
+**not** rendered as generic check-in sliders (no `METRIC_UI` entry).
+
+### Outcome keys
+
+| Key | Type / encoding | Notes |
+|---|---|---|
+| `appleSleepScore` | `number` 0-100 | Apple Watch overall Sleep Score (PRIMARY signal) |
+| `appleSleepBedtimeScore` | `number` 0-100 | Apple Watch bedtime sub-score |
+| `appleSleepDurationScore` | `number` 0-100 | Apple Watch duration sub-score |
+| `appleSleepInterruptionScore` | `number` 0-100 | Apple Watch interruption sub-score |
+| `sleepBedtimeMinutes` | `number` 0..1439 | Clock time fell asleep, **minutes-after-noon** (see below) |
+| `sleepWakeMinutes` | `number` 0..1439 | Clock time woke, **minutes-after-noon** |
+| `sleepDurationMinutes` | `number` minutes | Total time asleep (e.g. 408 = 6h48m) |
+| `sleepLatencyMinutes` | `number` minutes | Time to fall asleep (deferred from default form) |
+| `sleepAwakenings` | `number` count ≥ 0 | Interruptions during the night (deferred from default form) |
+| `sleepAidUsed` | `number` 0/1 | 1 = a sleep aid was used (e.g. clonazepam) |
+
+### Behavioral correlation factor keys
+
+These replace the user's former "Sleep" habit category; the correlation engine treats them
+identically to habit-derived factor signals.
+
+| Key | Type / encoding | Notes |
+|---|---|---|
+| `factorPhoneInBed` | `number` 0/1 | Phone used in bed |
+| `factorBlueLightMinutes` | `number` minutes ≥ 0 | Blue-light exposure after target time |
+| `factorWindDown` | `number` 0/1 | Completed a wind-down routine |
+| `factorLateNightEating` | `number` 0/1 | Ate within ~3h of bed |
+| `factorCaffeineAfter12` | `number` count ≥ 0 | Caffeinated drinks after noon |
+
+### Minutes-after-noon encoding (clock times)
+
+Bedtime/wake clock times are stored as **minutes elapsed since 12:00 noon**, wrapped into
+`0..1439`, so a normal sleep window stays numerically contiguous across midnight:
+
+```
+minutesAfterNoon = ((hour*60 + minute) - 720 + 1440) % 1440
+// 10:00 PM → 600, 11:58 PM → 718, 12:05 AM → 725, 6:00 AM → 1083
+// inverse: clockMinutes = (minutesAfterNoon + 720) % 1440
+```
+
+- **User Input**: Yes (SleepEntryForm). **Derived**: No. **Stability Status**: **LOCKED**.
+
+---
+
 ### Session Structure Keys
 
 #### `morning`

--- a/src/components/DailyCheckInModal.tsx
+++ b/src/components/DailyCheckInModal.tsx
@@ -44,7 +44,9 @@ type MetricUiConfig = {
     kind?: 'number' | 'text';
 };
 
-const METRIC_UI: Record<WellbeingMetricKey, MetricUiConfig> = {
+// Partial: sleep-analytics metric keys (appleSleepScore, sleep*, factor*) are captured
+// via the dedicated SleepEntryForm, not as generic sliders, so they have no entry here.
+const METRIC_UI: Partial<Record<WellbeingMetricKey, MetricUiConfig>> = {
     depression: { key: 'depression', label: 'Depression (legacy)', icon: <Brain size={16} className="text-blue-400" />, colorClass: 'text-blue-400', min: 1, max: 5, step: 1, kind: 'number' },
     anxiety: { key: 'anxiety', label: 'Anxiety', icon: <Activity size={16} className="text-purple-400" />, colorClass: 'text-purple-400', min: 1, max: 5, step: 1, kind: 'number' },
     energy: { key: 'energy', label: 'Energy', icon: <Battery size={16} className="text-emerald-400" />, colorClass: 'text-emerald-400', min: 1, max: 5, step: 1, kind: 'number' },
@@ -141,7 +143,8 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
 
     const addableMetrics = (WELLBEING_METRIC_KEYS as readonly WellbeingMetricKey[])
         .filter((k) => k !== 'notes')
-        .filter((k) => !subsetSet.has(k));
+        .filter((k) => !subsetSet.has(k))
+        .filter((k) => !!METRIC_UI[k]); // exclude sleep-form-only keys (no slider config)
 
     const handleAddMetric = async (key: WellbeingMetricKey) => {
         const next = Array.from(new Set([...extraKeys, key]));

--- a/src/components/DailyCheckInModal.tsx
+++ b/src/components/DailyCheckInModal.tsx
@@ -6,6 +6,7 @@ import type { WellbeingSession } from '../types';
 import { WELLBEING_METRIC_KEYS, type WellbeingMetricKey } from '../models/persistenceTypes';
 import { getActivePersonaConfig } from '../shared/personas/activePersona';
 import { fetchDashboardPrefs, updateDashboardPrefs } from '../lib/persistenceClient';
+import { SleepEntryForm } from './SleepEntryForm';
 
 interface DailyCheckInModalProps {
     isOpen: boolean;
@@ -72,6 +73,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
     const checkinSubset = persona.checkinSubset;
     const [extraKeys, setExtraKeys] = useState<WellbeingMetricKey[]>([]);
     const [notesOpen, setNotesOpen] = useState(false);
+    const [sleepFormOpen, setSleepFormOpen] = useState(false);
 
     const subsetSet = new Set<WellbeingMetricKey>([
         ...(checkinSubset as WellbeingMetricKey[]),
@@ -220,6 +222,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
     if (!isOpen) return null;
 
     return (
+      <>
         <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
             <div className="bg-neutral-900 border border-white/10 rounded-2xl w-full max-w-md max-h-[90dvh] shadow-2xl overflow-hidden flex flex-col animate-in fade-in zoom-in duration-200">
                 {/* Header with Tabs */}
@@ -272,6 +275,20 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
 
                 {/* Body */}
                 <div className="flex-1 overflow-y-auto modal-scroll p-6 space-y-6">
+                    {/* Dedicated sleep logging (morning) — feeds Sleep Analytics */}
+                    {activeTab === 'morning' && (
+                        <button
+                            type="button"
+                            onClick={() => setSleepFormOpen(true)}
+                            className="w-full flex items-center justify-between gap-2 px-4 py-3 bg-indigo-500/10 border border-indigo-500/30 rounded-xl text-indigo-300 hover:bg-indigo-500/15 transition-colors"
+                        >
+                            <span className="flex items-center gap-2 text-sm font-medium">
+                                <Moon size={16} className="text-indigo-400" /> Log Sleep (Apple Watch score & schedule)
+                            </span>
+                            <span className="text-xs text-indigo-400/70">Open</span>
+                        </button>
+                    )}
+
                     {/* Render persona-selected metric subset from the canonical superset */}
                     {checkinSubset
                         .filter((k): k is WellbeingMetricKey => (WELLBEING_METRIC_KEYS as readonly string[]).includes(k))
@@ -449,5 +466,7 @@ export const DailyCheckInModal: React.FC<DailyCheckInModalProps> = ({ isOpen, on
                 </div>
             </div>
         </div>
+        <SleepEntryForm isOpen={sleepFormOpen} onClose={() => setSleepFormOpen(false)} />
+      </>
     );
 };

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -362,6 +362,31 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
 
               <div className="border-b border-white/5" />
 
+              {/* Sleep Analytics */}
+              <div className="pl-3 border-l-2 border-emerald-500/40">
+                <p className="text-sm text-neutral-200">
+                  <span className="font-bold text-emerald-400">Sleep Analytics</span>
+                </p>
+                <p className="text-sm text-neutral-300 mt-1">A dedicated Sleep tab in Analytics built around your Apple Watch Sleep Score (overall plus bedtime, duration, and interruption sub-scores). Use the "Log Sleep" button on the morning check-in to record your score, bedtime/wake times, duration, quality, and last-night habits.</p>
+                <ul className="mt-1.5 space-y-1.5">
+                  <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
+                    <Activity size={13} className="text-emerald-400 mt-0.5 shrink-0" />
+                    <span><span className="font-semibold text-emerald-400">Consistency Score</span> — rewards similar bedtime and wake times night-to-night, independent of how long you sleep.</span>
+                  </li>
+                  <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
+                    <Activity size={13} className="text-emerald-400 mt-0.5 shrink-0" />
+                    <span><span className="font-semibold text-emerald-400">Independence</span> — tracks sleep-aid-free nights and streaks to help reduce reliance on sleep aids.</span>
+                  </li>
+                  <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
+                    <Activity size={13} className="text-emerald-400 mt-0.5 shrink-0" />
+                    <span><span className="font-semibold text-emerald-400">Correlations</span> — surfaces which behaviors (phone in bed, blue light, caffeine, wind-down, late eating, and more) line up with better or worse sleep, always framed as correlation, not proof.</span>
+                  </li>
+                </ul>
+                <p className="text-xs text-neutral-500 mt-2">Set your own target bedtime, wake time, and duration (default 10 PM / 6 AM / 8h) from the Log Sleep form.</p>
+              </div>
+
+              <div className="border-b border-white/5" />
+
               {/* Goal Types */}
               <div className="pl-3 border-l-2 border-emerald-500/40">
                 <p className="text-sm text-neutral-200">

--- a/src/components/SleepEntryForm.tsx
+++ b/src/components/SleepEntryForm.tsx
@@ -1,0 +1,321 @@
+import React, { useEffect, useState } from 'react';
+import { X, Save, Watch, Clock, Sunrise, Moon, Settings2 } from 'lucide-react';
+import { format } from 'date-fns';
+import {
+  fetchWellbeingEntries,
+  upsertWellbeingEntries,
+  fetchDashboardPrefs,
+  updateDashboardPrefs,
+  getLocalTimeZone,
+} from '../lib/persistenceClient';
+import type { WellbeingMetricKey } from '../models/persistenceTypes';
+import {
+  timeStringToMinutesAfterNoon,
+  minutesAfterNoonToTimeString,
+} from './analytics/sleep/sleepFormat';
+
+interface SleepEntryFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+const DEFAULT_TARGETS = { bedtimeMinutes: 600, wakeMinutes: 1080, durationMinutes: 480 };
+
+/** numeric field state stored as string for controlled inputs */
+type NumStr = string;
+
+export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose, onSaved }) => {
+  const today = format(new Date(), 'yyyy-MM-dd');
+
+  // Sleep results
+  const [bedtime, setBedtime] = useState('');     // "HH:MM" 24h
+  const [wake, setWake] = useState('');
+  const [appleScore, setAppleScore] = useState<NumStr>('');
+  const [bedtimeScore, setBedtimeScore] = useState<NumStr>('');
+  const [durationScore, setDurationScore] = useState<NumStr>('');
+  const [interruptionScore, setInterruptionScore] = useState<NumStr>('');
+  const [durationH, setDurationH] = useState<NumStr>('');
+  const [durationM, setDurationM] = useState<NumStr>('');
+  const [quality, setQuality] = useState<number>(2);
+
+  // Last night's habits
+  const [aidUsed, setAidUsed] = useState(false);
+  const [phoneInBed, setPhoneInBed] = useState(false);
+  const [windDown, setWindDown] = useState(false);
+  const [lateEating, setLateEating] = useState(false);
+  const [blueLight, setBlueLight] = useState<NumStr>('');
+  const [caffeine, setCaffeine] = useState<NumStr>('');
+
+  // Targets
+  const [showTargets, setShowTargets] = useState(false);
+  const [targetBedtime, setTargetBedtime] = useState(minutesAfterNoonToTimeString(DEFAULT_TARGETS.bedtimeMinutes));
+  const [targetWake, setTargetWake] = useState(minutesAfterNoonToTimeString(DEFAULT_TARGETS.wakeMinutes));
+  const [targetDurationH, setTargetDurationH] = useState('8');
+
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [entries, prefs] = await Promise.all([
+          fetchWellbeingEntries({ startDayKey: today, endDayKey: today }),
+          fetchDashboardPrefs(),
+        ]);
+        if (cancelled) return;
+        const byKey = new Map<string, number>();
+        for (const e of entries) {
+          if (e.timeOfDay === 'morning' && typeof e.value === 'number') byKey.set(e.metricKey, e.value);
+        }
+        const num = (k: string) => (byKey.has(k) ? String(byKey.get(k)) : '');
+        if (byKey.has('sleepBedtimeMinutes')) setBedtime(minutesAfterNoonToTimeString(byKey.get('sleepBedtimeMinutes')!));
+        if (byKey.has('sleepWakeMinutes')) setWake(minutesAfterNoonToTimeString(byKey.get('sleepWakeMinutes')!));
+        setAppleScore(num('appleSleepScore'));
+        setBedtimeScore(num('appleSleepBedtimeScore'));
+        setDurationScore(num('appleSleepDurationScore'));
+        setInterruptionScore(num('appleSleepInterruptionScore'));
+        if (byKey.has('sleepDurationMinutes')) {
+          const d = byKey.get('sleepDurationMinutes')!;
+          setDurationH(String(Math.floor(d / 60)));
+          setDurationM(String(d % 60));
+        }
+        if (byKey.has('sleepQuality')) setQuality(byKey.get('sleepQuality')!);
+        setAidUsed((byKey.get('sleepAidUsed') ?? 0) >= 1);
+        setPhoneInBed((byKey.get('factorPhoneInBed') ?? 0) >= 1);
+        setWindDown((byKey.get('factorWindDown') ?? 0) >= 1);
+        setLateEating((byKey.get('factorLateNightEating') ?? 0) >= 1);
+        setBlueLight(num('factorBlueLightMinutes'));
+        setCaffeine(num('factorCaffeineAfter12'));
+
+        const t = prefs.sleepTargets ?? DEFAULT_TARGETS;
+        setTargetBedtime(minutesAfterNoonToTimeString(t.bedtimeMinutes));
+        setTargetWake(minutesAfterNoonToTimeString(t.wakeMinutes));
+        setTargetDurationH(String(Math.round((t.durationMinutes / 60) * 10) / 10));
+      } catch {
+        // best-effort prefill
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [isOpen, today]);
+
+  if (!isOpen) return null;
+
+  const parseIntOrNull = (s: string): number | null => {
+    if (s.trim() === '') return null;
+    const n = Math.round(Number(s));
+    return Number.isFinite(n) ? n : null;
+  };
+
+  const computedDuration = (): number | null => {
+    const h = parseIntOrNull(durationH);
+    const m = parseIntOrNull(durationM);
+    if (h === null && m === null) {
+      // derive from bedtime/wake if available
+      const b = timeStringToMinutesAfterNoon(bedtime);
+      const w = timeStringToMinutesAfterNoon(wake);
+      if (b !== null && w !== null) {
+        const diff = (w - b + 1440) % 1440;
+        return diff;
+      }
+      return null;
+    }
+    return (h ?? 0) * 60 + (m ?? 0);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    const entries: Array<{ dayKey: string; timeOfDay: 'morning'; metricKey: WellbeingMetricKey; value: number; source: 'checkin' }> = [];
+    const push = (metricKey: WellbeingMetricKey, value: number | null) => {
+      if (value === null) return;
+      entries.push({ dayKey: today, timeOfDay: 'morning', metricKey, value, source: 'checkin' });
+    };
+
+    const bedMin = timeStringToMinutesAfterNoon(bedtime);
+    const wakeMin = timeStringToMinutesAfterNoon(wake);
+    push('sleepBedtimeMinutes', bedMin);
+    push('sleepWakeMinutes', wakeMin);
+    push('sleepDurationMinutes', computedDuration());
+    push('appleSleepScore', parseIntOrNull(appleScore));
+    push('appleSleepBedtimeScore', parseIntOrNull(bedtimeScore));
+    push('appleSleepDurationScore', parseIntOrNull(durationScore));
+    push('appleSleepInterruptionScore', parseIntOrNull(interruptionScore));
+    push('sleepQuality', quality);
+    // factors (toggles always represent the night)
+    push('sleepAidUsed', aidUsed ? 1 : 0);
+    push('factorPhoneInBed', phoneInBed ? 1 : 0);
+    push('factorWindDown', windDown ? 1 : 0);
+    push('factorLateNightEating', lateEating ? 1 : 0);
+    push('factorBlueLightMinutes', parseIntOrNull(blueLight));
+    push('factorCaffeineAfter12', parseIntOrNull(caffeine));
+
+    try {
+      if (entries.length > 0) {
+        await upsertWellbeingEntries({ entries, defaultTimeZone: getLocalTimeZone() });
+      }
+      onSaved?.();
+      onClose();
+    } catch (error) {
+      console.error('[SleepEntryForm] Failed to save sleep entry:', error);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveTargets = async () => {
+    const b = timeStringToMinutesAfterNoon(targetBedtime) ?? DEFAULT_TARGETS.bedtimeMinutes;
+    const w = timeStringToMinutesAfterNoon(targetWake) ?? DEFAULT_TARGETS.wakeMinutes;
+    const durH = Number(targetDurationH);
+    const durationMinutes = Number.isFinite(durH) ? Math.round(durH * 60) : DEFAULT_TARGETS.durationMinutes;
+    try {
+      await updateDashboardPrefs({ sleepTargets: { bedtimeMinutes: b, wakeMinutes: w, durationMinutes } });
+      setShowTargets(false);
+    } catch (error) {
+      console.error('[SleepEntryForm] Failed to save targets:', error);
+    }
+  };
+
+  return (
+    <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="bg-neutral-900 border border-white/10 rounded-2xl w-full max-w-md max-h-[90dvh] shadow-2xl overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-white/5 bg-neutral-800/50">
+          <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+            <Moon size={18} className="text-indigo-400" /> Log Sleep
+          </h2>
+          <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full hover:bg-white/10 text-neutral-400 hover:text-white" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto modal-scroll p-5 space-y-6">
+          {/* Apple Watch Sleep Score */}
+          <section className="space-y-3">
+            <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wide flex items-center gap-2">
+              <Watch size={14} className="text-indigo-400" /> Apple Watch Sleep Score
+            </h3>
+            <NumberField label="Overall (0-100)" value={appleScore} onChange={setAppleScore} max={100} />
+            <div className="grid grid-cols-3 gap-2">
+              <NumberField label="Bedtime" value={bedtimeScore} onChange={setBedtimeScore} max={100} small />
+              <NumberField label="Duration" value={durationScore} onChange={setDurationScore} max={100} small />
+              <NumberField label="Interrupt." value={interruptionScore} onChange={setInterruptionScore} max={100} small />
+            </div>
+          </section>
+
+          {/* Sleep results */}
+          <section className="space-y-3">
+            <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wide">Sleep results</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <TimeField label="Bedtime" icon={<Clock size={14} className="text-sky-400" />} value={bedtime} onChange={setBedtime} />
+              <TimeField label="Wake time" icon={<Sunrise size={14} className="text-orange-400" />} value={wake} onChange={setWake} />
+            </div>
+            <div>
+              <label className="text-xs text-neutral-400 mb-1 block">Duration (auto from times if blank)</label>
+              <div className="flex items-center gap-2">
+                <NumberField value={durationH} onChange={setDurationH} placeholder="h" inline />
+                <span className="text-neutral-500 text-sm">h</span>
+                <NumberField value={durationM} onChange={setDurationM} placeholder="m" max={59} inline />
+                <span className="text-neutral-500 text-sm">m</span>
+              </div>
+            </div>
+            <div>
+              <div className="flex justify-between text-sm mb-1">
+                <label className="text-neutral-300 font-medium">Sleep quality</label>
+                <span className="text-fuchsia-300 font-bold">{quality}/4</span>
+              </div>
+              <input type="range" min={0} max={4} step={1} value={quality} onChange={(e) => setQuality(Number(e.target.value))}
+                className="w-full h-2 bg-neutral-800 rounded-lg appearance-none cursor-pointer accent-emerald-500" />
+            </div>
+          </section>
+
+          {/* Last night's habits */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wide">Last night's habits</h3>
+            <Toggle label="Used a sleep aid" value={aidUsed} onChange={setAidUsed} />
+            <Toggle label="Phone in bed" value={phoneInBed} onChange={setPhoneInBed} />
+            <Toggle label="Wind-down routine" value={windDown} onChange={setWindDown} />
+            <Toggle label="Late-night eating (within ~3h)" value={lateEating} onChange={setLateEating} />
+            <div className="grid grid-cols-2 gap-3 pt-1">
+              <NumberField label="Blue light (min)" value={blueLight} onChange={setBlueLight} />
+              <NumberField label="Caffeine after 12 (count)" value={caffeine} onChange={setCaffeine} />
+            </div>
+          </section>
+
+          {/* Targets */}
+          <section>
+            <button onClick={() => setShowTargets((s) => !s)} className="text-xs text-neutral-400 hover:text-white flex items-center gap-1.5">
+              <Settings2 size={13} /> Sleep goal (targets)
+            </button>
+            {showTargets && (
+              <div className="mt-3 space-y-3 bg-neutral-800/40 rounded-xl p-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <TimeField label="Target bedtime" value={targetBedtime} onChange={setTargetBedtime} />
+                  <TimeField label="Target wake" value={targetWake} onChange={setTargetWake} />
+                </div>
+                <NumberField label="Target duration (h)" value={targetDurationH} onChange={setTargetDurationH} />
+                <button onClick={saveTargets} className="text-xs px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg">
+                  Save targets
+                </button>
+              </div>
+            )}
+          </section>
+        </div>
+
+        <div className="p-4 border-t border-white/5 bg-neutral-800/50 flex justify-end">
+          <button onClick={handleSave} disabled={saving} type="button"
+            className="flex items-center gap-2 px-6 py-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-60 text-white rounded-lg font-medium transition-colors">
+            <Save size={18} /> {saving ? 'Saving…' : 'Save Sleep'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Small inputs ──────────────────────────────────────────────────────────────
+
+function NumberField({ label, value, onChange, max, small, inline, placeholder }: {
+  label?: string; value: string; onChange: (v: string) => void; max?: number; small?: boolean; inline?: boolean; placeholder?: string;
+}) {
+  return (
+    <div className={inline ? '' : 'space-y-1'}>
+      {label && <label className={`text-xs text-neutral-400 block ${small ? 'text-[10px]' : ''}`}>{label}</label>}
+      <input
+        type="number"
+        inputMode="numeric"
+        min={0}
+        max={max}
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className={`bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-emerald-500 outline-none ${inline ? 'w-16' : 'w-full'}`}
+      />
+    </div>
+  );
+}
+
+function TimeField({ label, value, onChange, icon }: { label: string; value: string; onChange: (v: string) => void; icon?: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs text-neutral-400 flex items-center gap-1.5">{icon}{label}</label>
+      <input
+        type="time"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-emerald-500 outline-none"
+      />
+    </div>
+  );
+}
+
+function Toggle({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button type="button" onClick={() => onChange(!value)} className="w-full flex items-center justify-between py-2">
+      <span className="text-sm text-neutral-300">{label}</span>
+      <span className={`relative w-10 h-6 rounded-full transition-colors ${value ? 'bg-emerald-500' : 'bg-neutral-700'}`}>
+        <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${value ? 'translate-x-4' : ''}`} />
+      </span>
+    </button>
+  );
+}

--- a/src/components/SleepEntryForm.tsx
+++ b/src/components/SleepEntryForm.tsx
@@ -108,6 +108,24 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
     return Number.isFinite(n) ? n : null;
   };
 
+  /**
+   * Apple's sleep score = duration (0-50) + bedtime (0-25) + interruption (0-25).
+   * When the user enters any sub-score, auto-fill the overall as their sum so the
+   * primary signal stays consistent (still manually overridable afterward).
+   */
+  const setSubScore = (which: 'bedtime' | 'duration' | 'interruption', raw: string) => {
+    const next = { bedtime: bedtimeScore, duration: durationScore, interruption: interruptionScore };
+    next[which] = raw;
+    if (which === 'bedtime') setBedtimeScore(raw);
+    if (which === 'duration') setDurationScore(raw);
+    if (which === 'interruption') setInterruptionScore(raw);
+    const anyPresent = [next.bedtime, next.duration, next.interruption].some((v) => v.trim() !== '');
+    if (anyPresent) {
+      const sum = (parseIntOrNull(next.bedtime) ?? 0) + (parseIntOrNull(next.duration) ?? 0) + (parseIntOrNull(next.interruption) ?? 0);
+      setAppleScore(String(sum));
+    }
+  };
+
   const computedDuration = (): number | null => {
     const h = parseIntOrNull(durationH);
     const m = parseIntOrNull(durationM);
@@ -195,11 +213,11 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
             <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wide flex items-center gap-2">
               <Watch size={14} className="text-indigo-400" /> Apple Watch Sleep Score
             </h3>
-            <NumberField label="Overall (0-100)" value={appleScore} onChange={setAppleScore} max={100} />
+            <NumberField label="Overall (0-100, auto-sums from components)" value={appleScore} onChange={setAppleScore} max={100} />
             <div className="grid grid-cols-3 gap-2">
-              <NumberField label="Bedtime" value={bedtimeScore} onChange={setBedtimeScore} max={100} small />
-              <NumberField label="Duration" value={durationScore} onChange={setDurationScore} max={100} small />
-              <NumberField label="Interrupt." value={interruptionScore} onChange={setInterruptionScore} max={100} small />
+              <NumberField label="Duration /50" value={durationScore} onChange={(v) => setSubScore('duration', v)} max={50} small />
+              <NumberField label="Bedtime /25" value={bedtimeScore} onChange={(v) => setSubScore('bedtime', v)} max={25} small />
+              <NumberField label="Interrupt. /25" value={interruptionScore} onChange={(v) => setSubScore('interruption', v)} max={25} small />
             </div>
           </section>
 

--- a/src/components/analytics/sleep/SleepAchievements.tsx
+++ b/src/components/analytics/sleep/SleepAchievements.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Flame, Heart, Award, Leaf, Timer } from 'lucide-react';
+import type { SleepAnalyticsSummary, SleepAchievement } from '../../../lib/analyticsClient';
+import { formatDurationMinutes } from './sleepFormat';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+const ICONS: Record<SleepAchievement['icon'], React.ComponentType<{ size?: number; className?: string }>> = {
+  streak: Flame,
+  quality: Heart,
+  consistency: Award,
+  aidfree: Leaf,
+  latency: Timer,
+};
+
+function formatValue(a: SleepAchievement): string {
+  if (a.value === null || a.value === undefined) return '—';
+  switch (a.icon) {
+    case 'streak':
+    case 'aidfree':
+      return `${a.value} night${a.value === 1 ? '' : 's'}`;
+    case 'quality':
+      return `${a.value}/10`;
+    case 'consistency':
+      return `${a.value}%`;
+    case 'latency':
+      return formatDurationMinutes(a.value);
+    default:
+      return `${a.value}`;
+  }
+}
+
+export const SleepAchievements: React.FC<Props> = ({ data, loading }) => {
+  if (loading) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Achievements</h3>
+        <div className="grid grid-cols-2 gap-3">
+          {[0, 1, 2, 3].map((i) => <div key={i} className="h-16 bg-neutral-800 rounded animate-pulse" />)}
+        </div>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+      <h3 className="text-sm font-medium text-neutral-400 mb-3">Achievements</h3>
+      <div className="grid grid-cols-2 gap-3">
+        {data.achievements.map((a) => {
+          const Icon = ICONS[a.icon];
+          return (
+            <div
+              key={a.id}
+              className={`rounded-xl p-3 border ${a.earned ? 'bg-emerald-500/10 border-emerald-500/30' : 'bg-neutral-800/40 border-white/5'}`}
+              title={a.description}
+            >
+              <div className="flex items-center gap-2">
+                <Icon size={16} className={a.earned ? 'text-emerald-400' : 'text-neutral-500'} />
+                <span className="text-lg font-bold text-white">{formatValue(a)}</span>
+              </div>
+              <div className="text-[11px] text-neutral-400 mt-1 leading-tight">{a.label}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/SleepAnalytics.tsx
+++ b/src/components/analytics/sleep/SleepAnalytics.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { SleepAnalyticsSummary } from '../../../lib/analyticsClient';
+import { SleepSummaryCards } from './SleepSummaryCards';
+import { SleepDurationTrendChart } from './SleepDurationTrendChart';
+import { SleepScheduleTrendChart } from './SleepScheduleTrendChart';
+import { SleepWeeklySummary } from './SleepWeeklySummary';
+import { SleepFactorsPanel } from './SleepFactorsPanel';
+import { SleepAchievements } from './SleepAchievements';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+export const SleepAnalytics: React.FC<Props> = ({ data, loading }) => {
+  return (
+    <div className="space-y-4">
+      <SleepSummaryCards data={data} loading={loading} />
+      <SleepScheduleTrendChart data={data} loading={loading} />
+      <SleepDurationTrendChart data={data} loading={loading} />
+      <SleepFactorsPanel data={data} loading={loading} />
+      <SleepWeeklySummary data={data} loading={loading} />
+      <SleepAchievements data={data} loading={loading} />
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/SleepDurationTrendChart.tsx
+++ b/src/components/analytics/sleep/SleepDurationTrendChart.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo } from 'react';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import type { SleepAnalyticsSummary } from '../../../lib/analyticsClient';
+import { formatDurationMinutes } from './sleepFormat';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+function shortDay(dayKey: string): string {
+  return dayKey.slice(5); // MM-DD
+}
+
+export const SleepDurationTrendChart: React.FC<Props> = ({ data, loading }) => {
+  const points = useMemo(() => {
+    if (!data) return null;
+    const pts = data.trend
+      .map((p) => ({ dayKey: p.dayKey, hours: p.durationMinutes === null ? null : Math.round((p.durationMinutes / 60) * 100) / 100 }));
+    return pts.some((p) => p.hours !== null) ? pts : null;
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Sleep Duration Trend</h3>
+        <div className="h-52 bg-neutral-800 rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!points) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Sleep Duration Trend</h3>
+        <p className="text-neutral-500 text-sm">Not enough data yet. Log a few nights to see your trend.</p>
+      </div>
+    );
+  }
+
+  const targetHours = (data!.targets.durationMinutes / 60);
+
+  return (
+    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-neutral-400">Sleep Duration Trend</h3>
+        <span className="text-[10px] text-neutral-500">target {formatDurationMinutes(data!.targets.durationMinutes)}</span>
+      </div>
+      <ResponsiveContainer width="100%" height={220}>
+        <AreaChart data={points} margin={{ top: 10, right: 5, left: -20, bottom: 5 }}>
+          <defs>
+            <linearGradient id="durationGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="#262626" />
+          <XAxis dataKey="dayKey" tick={{ fill: '#737373', fontSize: 10 }} tickFormatter={shortDay} minTickGap={20} />
+          <YAxis tick={{ fill: '#737373', fontSize: 10 }} domain={[0, 12]} tickFormatter={(v: number) => `${v}h`} />
+          <Tooltip
+            contentStyle={{ backgroundColor: '#171717', border: '1px solid #333', borderRadius: 8 }}
+            labelStyle={{ color: '#a3a3a3' }}
+            formatter={(value: number) => [formatDurationMinutes(value * 60), 'Slept']}
+          />
+          <ReferenceLine y={targetHours} stroke="#6366f1" strokeDasharray="6 3" />
+          <Area type="monotone" dataKey="hours" stroke="#10b981" strokeWidth={2} fill="url(#durationGradient)" connectNulls dot={{ r: 2, fill: '#10b981' }} />
+        </AreaChart>
+      </ResponsiveContainer>
+      <div className="flex items-center gap-4 mt-2 text-[10px] text-neutral-500">
+        <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-emerald-500 rounded" /> Hours slept</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-indigo-500 rounded" /> Target</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/SleepFactorsPanel.tsx
+++ b/src/components/analytics/sleep/SleepFactorsPanel.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Lightbulb, ArrowUpRight, ArrowDownRight } from 'lucide-react';
+import type { SleepAnalyticsSummary } from '../../../lib/analyticsClient';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+export const SleepFactorsPanel: React.FC<Props> = ({ data, loading }) => {
+  if (loading) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Top Factors Impacting Sleep</h3>
+        <div className="space-y-2">
+          {[0, 1, 2].map((i) => <div key={i} className="h-12 bg-neutral-800 rounded animate-pulse" />)}
+        </div>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const factors = data.topFactors;
+  const maxEffect = factors.reduce((m, f) => Math.max(m, Math.abs(f.effectSize)), 0) || 1;
+
+  return (
+    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+      <div className="flex items-center gap-2 mb-3">
+        <Lightbulb size={16} className="text-amber-400" />
+        <h3 className="text-sm font-medium text-neutral-200">Top Factors Impacting Sleep</h3>
+      </div>
+
+      {factors.length === 0 ? (
+        <p className="text-neutral-500 text-sm">
+          Not enough overlapping data yet. Keep logging your nightly habits — factors appear once a habit has at least 5 nights in each group.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {factors.map((f) => {
+            const improves = f.direction === 'improves';
+            const color = improves ? 'bg-emerald-500' : 'bg-red-500';
+            const textColor = improves ? 'text-emerald-400' : 'text-red-400';
+            const width = `${Math.max(8, Math.round((Math.abs(f.effectSize) / maxEffect) * 100))}%`;
+            return (
+              <div key={`${f.factorId}-${f.outcome}`} className="bg-neutral-800/40 rounded-xl p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium text-white flex items-center gap-1.5">
+                    {improves ? <ArrowUpRight size={14} className={textColor} /> : <ArrowDownRight size={14} className={textColor} />}
+                    {f.factorName}
+                  </span>
+                  <span className="text-[11px] text-neutral-500 shrink-0">n={f.nPresent} vs {f.nAbsent}</span>
+                </div>
+                <div className="h-1.5 bg-neutral-700/50 rounded-full mt-2 overflow-hidden">
+                  <div className={`h-full ${color} rounded-full`} style={{ width }} />
+                </div>
+                <p className="text-[11px] text-neutral-400 mt-1.5 leading-snug">{f.message}</p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/SleepScheduleTrendChart.tsx
+++ b/src/components/analytics/sleep/SleepScheduleTrendChart.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import type { SleepAnalyticsSummary } from '../../../lib/analyticsClient';
+import { minutesAfterNoonToClock } from './sleepFormat';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+function shortDay(dayKey: string): string {
+  return dayKey.slice(5);
+}
+
+export const SleepScheduleTrendChart: React.FC<Props> = ({ data, loading }) => {
+  const points = useMemo(() => {
+    if (!data) return null;
+    const pts = data.trend.map((p) => ({ dayKey: p.dayKey, bedtime: p.bedtimeMinutes, wake: p.wakeMinutes }));
+    return pts.some((p) => p.bedtime !== null || p.wake !== null) ? pts : null;
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Bedtime & Wake Trend</h3>
+        <div className="h-52 bg-neutral-800 rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!points) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Bedtime & Wake Trend</h3>
+        <p className="text-neutral-500 text-sm">Not enough data yet. Log bedtime and wake times to see drift vs your targets.</p>
+      </div>
+    );
+  }
+
+  const { bedtimeMinutes, wakeMinutes } = data!.targets;
+
+  return (
+    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-neutral-400">Bedtime & Wake Trend</h3>
+        <span className="text-[10px] text-neutral-500">
+          targets {minutesAfterNoonToClock(bedtimeMinutes)} / {minutesAfterNoonToClock(wakeMinutes)}
+        </span>
+      </div>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={points} margin={{ top: 10, right: 5, left: -8, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#262626" />
+          <XAxis dataKey="dayKey" tick={{ fill: '#737373', fontSize: 10 }} tickFormatter={shortDay} minTickGap={20} />
+          <YAxis
+            tick={{ fill: '#737373', fontSize: 10 }}
+            domain={[0, 1440]}
+            ticks={[360, 540, 720, 900, 1080, 1260]}
+            tickFormatter={(v: number) => minutesAfterNoonToClock(v)}
+            width={56}
+          />
+          <Tooltip
+            contentStyle={{ backgroundColor: '#171717', border: '1px solid #333', borderRadius: 8 }}
+            labelStyle={{ color: '#a3a3a3' }}
+            formatter={(value: number, name: string) => [minutesAfterNoonToClock(value), name === 'bedtime' ? 'Bedtime' : 'Wake']}
+          />
+          <ReferenceLine y={bedtimeMinutes} stroke="#6366f1" strokeDasharray="6 3" />
+          <ReferenceLine y={wakeMinutes} stroke="#f59e0b" strokeDasharray="6 3" />
+          <Line type="monotone" dataKey="bedtime" stroke="#818cf8" strokeWidth={2} connectNulls dot={{ r: 2, fill: '#818cf8' }} />
+          <Line type="monotone" dataKey="wake" stroke="#fbbf24" strokeWidth={2} connectNulls dot={{ r: 2, fill: '#fbbf24' }} />
+        </LineChart>
+      </ResponsiveContainer>
+      <div className="flex items-center gap-4 mt-2 text-[10px] text-neutral-500">
+        <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-indigo-400 rounded" /> Bedtime</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-amber-400 rounded" /> Wake</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-indigo-500 rounded" /> / target lines</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/SleepSummaryCards.tsx
+++ b/src/components/analytics/sleep/SleepSummaryCards.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { Moon, Sunrise, Clock, Timer, Heart, Watch, Flame, TrendingUp, TrendingDown, Minus, Info, ShieldCheck } from 'lucide-react';
+import { Tooltip } from 'react-tooltip';
+import type { SleepAnalyticsSummary, SleepStat } from '../../../lib/analyticsClient';
+import { formatDurationMinutes, minutesAfterNoonToClock } from './sleepFormat';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+function SkeletonCard({ large }: { large?: boolean }) {
+  return (
+    <div className={`bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm ${large ? 'col-span-2' : ''}`}>
+      <div className="h-4 w-20 bg-neutral-800 rounded animate-pulse mb-3" />
+      <div className="h-9 w-24 bg-neutral-800 rounded animate-pulse mb-2" />
+      <div className="h-3 w-16 bg-neutral-800 rounded animate-pulse" />
+    </div>
+  );
+}
+
+/** Render a stat's period-over-period trend with polarity-aware coloring. */
+function TrendLabel({ stat, format, neutral }: { stat: SleepStat; format: (delta: number) => string; neutral?: boolean }) {
+  if (stat.trendDirection === null || stat.trendDelta === null) {
+    return <span className="text-[11px] text-neutral-500">vs prev —</span>;
+  }
+  if (stat.trendDirection === 'stable') {
+    return (
+      <span className="flex items-center gap-1 text-blue-400 text-[11px] font-medium">
+        <Minus size={12} /> Stable
+      </span>
+    );
+  }
+  const better = stat.trendDirection === 'better';
+  const color = neutral ? 'text-neutral-300' : better ? 'text-emerald-400' : 'text-red-400';
+  const Icon = stat.trendDelta >= 0 ? TrendingUp : TrendingDown;
+  return (
+    <span className={`flex items-center gap-1 ${color} text-[11px] font-medium`}>
+      <Icon size={12} /> {format(stat.trendDelta)}
+    </span>
+  );
+}
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tooltip: string;
+  stat?: SleepStat;
+  trendFormat?: (delta: number) => string;
+  trendNeutral?: boolean;
+  accent?: string;
+}
+
+function StatCard({ icon, label, value, tooltip, stat, trendFormat, trendNeutral, accent }: StatCardProps) {
+  return (
+    <div className={`bg-neutral-900/50 rounded-2xl border ${accent ?? 'border-white/5'} p-4 backdrop-blur-sm`}>
+      <div className="flex items-center gap-2 mb-1">{icon}</div>
+      <div className="text-2xl font-bold text-white mt-1.5">{value}</div>
+      <div className="flex items-center gap-1 mt-1">
+        <span className="text-[11px] text-neutral-400 font-medium">{label}</span>
+        <Info size={11} className="text-neutral-500 cursor-help" data-tooltip-id="sleep-summary-tooltip" data-tooltip-content={tooltip} />
+      </div>
+      {stat && trendFormat && (
+        <div className="mt-1.5">
+          <TrendLabel stat={stat} format={trendFormat} neutral={trendNeutral} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function avgFromNights(nights: SleepAnalyticsSummary['nights'], field: 'bedtimeScore' | 'durationScore' | 'interruptionScore'): number | null {
+  const vals = nights.map((n) => n[field]).filter((v): v is number => typeof v === 'number');
+  if (!vals.length) return null;
+  return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
+}
+
+export const SleepSummaryCards: React.FC<Props> = ({ data, loading }) => {
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <SkeletonCard large />
+        <div className="grid grid-cols-2 gap-3">
+          <SkeletonCard /> <SkeletonCard /> <SkeletonCard /> <SkeletonCard />
+        </div>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const score = data.avgAppleSleepScore;
+  const sub = {
+    bedtime: avgFromNights(data.nights, 'bedtimeScore'),
+    duration: avgFromNights(data.nights, 'durationScore'),
+    interruption: avgFromNights(data.nights, 'interruptionScore'),
+  };
+  const ind = data.independence;
+
+  return (
+    <div className="space-y-3">
+      {/* Hero — Apple Watch Sleep Score (primary signal) */}
+      <div className="bg-neutral-900/50 rounded-2xl border border-indigo-500/30 p-5 backdrop-blur-sm">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <div className="w-8 h-8 rounded-lg bg-indigo-500/15 flex items-center justify-center">
+                <Watch size={18} className="text-indigo-400" />
+              </div>
+              <span className="text-xs text-neutral-400 font-medium">Apple Watch Sleep Score</span>
+            </div>
+            <div className="text-4xl font-bold text-white">
+              {score.value !== null ? Math.round(score.value) : '—'}
+              {score.value !== null && <span className="text-lg text-neutral-500 font-medium"> /100</span>}
+            </div>
+            <div className="mt-1">
+              <TrendLabel stat={score} format={(d) => `${d > 0 ? '+' : ''}${Math.round(d)} pts`} />
+            </div>
+          </div>
+          <div className="text-right space-y-1 text-[11px] text-neutral-400">
+            <div>Bedtime <span className="text-white font-semibold">{sub.bedtime ?? '—'}</span></div>
+            <div>Duration <span className="text-white font-semibold">{sub.duration ?? '—'}</span></div>
+            <div>Interruption <span className="text-white font-semibold">{sub.interruption ?? '—'}</span></div>
+          </div>
+        </div>
+        <div className="mt-2 text-[10px] text-neutral-600">
+          {score.sampleSize > 0 ? `Based on ${score.sampleSize} night${score.sampleSize === 1 ? '' : 's'}` : 'No data yet'}
+        </div>
+      </div>
+
+      {/* Core metric grid */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatCard
+          icon={<Moon size={16} className="text-indigo-400" />}
+          label="Avg Duration"
+          value={formatDurationMinutes(data.avgDurationMinutes.value)}
+          tooltip="Average time asleep per night over this period."
+          stat={data.avgDurationMinutes}
+          trendFormat={(d) => `${d > 0 ? '+' : ''}${Math.round(d)} min`}
+        />
+        <StatCard
+          icon={<Timer size={16} className="text-amber-400" />}
+          label="Avg Latency"
+          value={data.avgLatencyMinutes.value !== null ? `${Math.round(data.avgLatencyMinutes.value)} min` : '—'}
+          tooltip="Average time to fall asleep. Lower is better."
+          stat={data.avgLatencyMinutes}
+          trendFormat={(d) => `${d > 0 ? '+' : ''}${Math.round(d)} min`}
+        />
+        <StatCard
+          icon={<Clock size={16} className="text-sky-400" />}
+          label="Avg Bedtime"
+          value={minutesAfterNoonToClock(data.avgBedtimeMinutes.value)}
+          tooltip="Average clock time you fell asleep. Trend reflects movement toward your target bedtime."
+          stat={data.avgBedtimeMinutes}
+          trendFormat={(d) => `${Math.abs(Math.round(d))} min ${d <= 0 ? 'earlier' : 'later'}`}
+          trendNeutral
+        />
+        <StatCard
+          icon={<Sunrise size={16} className="text-orange-400" />}
+          label="Avg Wake Time"
+          value={minutesAfterNoonToClock(data.avgWakeMinutes.value)}
+          tooltip="Average clock time you woke. Trend reflects movement toward your target wake time."
+          stat={data.avgWakeMinutes}
+          trendFormat={(d) => `${Math.abs(Math.round(d))} min ${d <= 0 ? 'earlier' : 'later'}`}
+          trendNeutral
+        />
+        <StatCard
+          icon={<Heart size={16} className="text-fuchsia-300" />}
+          label="Avg Quality"
+          value={data.avgSleepQuality0to10.value !== null ? `${data.avgSleepQuality0to10.value} /10` : '—'}
+          tooltip="Your subjective sleep quality, rescaled to a 0-10 scale."
+          stat={data.avgSleepQuality0to10}
+          trendFormat={(d) => `${d > 0 ? '+' : ''}${d}`}
+        />
+        <StatCard
+          icon={<Flame size={16} className="text-emerald-400" />}
+          label="Consistency"
+          value={data.consistencyScore !== null ? `${data.consistencyScore}%` : '—'}
+          tooltip="How tightly your bedtime AND wake time cluster night-to-night, independent of how long you sleep."
+          accent="border-emerald-500/20"
+        />
+      </div>
+
+      {/* Sleep Independence */}
+      <div className="bg-neutral-900/50 rounded-2xl border border-teal-500/20 p-5 backdrop-blur-sm">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="w-8 h-8 rounded-lg bg-teal-500/15 flex items-center justify-center">
+            <ShieldCheck size={18} className="text-teal-400" />
+          </div>
+          <span className="text-xs text-neutral-400 font-medium">Sleep Independence</span>
+          <Info size={11} className="text-neutral-500 cursor-help" data-tooltip-id="sleep-summary-tooltip"
+            data-tooltip-content="Your reliance on sleep aids. Higher aid-free percentage and longer aid-free streaks are the goal." />
+        </div>
+        <div className="grid grid-cols-3 gap-3 mt-1">
+          <div>
+            <div className="text-2xl font-bold text-white">
+              {ind.aidFreePercent !== null ? `${Math.round(ind.aidFreePercent * 100)}%` : '—'}
+            </div>
+            <div className="text-[10px] text-neutral-400 mt-0.5">Aid-free nights</div>
+          </div>
+          <div>
+            <div className="text-2xl font-bold text-white">{ind.currentAidFreeStreak}</div>
+            <div className="text-[10px] text-neutral-400 mt-0.5">Current streak</div>
+          </div>
+          <div>
+            <div className="text-2xl font-bold text-white">{ind.aidNights}</div>
+            <div className="text-[10px] text-neutral-400 mt-0.5">Aid nights</div>
+          </div>
+        </div>
+        {ind.trendDirection && ind.trendDelta !== null && (
+          <div className="mt-2">
+            <TrendLabel
+              stat={{ value: ind.aidFreePercent, sampleSize: ind.sampleSize, trendDelta: ind.trendDelta, trendDirection: ind.trendDirection }}
+              format={(d) => `${d > 0 ? '+' : ''}${d}% aid-free`}
+            />
+          </div>
+        )}
+      </div>
+
+      <Tooltip
+        id="sleep-summary-tooltip"
+        className="z-50 !bg-neutral-800 !text-white !opacity-100 !rounded-lg !px-3 !py-2 !text-xs !max-w-[220px]"
+      />
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/SleepSummaryCards.tsx
+++ b/src/components/analytics/sleep/SleepSummaryCards.tsx
@@ -118,9 +118,9 @@ export const SleepSummaryCards: React.FC<Props> = ({ data, loading }) => {
             </div>
           </div>
           <div className="text-right space-y-1 text-[11px] text-neutral-400">
-            <div>Bedtime <span className="text-white font-semibold">{sub.bedtime ?? '—'}</span></div>
-            <div>Duration <span className="text-white font-semibold">{sub.duration ?? '—'}</span></div>
-            <div>Interruption <span className="text-white font-semibold">{sub.interruption ?? '—'}</span></div>
+            <div>Duration <span className="text-white font-semibold">{sub.duration ?? '—'}</span><span className="text-neutral-600">/50</span></div>
+            <div>Bedtime <span className="text-white font-semibold">{sub.bedtime ?? '—'}</span><span className="text-neutral-600">/25</span></div>
+            <div>Interruption <span className="text-white font-semibold">{sub.interruption ?? '—'}</span><span className="text-neutral-600">/25</span></div>
           </div>
         </div>
         <div className="mt-2 text-[10px] text-neutral-600">

--- a/src/components/analytics/sleep/SleepWeeklySummary.tsx
+++ b/src/components/analytics/sleep/SleepWeeklySummary.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { SleepAnalyticsSummary } from '../../../lib/analyticsClient';
+import { formatDurationMinutes } from './sleepFormat';
+
+interface Props {
+  data: SleepAnalyticsSummary | null;
+  loading: boolean;
+}
+
+function Cell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="text-center">
+      <div className="text-sm font-bold text-white leading-tight">{value}</div>
+      <div className="text-[10px] text-neutral-400 mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+export const SleepWeeklySummary: React.FC<Props> = ({ data, loading }) => {
+  if (loading) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3">Weekly Sleep Summary</h3>
+        <div className="h-20 bg-neutral-800 rounded animate-pulse" />
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const weeks = [...data.weeklySummary].reverse(); // most recent first
+
+  return (
+    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-5 backdrop-blur-sm">
+      <h3 className="text-sm font-medium text-neutral-400 mb-3">Weekly Sleep Summary</h3>
+      {weeks.length === 0 ? (
+        <p className="text-neutral-500 text-sm">No nights logged yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {weeks.map((w) => (
+            <div key={w.weekLabel} className="bg-neutral-800/40 rounded-xl p-3">
+              <div className="text-[11px] text-neutral-500 mb-2">{w.weekLabel}</div>
+              <div className="grid grid-cols-3 gap-y-3">
+                <Cell label="Avg duration" value={formatDurationMinutes(w.avgDurationMinutes)} />
+                <Cell label="Avg latency" value={w.avgLatencyMinutes !== null ? `${w.avgLatencyMinutes}m` : '—'} />
+                <Cell label="On target" value={`${w.nightsOnTarget}`} />
+                <Cell label="Awakenings" value={w.avgAwakenings !== null ? `${w.avgAwakenings}` : '—'} />
+                <Cell label="Aid-free" value={`${w.sleepAidFreeNights}`} />
+                <Cell label="Morning energy" value={w.avgMorningEnergy !== null ? `${w.avgMorningEnergy}` : '—'} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/analytics/sleep/sleepFormat.ts
+++ b/src/components/analytics/sleep/sleepFormat.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure formatting/encoding helpers for Sleep Analytics.
+ *
+ * Clock times are stored as "minutes-after-noon" (see
+ * docs/reference/V1/00_DATA_CONTRACT_WELLBEING_KEYS.md): minutes elapsed since
+ * 12:00 noon, wrapped into 0..1439, so a normal sleep window stays numerically
+ * contiguous across midnight (10 PM → 600, 12:05 AM → 725, 6 AM → 1083).
+ *
+ * Keeping these out of components makes them trivially unit-testable.
+ */
+
+const MINUTES_PER_DAY = 1440;
+const NOON_OFFSET = 720;
+
+/** Encode a wall-clock time (0-23h, 0-59m) to minutes-after-noon (0..1439). */
+export function clockToMinutesAfterNoon(hour: number, minute: number): number {
+  return ((hour * 60 + minute) - NOON_OFFSET + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+}
+
+/** Decode minutes-after-noon back to minutes-after-midnight (0..1439). */
+export function minutesAfterNoonToClockMinutes(minutesAfterNoon: number): number {
+  return (Math.round(minutesAfterNoon) + NOON_OFFSET) % MINUTES_PER_DAY;
+}
+
+/**
+ * Parse an <input type="time"> value ("HH:MM", 24h) to minutes-after-noon.
+ * Returns null for empty/invalid input.
+ */
+export function timeStringToMinutesAfterNoon(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!m) return null;
+  const hour = Number(m[1]);
+  const minute = Number(m[2]);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return clockToMinutesAfterNoon(hour, minute);
+}
+
+/** Format minutes-after-noon as a 24h "HH:MM" string for <input type="time">. */
+export function minutesAfterNoonToTimeString(minutesAfterNoon: number | null | undefined): string {
+  if (minutesAfterNoon == null || !Number.isFinite(minutesAfterNoon)) return '';
+  const clock = minutesAfterNoonToClockMinutes(minutesAfterNoon);
+  const hh = String(Math.floor(clock / 60)).padStart(2, '0');
+  const mm = String(clock % 60).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/** Format minutes-after-noon as a human clock label, e.g. "10:02 PM" / "6:08 AM". */
+export function minutesAfterNoonToClock(minutesAfterNoon: number | null | undefined): string {
+  if (minutesAfterNoon == null || !Number.isFinite(minutesAfterNoon)) return '—';
+  const clock = minutesAfterNoonToClockMinutes(minutesAfterNoon);
+  let hour = Math.floor(clock / 60);
+  const minute = clock % 60;
+  const period = hour >= 12 ? 'PM' : 'AM';
+  hour = hour % 12;
+  if (hour === 0) hour = 12;
+  return `${hour}:${String(minute).padStart(2, '0')} ${period}`;
+}
+
+/** Format a duration in minutes as "6h 48m". */
+export function formatDurationMinutes(minutes: number | null | undefined): string {
+  if (minutes == null || !Number.isFinite(minutes)) return '—';
+  const rounded = Math.round(minutes);
+  const h = Math.floor(rounded / 60);
+  const m = rounded % 60;
+  if (h === 0) return `${m}m`;
+  return `${h}h ${String(m).padStart(2, '0')}m`;
+}
+
+/** Rescale a 0-4 subjective sleep-quality score to a 0-10 display value. */
+export function quality4to10(quality0to4: number | null | undefined): number | null {
+  if (quality0to4 == null || !Number.isFinite(quality0to4)) return null;
+  return Math.round(quality0to4 * 2.5 * 10) / 10;
+}

--- a/src/lib/analyticsClient.ts
+++ b/src/lib/analyticsClient.ts
@@ -228,3 +228,130 @@ export interface GoalAnalyticsSummary {
 export async function fetchGoalSummary(days = 90): Promise<GoalAnalyticsSummary> {
   return analyticsRequest(`/analytics/goals/summary${buildParams(days)}`);
 }
+
+// ─── Sleep Analytics ─────────────────────────────────────────────────────────
+
+/** A single headline metric with its sample size and period-over-period trend. */
+export interface SleepStat {
+  /** Average over the window, or null when there is no data. */
+  value: number | null;
+  /** Number of nights that contributed to `value`. */
+  sampleSize: number;
+  /** Signed change vs the previous equal-length period (same units as value). */
+  trendDelta: number | null;
+  /**
+   * Whether the metric improved/worsened vs the previous period.
+   * 'better'/'worse' is interpreted against the metric's polarity by the service.
+   */
+  trendDirection: 'better' | 'worse' | 'stable' | null;
+}
+
+/**
+ * Flat, numeric, null-explicit per-night record. Keyed by the MORNING dayKey the
+ * night was logged under. AI-friendly: future features consume this directly.
+ */
+export interface SleepNight {
+  dayKey: string;
+  appleSleepScore: number | null;
+  bedtimeScore: number | null;
+  durationScore: number | null;
+  interruptionScore: number | null;
+  bedtimeMinutes: number | null;   // minutes-after-noon (0..1439)
+  wakeMinutes: number | null;      // minutes-after-noon (0..1439)
+  durationMinutes: number | null;
+  latencyMinutes: number | null;
+  awakenings: number | null;
+  sleepAidUsed: boolean | null;
+  sleepQuality0to4: number | null;
+  morningEnergy: number | null;
+  hasData: boolean;
+}
+
+export interface SleepTrendPoint {
+  dayKey: string;
+  durationMinutes: number | null;
+  appleSleepScore: number | null;
+  bedtimeMinutes: number | null;   // minutes-after-noon (for bedtime chart + 10PM line)
+  wakeMinutes: number | null;      // minutes-after-noon (for wake chart + 6AM line)
+  sleepQuality0to10: number | null;
+}
+
+export interface SleepWeekSummary {
+  weekLabel: string;               // ISO week, matches TrendDataPoint convention
+  avgDurationMinutes: number | null;
+  avgLatencyMinutes: number | null;
+  nightsOnTarget: number;
+  avgAwakenings: number | null;
+  sleepAidFreeNights: number;
+  avgMorningEnergy: number | null;
+}
+
+export interface SleepFactorInsight {
+  factorId: string;                // metricKey or habitId
+  factorName: string;
+  source: 'form' | 'habit';
+  outcome: 'appleSleepScore' | 'sleepQuality' | 'latencyMinutes' | 'bedtimeMinutes';
+  factorPresentMean: number;
+  factorAbsentMean: number;
+  meanDifference: number;          // signed, outcome units
+  effectSize: number;              // Cohen's d
+  direction: 'improves' | 'worsens';
+  nPresent: number;
+  nAbsent: number;
+  message: string;                 // pre-rendered, caveated, includes both Ns
+}
+
+export interface SleepAchievement {
+  id: string;
+  label: string;
+  description: string;
+  earned: boolean;
+  value?: number | null;
+  icon: 'streak' | 'quality' | 'consistency' | 'aidfree' | 'latency';
+}
+
+export interface SleepTargets {
+  bedtimeMinutes: number;          // minutes-after-noon
+  wakeMinutes: number;             // minutes-after-noon
+  durationMinutes: number;
+}
+
+export interface SleepIndependence {
+  aidFreeNights: number;
+  aidNights: number;
+  aidFreePercent: number | null;   // 0-1, null if no data
+  currentAidFreeStreak: number;
+  longestAidFreeStreak: number;
+  trendDirection: 'better' | 'worse' | 'stable' | null;
+  trendDelta: number | null;       // change in aid-free percent vs previous period
+  sampleSize: number;
+}
+
+export interface SleepAnalyticsSummary {
+  // headline cards
+  avgDurationMinutes: SleepStat;
+  avgLatencyMinutes: SleepStat;
+  avgBedtimeMinutes: SleepStat;    // minutes-after-noon; client formats to clock
+  avgWakeMinutes: SleepStat;
+  avgSleepQuality0to10: SleepStat;
+  avgAppleSleepScore: SleepStat;
+  // consistency
+  consistencyScore: number | null; // 0-100
+  consistencyBedtime: number | null;
+  consistencyWake: number | null;
+  consistencyTrendDelta: number | null;
+  // independence
+  independence: SleepIndependence;
+  // trend + weekly
+  trend: SleepTrendPoint[];
+  weeklySummary: SleepWeekSummary[];
+  // correlations
+  topFactors: SleepFactorInsight[];
+  // achievements
+  achievements: SleepAchievement[];
+  // meta / AI-friendly
+  nights: SleepNight[];
+  targets: SleepTargets;
+  rangeDays: number;
+  coverage: { nightsWithData: number; nightsInRange: number };
+}

--- a/src/lib/analyticsClient.ts
+++ b/src/lib/analyticsClient.ts
@@ -327,6 +327,10 @@ export interface SleepIndependence {
   sampleSize: number;
 }
 
+export async function fetchSleepSummary(days = 30): Promise<SleepAnalyticsSummary> {
+  return analyticsRequest(`/analytics/sleep/summary${buildParams(days)}`);
+}
+
 export interface SleepAnalyticsSummary {
   // headline cards
   avgDurationMinutes: SleepStat;

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -338,7 +338,7 @@ export async function fetchDashboardPrefs(): Promise<DashboardPrefs> {
   return response.dashboardPrefs;
 }
 
-export async function updateDashboardPrefs(patch: Partial<Pick<DashboardPrefs, 'pinnedRoutineIds' | 'pinnedGoalIds' | 'pinnedJournalTemplateIds' | 'checkinExtraMetricKeys' | 'hideStreaks'>>): Promise<DashboardPrefs> {
+export async function updateDashboardPrefs(patch: Partial<Pick<DashboardPrefs, 'pinnedRoutineIds' | 'pinnedGoalIds' | 'pinnedJournalTemplateIds' | 'checkinExtraMetricKeys' | 'hideStreaks' | 'sleepTargets'>>): Promise<DashboardPrefs> {
   const response = await apiRequest<{ dashboardPrefs: DashboardPrefs }>('/dashboardPrefs', {
     method: 'PUT',
     body: JSON.stringify(patch),

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -683,6 +683,17 @@ export interface DashboardPrefs {
     /** When true, streak/flame indicators are hidden across the UI */
     hideStreaks?: boolean;
 
+    /**
+     * User's sleep schedule targets for Sleep Analytics.
+     * Clock times encoded as minutes-after-noon (see Sleep data contract).
+     * Defaults (10 PM / 6 AM / 8h) are applied server-side when unset.
+     */
+    sleepTargets?: {
+        bedtimeMinutes: number;
+        wakeMinutes: number;
+        durationMinutes: number;
+    };
+
     /** ISO 8601 timestamp */
     updatedAt: string;
 }

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -883,10 +883,10 @@ export const WELLBEING_METRIC_KEYS = [
     'fueling',
     'recovery',
     // Sleep Analytics — outcomes (all recorded with timeOfDay:'morning')
-    'appleSleepScore',            // Apple Watch overall Sleep Score, 0-100 (PRIMARY signal)
-    'appleSleepBedtimeScore',     // Apple Watch bedtime sub-score, 0-100
-    'appleSleepDurationScore',    // Apple Watch duration sub-score, 0-100
-    'appleSleepInterruptionScore',// Apple Watch interruption sub-score, 0-100
+    'appleSleepScore',            // Apple Watch overall Sleep Score, 0-100 (PRIMARY); = sum of the 3 sub-scores
+    'appleSleepBedtimeScore',     // Apple Watch bedtime sub-score, 0-25
+    'appleSleepDurationScore',    // Apple Watch duration sub-score, 0-50
+    'appleSleepInterruptionScore',// Apple Watch interruption sub-score, 0-25
     'sleepBedtimeMinutes',        // clock time fell asleep, minutes-after-noon (0..1439)
     'sleepWakeMinutes',           // clock time woke, minutes-after-noon (0..1439)
     'sleepDurationMinutes',       // total time asleep, minutes (e.g. 408 = 6h48m)

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -871,6 +871,23 @@ export const WELLBEING_METRIC_KEYS = [
     'hydration',
     'fueling',
     'recovery',
+    // Sleep Analytics — outcomes (all recorded with timeOfDay:'morning')
+    'appleSleepScore',            // Apple Watch overall Sleep Score, 0-100 (PRIMARY signal)
+    'appleSleepBedtimeScore',     // Apple Watch bedtime sub-score, 0-100
+    'appleSleepDurationScore',    // Apple Watch duration sub-score, 0-100
+    'appleSleepInterruptionScore',// Apple Watch interruption sub-score, 0-100
+    'sleepBedtimeMinutes',        // clock time fell asleep, minutes-after-noon (0..1439)
+    'sleepWakeMinutes',           // clock time woke, minutes-after-noon (0..1439)
+    'sleepDurationMinutes',       // total time asleep, minutes (e.g. 408 = 6h48m)
+    'sleepLatencyMinutes',        // time to fall asleep, minutes (deferred from default form)
+    'sleepAwakenings',            // count of interruptions (deferred from default form)
+    'sleepAidUsed',               // 0/1, 1 = a sleep aid was used (e.g. clonazepam)
+    // Sleep Analytics — behavioral correlation factors (replace the deleted Sleep habits)
+    'factorPhoneInBed',           // 0/1
+    'factorBlueLightMinutes',     // minutes of blue-light exposure after target, >= 0
+    'factorWindDown',             // 0/1, completed a wind-down routine
+    'factorLateNightEating',      // 0/1, ate within ~3h of bed
+    'factorCaffeineAfter12',      // count of caffeinated drinks after noon, >= 0
 ] as const;
 
 export type WellbeingMetricKey = typeof WELLBEING_METRIC_KEYS[number];

--- a/src/pages/AnalyticsPage.tsx
+++ b/src/pages/AnalyticsPage.tsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { ArrowLeft, CheckSquare, RefreshCw, Target } from 'lucide-react';
+import { ArrowLeft, CheckSquare, RefreshCw, Target, Moon } from 'lucide-react';
 import { useAuth } from '../store/AuthContext';
 import {
   fetchAllHabitAnalytics,
   fetchRoutineSummary,
   fetchGoalSummary,
+  fetchSleepSummary,
   type HabitAnalyticsSummary,
   type TrendDataPoint,
   type CategoryBreakdownItem,
   type Insight,
   type RoutineAnalyticsSummary,
   type GoalAnalyticsSummary,
+  type SleepAnalyticsSummary,
 } from '../lib/analyticsClient';
 import { SummaryCards } from '../components/analytics/SummaryCards';
 import { StreaksSection } from '../components/analytics/StreaksSection';
@@ -22,12 +24,13 @@ import { AchievementsSection } from '../components/analytics/AchievementsSection
 import { InsightsPanel } from '../components/analytics/InsightsPanel';
 import { RoutineAnalytics } from '../components/analytics/RoutineAnalytics';
 import { GoalAnalytics } from '../components/analytics/GoalAnalytics';
+import { SleepAnalytics } from '../components/analytics/sleep/SleepAnalytics';
 import { ActivitySection } from '../components/ActivitySection';
 
 const BETA_EMAIL = 'tj.galloway1@gmail.com';
 
 type TimeRange = 7 | 14 | 30 | 'custom';
-type AnalyticsTab = 'habits' | 'routines' | 'goals';
+type AnalyticsTab = 'habits' | 'routines' | 'goals' | 'sleep';
 
 function getDaysFromRange(range: TimeRange, customStart: string, customEnd: string): number {
   if (range === 'custom' && customStart && customEnd) {
@@ -66,6 +69,9 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ onBack }) => {
 
   // Goals state
   const [goalData, setGoalData] = useState<GoalAnalyticsSummary | null>(null);
+
+  // Sleep state
+  const [sleepData, setSleepData] = useState<SleepAnalyticsSummary | null>(null);
 
   const loadHabitData = useCallback(async (days: number) => {
     setLoading(true);
@@ -113,6 +119,18 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ onBack }) => {
     }
   }, []);
 
+  const loadSleepData = useCallback(async (days: number) => {
+    setLoading(true);
+    try {
+      const data = await fetchSleepSummary(days);
+      setSleepData(data);
+    } catch (err) {
+      console.error('[AnalyticsPage] Failed to load sleep analytics:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (!isAuthorized) {
       onBack();
@@ -124,7 +142,8 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ onBack }) => {
     if (activeTab === 'habits') loadHabitData(days);
     else if (activeTab === 'routines') loadRoutineData(days);
     else if (activeTab === 'goals') loadGoalData(days);
-  }, [isAuthorized, onBack, activeTab, timeRange, customStart, customEnd, loadHabitData, loadRoutineData, loadGoalData]);
+    else if (activeTab === 'sleep') loadSleepData(days);
+  }, [isAuthorized, onBack, activeTab, timeRange, customStart, customEnd, loadHabitData, loadRoutineData, loadGoalData, loadSleepData]);
 
   if (!isAuthorized) return null;
 
@@ -132,6 +151,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ onBack }) => {
     { value: 'habits', label: 'Habits', icon: CheckSquare },
     { value: 'routines', label: 'Routines', icon: RefreshCw },
     { value: 'goals', label: 'Goals', icon: Target },
+    { value: 'sleep', label: 'Sleep', icon: Moon },
   ];
 
   return (
@@ -225,6 +245,10 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ onBack }) => {
 
       {activeTab === 'goals' && (
         <GoalAnalytics data={goalData} loading={loading} />
+      )}
+
+      {activeTab === 'sleep' && (
+        <SleepAnalytics data={sleepData} loading={loading} />
       )}
     </div>
   );

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -77,6 +77,7 @@ import {
   getAllHabitAnalytics,
   getRoutineAnalyticsSummary,
   getGoalAnalyticsSummary,
+  getSleepAnalyticsSummary,
 } from './routes/analytics';
 
 export function createApp(): Express {
@@ -240,6 +241,7 @@ export function createApp(): Express {
   app.get('/api/analytics/habits/insights', getHabitAnalyticsInsights);
   app.get('/api/analytics/routines/summary', getRoutineAnalyticsSummary);
   app.get('/api/analytics/goals/summary', getGoalAnalyticsSummary);
+  app.get('/api/analytics/sleep/summary', getSleepAnalyticsSummary);
   app.get('/api/admin/integrity-report', getIntegrityReport);
   app.post('/api/admin/dedup-habits', requireAdmin, dedupHabits);
   app.post('/api/admin/recover-habits', requireAdmin, recoverHabits);

--- a/src/server/repositories/dashboardPrefsRepository.ts
+++ b/src/server/repositories/dashboardPrefsRepository.ts
@@ -42,7 +42,7 @@ export async function getDashboardPrefs(householdId: string, userId: string): Pr
 export async function updateDashboardPrefs(
   householdId: string,
   userId: string,
-  patch: { pinnedRoutineIds?: string[]; pinnedGoalIds?: string[]; pinnedJournalTemplateIds?: string[]; checkinExtraMetricKeys?: string[]; hideStreaks?: boolean }
+  patch: { pinnedRoutineIds?: string[]; pinnedGoalIds?: string[]; pinnedJournalTemplateIds?: string[]; checkinExtraMetricKeys?: string[]; hideStreaks?: boolean; sleepTargets?: { bedtimeMinutes: number; wakeMinutes: number; durationMinutes: number } }
 ): Promise<DashboardPrefs> {
   const scope = requireScope(householdId, userId);
   await ensureIndexes();
@@ -119,6 +119,20 @@ export async function updateDashboardPrefs(
 
   if (patch.hideStreaks !== undefined) {
     update.hideStreaks = !!patch.hideStreaks;
+  }
+
+  if (patch.sleepTargets !== undefined) {
+    const t = patch.sleepTargets;
+    const clampMinute = (n: unknown) => {
+      const v = Math.round(Number(n));
+      if (!Number.isFinite(v)) throw new Error('sleepTargets values must be numbers');
+      return Math.max(0, Math.min(1439, v));
+    };
+    update.sleepTargets = {
+      bedtimeMinutes: clampMinute(t.bedtimeMinutes),
+      wakeMinutes: clampMinute(t.wakeMinutes),
+      durationMinutes: Math.max(0, Math.min(1440, Math.round(Number(t.durationMinutes)) || 0)),
+    };
   }
 
   // Fix: Use full document replace approach to avoid MongoDB update conflicts

--- a/src/server/routes/analytics.ts
+++ b/src/server/routes/analytics.ts
@@ -26,6 +26,8 @@ import {
   computeGoalAnalytics,
   computeGoalTrackAchievements,
 } from '../services/analyticsService';
+import { computeSleepAnalytics, DEFAULT_SLEEP_TARGETS } from '../services/sleepAnalyticsService';
+import { getWellbeingEntries } from '../repositories/wellbeingEntryRepository';
 import { analyticsCache } from '../lib/cacheInstances';
 
 function parseDays(query: unknown, defaultDays = 90): number {
@@ -228,6 +230,50 @@ export async function getAllHabitAnalytics(req: Request, res: Response): Promise
   } catch (error) {
     console.error('[analytics] all habit analytics error:', error);
     res.status(500).json({ error: 'Failed to compute habit analytics' });
+  }
+}
+
+export async function getSleepAnalyticsSummary(req: Request, res: Response): Promise<void> {
+  try {
+    const { householdId, userId } = getRequestIdentity(req);
+    const timeZone = resolveTimeZone(typeof req.query.timeZone === 'string' ? req.query.timeZone : undefined);
+    const days = parseDays(req.query.days, 30);
+    const referenceDayKey = getNowDayKey(timeZone);
+
+    // Cache key is prefixed with `${userId}:` so invalidateUserCaches() clears it.
+    const cacheKey = `${userId}:sleep:${days}`;
+    const cached = analyticsCache.get(cacheKey);
+    if (cached) {
+      res.json(cached);
+      return;
+    }
+
+    // Wellbeing entries span two windows (current + previous) for trend deltas.
+    const wellbeingStart = startDayKeyForRange(referenceDayKey, days * 2);
+    const habitStart = startDayKeyForRange(referenceDayKey, days);
+    const [wellbeingEntries, habits, habitEntries, categories] = await Promise.all([
+      getWellbeingEntries({ userId, startDayKey: wellbeingStart, endDayKey: referenceDayKey }),
+      getHabitsByUser(householdId, userId),
+      getHabitEntriesByUserInRange(householdId, userId, habitStart, referenceDayKey),
+      getCategoriesByUser(householdId, userId),
+    ]);
+
+    const result = computeSleepAnalytics(
+      wellbeingEntries,
+      habits,
+      habitEntries,
+      categories,
+      referenceDayKey,
+      days,
+      timeZone,
+      DEFAULT_SLEEP_TARGETS,
+    );
+
+    analyticsCache.set(cacheKey, result);
+    res.json(result);
+  } catch (error) {
+    console.error('[analytics] sleep summary error:', error);
+    res.status(500).json({ error: 'Failed to compute sleep analytics' });
   }
 }
 

--- a/src/server/routes/analytics.ts
+++ b/src/server/routes/analytics.ts
@@ -28,6 +28,7 @@ import {
 } from '../services/analyticsService';
 import { computeSleepAnalytics, DEFAULT_SLEEP_TARGETS } from '../services/sleepAnalyticsService';
 import { getWellbeingEntries } from '../repositories/wellbeingEntryRepository';
+import { getDashboardPrefs } from '../repositories/dashboardPrefsRepository';
 import { analyticsCache } from '../lib/cacheInstances';
 
 function parseDays(query: unknown, defaultDays = 90): number {
@@ -251,11 +252,12 @@ export async function getSleepAnalyticsSummary(req: Request, res: Response): Pro
     // Wellbeing entries span two windows (current + previous) for trend deltas.
     const wellbeingStart = startDayKeyForRange(referenceDayKey, days * 2);
     const habitStart = startDayKeyForRange(referenceDayKey, days);
-    const [wellbeingEntries, habits, habitEntries, categories] = await Promise.all([
+    const [wellbeingEntries, habits, habitEntries, categories, prefs] = await Promise.all([
       getWellbeingEntries({ userId, startDayKey: wellbeingStart, endDayKey: referenceDayKey }),
       getHabitsByUser(householdId, userId),
       getHabitEntriesByUserInRange(householdId, userId, habitStart, referenceDayKey),
       getCategoriesByUser(householdId, userId),
+      getDashboardPrefs(householdId, userId),
     ]);
 
     const result = computeSleepAnalytics(
@@ -266,7 +268,7 @@ export async function getSleepAnalyticsSummary(req: Request, res: Response): Pro
       referenceDayKey,
       days,
       timeZone,
-      DEFAULT_SLEEP_TARGETS,
+      prefs.sleepTargets ?? DEFAULT_SLEEP_TARGETS,
     );
 
     analyticsCache.set(cacheKey, result);

--- a/src/server/routes/dashboardPrefs.ts
+++ b/src/server/routes/dashboardPrefs.ts
@@ -29,9 +29,9 @@ export async function getDashboardPrefsRoute(req: Request, res: Response): Promi
 export async function updateDashboardPrefsRoute(req: Request, res: Response): Promise<void> {
   try {
     const { householdId, userId } = getRequestIdentity(req);
-    const { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks } = req.body || {};
+    const { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks, sleepTargets } = req.body || {};
 
-    const prefs = await updateDashboardPrefs(householdId, userId, { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks });
+    const prefs = await updateDashboardPrefs(householdId, userId, { pinnedRoutineIds, pinnedGoalIds, pinnedJournalTemplateIds, checkinExtraMetricKeys, hideStreaks, sleepTargets });
     res.status(200).json({ dashboardPrefs: prefs });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/server/routes/wellbeingEntries.ts
+++ b/src/server/routes/wellbeingEntries.ts
@@ -9,6 +9,7 @@ import type { Request, Response } from 'express';
 import { getRequestIdentity } from '../middleware/identity';
 import { validateDayKey } from '../domain/canonicalValidators';
 import { createWellbeingEntries, getWellbeingEntries, softDeleteWellbeingEntry, type WellbeingEntryUpsertInput } from '../repositories/wellbeingEntryRepository';
+import { invalidateUserCaches } from '../lib/cacheInstances';
 
 /**
  * Get wellbeing entries for a user in a dayKey range.
@@ -74,6 +75,9 @@ export async function upsertWellbeingEntriesRoute(req: Request, res: Response): 
       defaultTimeZone: typeof defaultTimeZone === 'string' ? defaultTimeZone : 'UTC',
     });
 
+    // Sleep analytics is derived from wellbeing entries — refresh on write.
+    invalidateUserCaches(userId);
+
     res.status(200).json({ wellbeingEntries: saved });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -107,6 +111,8 @@ export async function deleteWellbeingEntryRoute(req: Request, res: Response): Pr
       res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Wellbeing entry not found' } });
       return;
     }
+
+    invalidateUserCaches(userId);
 
     res.status(200).json({ message: 'Wellbeing entry deleted successfully' });
   } catch (error) {

--- a/src/server/services/sleepAnalyticsService.test.ts
+++ b/src/server/services/sleepAnalyticsService.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import { format, parseISO, subDays } from 'date-fns';
+import type { WellbeingEntry, Habit, HabitEntry, Category } from '../../models/persistenceTypes';
+import {
+  circularStdDevMinutes,
+  consistencySubScore,
+  computeSleepAnalytics,
+  buildSleepNights,
+  SLEEP_CONSISTENCY_TOLERANCE_MIN,
+} from './sleepAnalyticsService';
+import { clockToMinutesAfterNoon, minutesAfterNoonToClock } from '../../components/analytics/sleep/sleepFormat';
+
+function we(dayKey: string, metricKey: string, value: number): WellbeingEntry {
+  return {
+    id: `${dayKey}-${metricKey}`,
+    userId: 'u1',
+    timestampUtc: `${dayKey}T12:00:00.000Z`,
+    dayKey,
+    timeOfDay: 'morning',
+    metricKey: metricKey as WellbeingEntry['metricKey'],
+    value,
+    source: 'test',
+    createdAt: `${dayKey}T12:00:00.000Z`,
+    updatedAt: `${dayKey}T12:00:00.000Z`,
+  };
+}
+
+function lastNDayKeys(referenceDayKey: string, n: number): string[] {
+  const out: string[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    out.push(format(subDays(parseISO(referenceDayKey), i), 'yyyy-MM-dd'));
+  }
+  return out;
+}
+
+describe('minutes-after-noon encoding', () => {
+  it('keeps a normal sleep window contiguous across midnight', () => {
+    expect(clockToMinutesAfterNoon(22, 0)).toBe(600);   // 10:00 PM
+    expect(clockToMinutesAfterNoon(23, 58)).toBe(718);  // 11:58 PM
+    expect(clockToMinutesAfterNoon(0, 5)).toBe(725);    // 12:05 AM (adjacent to 718)
+    expect(clockToMinutesAfterNoon(6, 3)).toBe(1083);   // 6:03 AM
+  });
+
+  it('round-trips back to a clock label', () => {
+    expect(minutesAfterNoonToClock(600)).toBe('10:00 PM');
+    expect(minutesAfterNoonToClock(1083)).toBe('6:03 AM');
+    expect(minutesAfterNoonToClock(725)).toBe('12:05 AM');
+  });
+});
+
+describe('sleep consistency algorithm', () => {
+  it('scores tightly-clustered bedtimes very high', () => {
+    // 10:00 / 10:05 / 9:58 / 10:02 PM → minutes-after-noon
+    const bedtimes = [600, 605, 598, 602];
+    const sigma = circularStdDevMinutes(bedtimes);
+    expect(sigma).toBeLessThan(5);
+    expect(consistencySubScore(sigma)).toBeGreaterThanOrEqual(90);
+  });
+
+  it('scores scattered bedtimes poorly', () => {
+    // 9:00 / 11:30 / 10:15 / 12:00 → minutes-after-noon
+    const bedtimes = [540, 690, 615, 720];
+    const sigma = circularStdDevMinutes(bedtimes);
+    expect(sigma).toBeGreaterThan(50);
+    const score = consistencySubScore(sigma);
+    expect(score).toBeLessThan(60);
+    // and strictly worse than the tight cluster
+    expect(score).toBeLessThan(consistencySubScore(circularStdDevMinutes([600, 605, 598, 602])));
+  });
+
+  it('uses τ as the documented decay constant', () => {
+    expect(consistencySubScore(0)).toBe(100);
+    expect(consistencySubScore(SLEEP_CONSISTENCY_TOLERANCE_MIN)).toBe(Math.round(100 * Math.exp(-1)));
+  });
+});
+
+describe('buildSleepNights', () => {
+  it('pivots metric keys per day and marks data presence', () => {
+    const ref = '2026-06-16';
+    const keys = lastNDayKeys(ref, 2);
+    const entries = [
+      we(keys[1], 'appleSleepScore', 82),
+      we(keys[1], 'sleepDurationMinutes', 408),
+      we(keys[1], 'sleepAidUsed', 0),
+    ];
+    const nights = buildSleepNights(entries, keys);
+    expect(nights).toHaveLength(2);
+    expect(nights[0].hasData).toBe(false);
+    expect(nights[1].appleSleepScore).toBe(82);
+    expect(nights[1].durationMinutes).toBe(408);
+    expect(nights[1].sleepAidUsed).toBe(false);
+    expect(nights[1].hasData).toBe(true);
+  });
+});
+
+describe('computeSleepAnalytics', () => {
+  const ref = '2026-06-16';
+
+  it('computes headline averages and consistency from form entries', () => {
+    const keys = lastNDayKeys(ref, 14);
+    const entries: WellbeingEntry[] = [];
+    for (const dk of keys) {
+      entries.push(we(dk, 'appleSleepScore', 80));
+      entries.push(we(dk, 'sleepDurationMinutes', 420));
+      entries.push(we(dk, 'sleepBedtimeMinutes', 600));
+      entries.push(we(dk, 'sleepWakeMinutes', 1080));
+    }
+    const result = computeSleepAnalytics(entries, [], [], [], ref, 14, 'America/New_York');
+    expect(result.avgAppleSleepScore.value).toBe(80);
+    expect(result.avgDurationMinutes.value).toBe(420);
+    expect(result.consistencyScore).toBe(100); // identical times every night
+    expect(result.coverage.nightsWithData).toBe(14);
+  });
+
+  it('surfaces a correlated factor with caveated message', () => {
+    const keys = lastNDayKeys(ref, 12);
+    const entries: WellbeingEntry[] = [];
+    keys.forEach((dk, i) => {
+      const phone = i % 2 === 0 ? 1 : 0; // alternate → 6 present, 6 absent
+      entries.push(we(dk, 'factorPhoneInBed', phone));
+      // phone nights score worse (70) vs no-phone (90)
+      entries.push(we(dk, 'appleSleepScore', phone ? 70 : 90));
+    });
+    const result = computeSleepAnalytics(entries, [], [], [], ref, 12, 'America/New_York');
+    const phoneFactor = result.topFactors.find((f) => f.factorId === 'factorPhoneInBed');
+    expect(phoneFactor).toBeDefined();
+    expect(phoneFactor!.direction).toBe('worsens');
+    expect(phoneFactor!.nPresent).toBe(6);
+    expect(phoneFactor!.nAbsent).toBe(6);
+    expect(phoneFactor!.message).toContain('Correlation, not proof.');
+  });
+
+  it('computes sleep-aid independence stats', () => {
+    const keys = lastNDayKeys(ref, 10);
+    const entries: WellbeingEntry[] = [];
+    keys.forEach((dk, i) => {
+      // last 4 nights aid-free, earlier mixed
+      const used = i < 6 && i % 2 === 0 ? 1 : 0;
+      entries.push(we(dk, 'sleepAidUsed', used));
+      entries.push(we(dk, 'appleSleepScore', 75));
+    });
+    const result = computeSleepAnalytics(entries, [], [], [], ref, 10, 'America/New_York');
+    expect(result.independence.sampleSize).toBe(10);
+    expect(result.independence.aidFreeNights + result.independence.aidNights).toBe(10);
+    expect(result.independence.currentAidFreeStreak).toBeGreaterThanOrEqual(4);
+  });
+
+  it('returns null stats and consistency when there is no data', () => {
+    const result = computeSleepAnalytics([], [], [], [], ref, 7, 'America/New_York');
+    expect(result.avgAppleSleepScore.value).toBeNull();
+    expect(result.consistencyScore).toBeNull();
+    expect(result.coverage.nightsWithData).toBe(0);
+    expect(result.topFactors).toHaveLength(0);
+  });
+
+  it('includes ordinary habits as generic correlation factors', () => {
+    const keys = lastNDayKeys(ref, 12);
+    const entries: WellbeingEntry[] = [];
+    const habitEntries: HabitEntry[] = [];
+    keys.forEach((dk, i) => {
+      const exercised = i % 2 === 0;
+      entries.push(we(dk, 'appleSleepScore', exercised ? 88 : 72));
+      if (exercised) {
+        habitEntries.push({
+          id: `h-${dk}`,
+          habitId: 'habit-exercise',
+          timestamp: `${dk}T18:00:00.000Z`,
+          dayKey: dk,
+          value: 1,
+          source: 'manual',
+          createdAt: `${dk}T18:00:00.000Z`,
+          updatedAt: `${dk}T18:00:00.000Z`,
+        });
+      }
+    });
+    const habits: Habit[] = [{
+      id: 'habit-exercise',
+      categoryId: 'cat-1',
+      name: 'Exercise',
+      goal: { type: 'boolean', frequency: 'daily', target: 1 },
+      archived: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }];
+    const categories: Category[] = [{ id: 'cat-1', name: 'Fitness', color: '#10b981' }];
+    const result = computeSleepAnalytics(entries, habits, habitEntries, categories, ref, 12, 'America/New_York');
+    const ex = result.topFactors.find((f) => f.factorId === 'habit-exercise');
+    expect(ex).toBeDefined();
+    expect(ex!.source).toBe('habit');
+    expect(ex!.direction).toBe('improves');
+  });
+});

--- a/src/server/services/sleepAnalyticsService.ts
+++ b/src/server/services/sleepAnalyticsService.ts
@@ -1,0 +1,751 @@
+/**
+ * Sleep Analytics Service
+ *
+ * Computes the Sleep Analytics dashboard entirely from canonical truth at read
+ * time. Nothing is stored. Inputs are WellbeingEntry records (sleep outcomes +
+ * behavioral factors, all logged with timeOfDay:'morning') plus the user's
+ * HabitEntries (so the correlation engine can also use any other tracked habit).
+ *
+ * `computeSleepAnalytics` is PURE (inputs -> output, no I/O) so the same function
+ * can back a future AI prompt-assembly layer and be unit-tested deterministically.
+ *
+ * ── Clock-time encoding ──────────────────────────────────────────────────────
+ * Bedtime/wake clock times are stored as "minutes-after-noon" (minutes elapsed
+ * since 12:00 noon, wrapped 0..1439) so a normal sleep window stays numerically
+ * contiguous across midnight. See the data contract doc for details.
+ *
+ * ── Sleep Consistency Score ──────────────────────────────────────────────────
+ * Rewards going to bed AND waking at SIMILAR clock times night-to-night,
+ * independent of sleep DURATION. For bedtime and wake separately we compute a
+ * circular standard deviation (clock is modular, period 1440 min), map it to a
+ * 0-100 sub-score via exponential decay, then average the two:
+ *
+ *   σ_circ = sqrt(-2 ln R)   where R is the mean resultant length of the angles
+ *   σ_min  = σ_circ * 1440 / (2π)
+ *   subScore = 100 * exp(-σ_min / τ)        τ = SLEEP_CONSISTENCY_TOLERANCE_MIN
+ *   consistency = round((subScore_bedtime + subScore_wake) / 2)
+ *
+ * Worked examples (τ = 90):
+ *   Bedtimes 10:00/10:05/9:58/10:02 → σ≈2.6m → subScore≈97 (very consistent).
+ *   Bedtimes 9:00/11:30/10:15/12:00 → σ≈68m → subScore≈47 (poor) — even though
+ *   the average bedtime (~10:41 PM) and duration could look fine; duration is
+ *   excluded by design.
+ */
+
+import { parseISO, subDays, format, getISOWeek, getISOWeekYear } from 'date-fns';
+import type { Habit, HabitEntry, Category, WellbeingEntry } from '../../models/persistenceTypes';
+import { buildDayStatesByHabit } from './analyticsService';
+import { isTrackableHabit } from './scheduleEngine';
+
+// ─── Tunable constants ─────────────────────────────────────────────────────────
+
+/** Tolerance (minutes) for the consistency exponential decay. Single tuning knob. */
+export const SLEEP_CONSISTENCY_TOLERANCE_MIN = 90;
+/** Minimum nights with a field before a stat/consistency value is reported. */
+const MIN_NIGHTS_FOR_CONSISTENCY = 3;
+/** Minimum nights per group before a correlation factor is surfaced. */
+const MIN_NIGHTS_PER_GROUP = 5;
+/** Minimum |Cohen's d| before a correlation factor is surfaced. */
+const MIN_EFFECT_SIZE = 0.2;
+/** Max correlation factors returned. */
+const MAX_FACTORS = 6;
+
+const MINUTES_PER_DAY = 1440;
+
+// ─── Types (mirrored structurally in src/lib/analyticsClient.ts) ───────────────
+
+export interface SleepStat {
+  value: number | null;
+  sampleSize: number;
+  trendDelta: number | null;
+  trendDirection: 'better' | 'worse' | 'stable' | null;
+}
+
+export interface SleepNight {
+  dayKey: string;
+  appleSleepScore: number | null;
+  bedtimeScore: number | null;
+  durationScore: number | null;
+  interruptionScore: number | null;
+  bedtimeMinutes: number | null;
+  wakeMinutes: number | null;
+  durationMinutes: number | null;
+  latencyMinutes: number | null;
+  awakenings: number | null;
+  sleepAidUsed: boolean | null;
+  sleepQuality0to4: number | null;
+  morningEnergy: number | null;
+  hasData: boolean;
+}
+
+export interface SleepTrendPoint {
+  dayKey: string;
+  durationMinutes: number | null;
+  appleSleepScore: number | null;
+  bedtimeMinutes: number | null;
+  wakeMinutes: number | null;
+  sleepQuality0to10: number | null;
+}
+
+export interface SleepWeekSummary {
+  weekLabel: string;
+  avgDurationMinutes: number | null;
+  avgLatencyMinutes: number | null;
+  nightsOnTarget: number;
+  avgAwakenings: number | null;
+  sleepAidFreeNights: number;
+  avgMorningEnergy: number | null;
+}
+
+export interface SleepFactorInsight {
+  factorId: string;
+  factorName: string;
+  source: 'form' | 'habit';
+  outcome: 'appleSleepScore' | 'sleepQuality' | 'latencyMinutes' | 'bedtimeMinutes';
+  factorPresentMean: number;
+  factorAbsentMean: number;
+  meanDifference: number;
+  effectSize: number;
+  direction: 'improves' | 'worsens';
+  nPresent: number;
+  nAbsent: number;
+  message: string;
+}
+
+export interface SleepAchievement {
+  id: string;
+  label: string;
+  description: string;
+  earned: boolean;
+  value?: number | null;
+  icon: 'streak' | 'quality' | 'consistency' | 'aidfree' | 'latency';
+}
+
+export interface SleepTargets {
+  bedtimeMinutes: number;
+  wakeMinutes: number;
+  durationMinutes: number;
+}
+
+export interface SleepIndependence {
+  aidFreeNights: number;
+  aidNights: number;
+  aidFreePercent: number | null;
+  currentAidFreeStreak: number;
+  longestAidFreeStreak: number;
+  trendDirection: 'better' | 'worse' | 'stable' | null;
+  trendDelta: number | null;
+  sampleSize: number;
+}
+
+export interface SleepAnalyticsSummary {
+  avgDurationMinutes: SleepStat;
+  avgLatencyMinutes: SleepStat;
+  avgBedtimeMinutes: SleepStat;
+  avgWakeMinutes: SleepStat;
+  avgSleepQuality0to10: SleepStat;
+  avgAppleSleepScore: SleepStat;
+  consistencyScore: number | null;
+  consistencyBedtime: number | null;
+  consistencyWake: number | null;
+  consistencyTrendDelta: number | null;
+  independence: SleepIndependence;
+  trend: SleepTrendPoint[];
+  weeklySummary: SleepWeekSummary[];
+  topFactors: SleepFactorInsight[];
+  achievements: SleepAchievement[];
+  nights: SleepNight[];
+  targets: SleepTargets;
+  rangeDays: number;
+  coverage: { nightsWithData: number; nightsInRange: number };
+}
+
+export const DEFAULT_SLEEP_TARGETS: SleepTargets = {
+  bedtimeMinutes: 600,  // 10:00 PM
+  wakeMinutes: 1080,    // 6:00 AM
+  durationMinutes: 480, // 8h
+};
+
+// ─── Small numeric helpers ─────────────────────────────────────────────────────
+
+function toNum(value: number | string | null | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) return Number(value);
+  return null;
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function generateDayKeyRange(startDayKey: string, endDayKey: string): string[] {
+  const days: string[] = [];
+  const start = parseISO(startDayKey);
+  const end = parseISO(endDayKey);
+  for (let d = start; d <= end; d = new Date(d.getTime() + 86400000)) {
+    days.push(format(d, 'yyyy-MM-dd'));
+  }
+  return days;
+}
+
+function startDayKeyForRange(referenceDayKey: string, days: number): string {
+  return format(subDays(parseISO(referenceDayKey), days - 1), 'yyyy-MM-dd');
+}
+
+/**
+ * Circular standard deviation (in minutes) of clock values on a 1440-min period.
+ * Returns 0 for <2 samples.
+ */
+export function circularStdDevMinutes(values: number[]): number {
+  if (values.length < 2) return 0;
+  let sumSin = 0;
+  let sumCos = 0;
+  for (const v of values) {
+    const theta = (2 * Math.PI * v) / MINUTES_PER_DAY;
+    sumSin += Math.sin(theta);
+    sumCos += Math.cos(theta);
+  }
+  const n = values.length;
+  const r = Math.sqrt((sumSin / n) ** 2 + (sumCos / n) ** 2);
+  if (r <= 0) return MINUTES_PER_DAY / 4; // fully dispersed → cap
+  const sigmaRad = Math.sqrt(-2 * Math.log(Math.min(1, r)));
+  return (sigmaRad * MINUTES_PER_DAY) / (2 * Math.PI);
+}
+
+/** Map a circular std-dev (minutes) to a 0-100 consistency sub-score. */
+export function consistencySubScore(sigmaMin: number): number {
+  return Math.round(100 * Math.exp(-sigmaMin / SLEEP_CONSISTENCY_TOLERANCE_MIN));
+}
+
+// ─── Per-night build ───────────────────────────────────────────────────────────
+
+const SLEEP_METRIC_KEYS = new Set<string>([
+  'appleSleepScore', 'appleSleepBedtimeScore', 'appleSleepDurationScore', 'appleSleepInterruptionScore',
+  'sleepBedtimeMinutes', 'sleepWakeMinutes', 'sleepDurationMinutes', 'sleepLatencyMinutes',
+  'sleepAwakenings', 'sleepAidUsed', 'sleepQuality', 'energy',
+  'factorPhoneInBed', 'factorBlueLightMinutes', 'factorWindDown', 'factorLateNightEating', 'factorCaffeineAfter12',
+]);
+
+/** Behavioral factor metric keys captured by the sleep form. */
+const FORM_FACTOR_KEYS: Array<{ key: string; name: string }> = [
+  { key: 'sleepAidUsed', name: 'Sleep aid used' },
+  { key: 'factorPhoneInBed', name: 'Phone in bed' },
+  { key: 'factorBlueLightMinutes', name: 'Blue light after target' },
+  { key: 'factorWindDown', name: 'Wind-down routine' },
+  { key: 'factorLateNightEating', name: 'Late-night eating' },
+  { key: 'factorCaffeineAfter12', name: 'Caffeine after noon' },
+];
+
+/**
+ * Pivot wellbeing entries into a Map<dayKey, Record<metricKey, number>>.
+ * Morning sleep entries only; last write wins per (dayKey, metricKey).
+ */
+function pivotByDayKey(wellbeingEntries: WellbeingEntry[]): Map<string, Record<string, number>> {
+  const byDay = new Map<string, Record<string, number>>();
+  for (const e of wellbeingEntries) {
+    if (!SLEEP_METRIC_KEYS.has(e.metricKey)) continue;
+    const num = toNum(e.value);
+    if (num === null) continue;
+    const rec = byDay.get(e.dayKey) ?? {};
+    rec[e.metricKey] = num;
+    byDay.set(e.dayKey, rec);
+  }
+  return byDay;
+}
+
+function buildNight(dayKey: string, rec: Record<string, number> | undefined): SleepNight {
+  const r = rec ?? {};
+  const get = (k: string): number | null => (k in r ? r[k] : null);
+  const appleSleepScore = get('appleSleepScore');
+  const durationMinutes = get('sleepDurationMinutes');
+  const aid = get('sleepAidUsed');
+  const night: SleepNight = {
+    dayKey,
+    appleSleepScore,
+    bedtimeScore: get('appleSleepBedtimeScore'),
+    durationScore: get('appleSleepDurationScore'),
+    interruptionScore: get('appleSleepInterruptionScore'),
+    bedtimeMinutes: get('sleepBedtimeMinutes'),
+    wakeMinutes: get('sleepWakeMinutes'),
+    durationMinutes,
+    latencyMinutes: get('sleepLatencyMinutes'),
+    awakenings: get('sleepAwakenings'),
+    sleepAidUsed: aid === null ? null : aid >= 1,
+    sleepQuality0to4: get('sleepQuality'),
+    morningEnergy: get('energy'),
+    hasData: appleSleepScore !== null || durationMinutes !== null,
+  };
+  return night;
+}
+
+/** Build per-night records for every dayKey in the range (gaps explicit). */
+export function buildSleepNights(
+  wellbeingEntries: WellbeingEntry[],
+  dayKeys: string[]
+): SleepNight[] {
+  const byDay = pivotByDayKey(wellbeingEntries);
+  return dayKeys.map((dk) => buildNight(dk, byDay.get(dk)));
+}
+
+// ─── Headline stats ────────────────────────────────────────────────────────────
+
+type Polarity = 'higher' | 'lower' | 'closeness';
+
+function pickNonNull(nights: SleepNight[], field: keyof SleepNight): number[] {
+  const out: number[] = [];
+  for (const n of nights) {
+    const v = n[field];
+    if (typeof v === 'number' && Number.isFinite(v)) out.push(v);
+  }
+  return out;
+}
+
+function buildStat(
+  currentValues: number[],
+  previousValues: number[],
+  polarity: Polarity,
+  target?: number
+): SleepStat {
+  const value = mean(currentValues);
+  const prev = mean(previousValues);
+  if (value === null) {
+    return { value: null, sampleSize: 0, trendDelta: null, trendDirection: null };
+  }
+  if (prev === null) {
+    return { value: round1(value), sampleSize: currentValues.length, trendDelta: null, trendDirection: null };
+  }
+  const delta = value - prev;
+  let direction: SleepStat['trendDirection'];
+  if (polarity === 'closeness' && target !== undefined) {
+    const curDist = Math.abs(value - target);
+    const prevDist = Math.abs(prev - target);
+    const distDelta = curDist - prevDist;
+    direction = Math.abs(distDelta) < 1 ? 'stable' : distDelta < 0 ? 'better' : 'worse';
+  } else if (polarity === 'higher') {
+    direction = Math.abs(delta) < 0.05 ? 'stable' : delta > 0 ? 'better' : 'worse';
+  } else {
+    direction = Math.abs(delta) < 0.05 ? 'stable' : delta < 0 ? 'better' : 'worse';
+  }
+  return {
+    value: round1(value),
+    sampleSize: currentValues.length,
+    trendDelta: round1(delta),
+    trendDirection: direction,
+  };
+}
+
+// ─── Consistency ───────────────────────────────────────────────────────────────
+
+function computeConsistency(nights: SleepNight[]): { overall: number | null; bedtime: number | null; wake: number | null } {
+  const bedtimes = pickNonNull(nights, 'bedtimeMinutes');
+  const wakes = pickNonNull(nights, 'wakeMinutes');
+  const bedtime = bedtimes.length >= MIN_NIGHTS_FOR_CONSISTENCY ? consistencySubScore(circularStdDevMinutes(bedtimes)) : null;
+  const wake = wakes.length >= MIN_NIGHTS_FOR_CONSISTENCY ? consistencySubScore(circularStdDevMinutes(wakes)) : null;
+  let overall: number | null = null;
+  if (bedtime !== null && wake !== null) overall = Math.round((bedtime + wake) / 2);
+  else if (bedtime !== null) overall = bedtime;
+  else if (wake !== null) overall = wake;
+  return { overall, bedtime, wake };
+}
+
+// ─── Independence (sleep-aid) ──────────────────────────────────────────────────
+
+function computeIndependence(currentNights: SleepNight[], previousNights: SleepNight[]): SleepIndependence {
+  const scored = currentNights.filter((n) => n.sleepAidUsed !== null);
+  const aidNights = scored.filter((n) => n.sleepAidUsed === true).length;
+  const aidFreeNights = scored.filter((n) => n.sleepAidUsed === false).length;
+  const aidFreePercent = scored.length > 0 ? aidFreeNights / scored.length : null;
+
+  // streaks over chronological scored nights
+  let current = 0;
+  let longest = 0;
+  let run = 0;
+  for (const n of scored) {
+    if (n.sleepAidUsed === false) {
+      run += 1;
+      longest = Math.max(longest, run);
+    } else {
+      run = 0;
+    }
+  }
+  // current streak = trailing run of aid-free nights
+  for (let i = scored.length - 1; i >= 0; i--) {
+    if (scored[i].sleepAidUsed === false) current += 1;
+    else break;
+  }
+
+  const prevScored = previousNights.filter((n) => n.sleepAidUsed !== null);
+  const prevPercent = prevScored.length > 0
+    ? prevScored.filter((n) => n.sleepAidUsed === false).length / prevScored.length
+    : null;
+  let trendDirection: SleepIndependence['trendDirection'] = null;
+  let trendDelta: number | null = null;
+  if (aidFreePercent !== null && prevPercent !== null) {
+    trendDelta = round1((aidFreePercent - prevPercent) * 100);
+    trendDirection = Math.abs(trendDelta) < 1 ? 'stable' : trendDelta > 0 ? 'better' : 'worse';
+  }
+
+  return {
+    aidFreeNights,
+    aidNights,
+    aidFreePercent: aidFreePercent === null ? null : Math.round(aidFreePercent * 100) / 100,
+    currentAidFreeStreak: current,
+    longestAidFreeStreak: longest,
+    trendDirection,
+    trendDelta,
+    sampleSize: scored.length,
+  };
+}
+
+// ─── Trend + weekly summary ────────────────────────────────────────────────────
+
+function buildTrend(nights: SleepNight[]): SleepTrendPoint[] {
+  return nights.map((n) => ({
+    dayKey: n.dayKey,
+    durationMinutes: n.durationMinutes,
+    appleSleepScore: n.appleSleepScore,
+    bedtimeMinutes: n.bedtimeMinutes,
+    wakeMinutes: n.wakeMinutes,
+    sleepQuality0to10: n.sleepQuality0to4 === null ? null : round1(n.sleepQuality0to4 * 2.5),
+  }));
+}
+
+function weekLabelFor(dayKey: string): string {
+  const date = parseISO(dayKey);
+  return `${getISOWeekYear(date)}-W${String(getISOWeek(date)).padStart(2, '0')}`;
+}
+
+function isOnTarget(n: SleepNight, targets: SleepTargets): boolean {
+  if (n.bedtimeMinutes === null || n.durationMinutes === null) return false;
+  const withinBedtime = Math.abs(n.bedtimeMinutes - targets.bedtimeMinutes) <= 30;
+  const enoughSleep = n.durationMinutes >= targets.durationMinutes - 30;
+  return withinBedtime && enoughSleep;
+}
+
+function buildWeeklySummary(nights: SleepNight[], targets: SleepTargets): SleepWeekSummary[] {
+  const byWeek = new Map<string, SleepNight[]>();
+  for (const n of nights) {
+    const label = weekLabelFor(n.dayKey);
+    const arr = byWeek.get(label) ?? [];
+    arr.push(n);
+    byWeek.set(label, arr);
+  }
+  return Array.from(byWeek.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([weekLabel, wkNights]) => {
+      const dur = mean(wkNights.map((n) => n.durationMinutes).filter((v): v is number => v !== null));
+      const lat = mean(wkNights.map((n) => n.latencyMinutes).filter((v): v is number => v !== null));
+      const awk = mean(wkNights.map((n) => n.awakenings).filter((v): v is number => v !== null));
+      const en = mean(wkNights.map((n) => n.morningEnergy).filter((v): v is number => v !== null));
+      return {
+        weekLabel,
+        avgDurationMinutes: dur === null ? null : Math.round(dur),
+        avgLatencyMinutes: lat === null ? null : Math.round(lat),
+        nightsOnTarget: wkNights.filter((n) => isOnTarget(n, targets)).length,
+        avgAwakenings: awk === null ? null : round1(awk),
+        sleepAidFreeNights: wkNights.filter((n) => n.sleepAidUsed === false).length,
+        avgMorningEnergy: en === null ? null : round1(en),
+      };
+    });
+}
+
+// ─── Achievements ──────────────────────────────────────────────────────────────
+
+function buildAchievements(
+  nights: SleepNight[],
+  consistency: number | null,
+  independence: SleepIndependence,
+  targets: SleepTargets
+): SleepAchievement[] {
+  // longest run of consecutive on-target nights
+  let onTargetRun = 0;
+  let onTargetBest = 0;
+  for (const n of nights) {
+    if (isOnTarget(n, targets)) {
+      onTargetRun += 1;
+      onTargetBest = Math.max(onTargetBest, onTargetRun);
+    } else {
+      onTargetRun = 0;
+    }
+  }
+  const qualities = pickNonNull(nights, 'sleepQuality0to4');
+  const bestQuality = qualities.length ? Math.max(...qualities) : null;
+  const latencies = pickNonNull(nights, 'latencyMinutes');
+  const lowestLatency = latencies.length ? Math.min(...latencies) : null;
+
+  return [
+    {
+      id: 'consistency-streak',
+      label: 'Consistency Streak',
+      description: 'Longest run of nights hitting your bedtime + duration targets.',
+      earned: onTargetBest >= 7,
+      value: onTargetBest,
+      icon: 'streak',
+    },
+    {
+      id: 'best-quality',
+      label: 'Best Quality',
+      description: 'Your highest single-night sleep quality.',
+      earned: bestQuality !== null && bestQuality >= 4,
+      value: bestQuality === null ? null : round1(bestQuality * 2.5),
+      icon: 'quality',
+    },
+    {
+      id: 'high-consistency',
+      label: 'Steady Sleeper',
+      description: 'Reached an 80+ consistency score.',
+      earned: consistency !== null && consistency >= 80,
+      value: consistency,
+      icon: 'consistency',
+    },
+    {
+      id: 'aid-free',
+      label: 'Sleep-Aid Free',
+      description: 'Longest run of nights without a sleep aid.',
+      earned: independence.longestAidFreeStreak >= 7,
+      value: independence.longestAidFreeStreak,
+      icon: 'aidfree',
+    },
+    {
+      id: 'low-latency',
+      label: 'Fast to Sleep',
+      description: 'Your fastest time to fall asleep.',
+      earned: lowestLatency !== null && lowestLatency <= 10,
+      value: lowestLatency,
+      icon: 'latency',
+    },
+  ];
+}
+
+// ─── Correlation engine ────────────────────────────────────────────────────────
+
+interface FactorSeries {
+  id: string;
+  name: string;
+  source: 'form' | 'habit';
+  /** dayKey -> numeric signal (0/1 for boolean/toggle, raw value for numeric). */
+  byDay: Map<string, number>;
+}
+
+const OUTCOMES: Array<{ key: 'appleSleepScore' | 'sleepQuality' | 'latencyMinutes' | 'bedtimeMinutes'; field: keyof SleepNight; higherIsBetter: boolean; unitLabel: string }> = [
+  { key: 'appleSleepScore', field: 'appleSleepScore', higherIsBetter: true, unitLabel: 'pts' },
+  { key: 'sleepQuality', field: 'sleepQuality0to4', higherIsBetter: true, unitLabel: 'pts (0-4)' },
+  { key: 'latencyMinutes', field: 'latencyMinutes', higherIsBetter: false, unitLabel: 'min' },
+];
+
+function cohensD(a: number[], b: number[]): number {
+  if (a.length < 2 || b.length < 2) return 0;
+  const ma = a.reduce((x, y) => x + y, 0) / a.length;
+  const mb = b.reduce((x, y) => x + y, 0) / b.length;
+  const va = a.reduce((acc, v) => acc + (v - ma) ** 2, 0) / (a.length - 1);
+  const vb = b.reduce((acc, v) => acc + (v - mb) ** 2, 0) / (b.length - 1);
+  const pooled = Math.sqrt(((a.length - 1) * va + (b.length - 1) * vb) / (a.length + b.length - 2));
+  if (pooled === 0) {
+    // No within-group spread: identical means → no effect; differing means → maximal.
+    if (ma === mb) return 0;
+    return ma > mb ? 4 : -4;
+  }
+  return (ma - mb) / pooled;
+}
+
+/** Collapse a factor series into present/absent night sets via median split. */
+function splitByFactor(series: FactorSeries, dayKeys: string[]): { present: Set<string>; absent: Set<string> } {
+  const present = new Set<string>();
+  const absent = new Set<string>();
+  // boolean-like if all values are 0/1
+  const values = dayKeys.map((dk) => series.byDay.get(dk) ?? 0);
+  const isBinary = values.every((v) => v === 0 || v === 1);
+  if (isBinary) {
+    for (const dk of dayKeys) {
+      ((series.byDay.get(dk) ?? 0) >= 1 ? present : absent).add(dk);
+    }
+    return { present, absent };
+  }
+  const nonZero = values.filter((v) => v > 0).sort((a, b) => a - b);
+  const median = nonZero.length ? nonZero[Math.floor(nonZero.length / 2)] : 0;
+  for (const dk of dayKeys) {
+    ((series.byDay.get(dk) ?? 0) >= median && median > 0 ? present : absent).add(dk);
+  }
+  return { present, absent };
+}
+
+function buildFactorSeries(
+  wellbeingByDay: Map<string, Record<string, number>>,
+  habits: Habit[],
+  habitEntries: HabitEntry[],
+  timeZone: string,
+  dayKeys: string[]
+): FactorSeries[] {
+  const series: FactorSeries[] = [];
+
+  // (a) form factor keys
+  for (const f of FORM_FACTOR_KEYS) {
+    const byDay = new Map<string, number>();
+    let any = false;
+    for (const dk of dayKeys) {
+      const rec = wellbeingByDay.get(dk);
+      if (rec && f.key in rec) {
+        byDay.set(dk, rec[f.key]);
+        any = true;
+      }
+    }
+    if (any) series.push({ id: f.key, name: f.name, source: 'form', byDay });
+  }
+
+  // (b) any other tracked habits (generic over type)
+  const dayStates = buildDayStatesByHabit(habitEntries, timeZone);
+  for (const habit of habits.filter(isTrackableHabit)) {
+    const states = dayStates.get(habit.id);
+    if (!states) continue;
+    const byDay = new Map<string, number>();
+    for (const dk of dayKeys) {
+      const st = states.get(dk);
+      if (!st) continue;
+      // boolean habit → completed (1); numeric/count/duration → summed value
+      byDay.set(dk, habit.goal.type === 'boolean' ? (st.completed ? 1 : 0) : st.value);
+    }
+    if (byDay.size > 0) {
+      series.push({ id: habit.id, name: habit.name, source: 'habit', byDay });
+    }
+  }
+
+  return series;
+}
+
+function correlate(nights: SleepNight[], series: FactorSeries[], dayKeys: string[]): SleepFactorInsight[] {
+  const nightByDay = new Map(nights.map((n) => [n.dayKey, n]));
+  const insights: SleepFactorInsight[] = [];
+
+  for (const f of series) {
+    const { present, absent } = splitByFactor(f, dayKeys);
+    for (const outcome of OUTCOMES) {
+      const presentVals: number[] = [];
+      const absentVals: number[] = [];
+      for (const dk of present) {
+        const v = nightByDay.get(dk)?.[outcome.field];
+        if (typeof v === 'number' && Number.isFinite(v)) presentVals.push(v);
+      }
+      for (const dk of absent) {
+        const v = nightByDay.get(dk)?.[outcome.field];
+        if (typeof v === 'number' && Number.isFinite(v)) absentVals.push(v);
+      }
+      if (presentVals.length < MIN_NIGHTS_PER_GROUP || absentVals.length < MIN_NIGHTS_PER_GROUP) continue;
+      const d = cohensD(presentVals, absentVals);
+      if (Math.abs(d) < MIN_EFFECT_SIZE) continue;
+
+      const mPresent = presentVals.reduce((a, b) => a + b, 0) / presentVals.length;
+      const mAbsent = absentVals.reduce((a, b) => a + b, 0) / absentVals.length;
+      const diff = mPresent - mAbsent;
+      const improves = outcome.higherIsBetter ? diff > 0 : diff < 0;
+
+      const magnitude = Math.abs(round1(diff));
+      const dirWord = improves ? 'higher' : (outcome.higherIsBetter ? 'lower' : 'higher');
+      const outcomeLabel = outcome.key === 'appleSleepScore' ? 'sleep score'
+        : outcome.key === 'sleepQuality' ? 'sleep quality'
+        : 'sleep latency';
+      const message = `On nights with "${f.name}", your ${outcomeLabel} is ${magnitude} ${outcome.unitLabel} ${dirWord} (n=${presentVals.length} vs ${absentVals.length}). Correlation, not proof.`;
+
+      insights.push({
+        factorId: f.id,
+        factorName: f.name,
+        source: f.source,
+        outcome: outcome.key,
+        factorPresentMean: round1(mPresent),
+        factorAbsentMean: round1(mAbsent),
+        meanDifference: round1(diff),
+        effectSize: round1(d),
+        direction: improves ? 'improves' : 'worsens',
+        nPresent: presentVals.length,
+        nAbsent: absentVals.length,
+        message,
+      });
+    }
+  }
+
+  // Keep the strongest outcome per factor, then rank by |effect size|.
+  const bestPerFactor = new Map<string, SleepFactorInsight>();
+  for (const ins of insights) {
+    const prev = bestPerFactor.get(ins.factorId);
+    if (!prev || Math.abs(ins.effectSize) > Math.abs(prev.effectSize)) bestPerFactor.set(ins.factorId, ins);
+  }
+  return Array.from(bestPerFactor.values())
+    .sort((a, b) => Math.abs(b.effectSize) - Math.abs(a.effectSize))
+    .slice(0, MAX_FACTORS);
+}
+
+// ─── Top-level ─────────────────────────────────────────────────────────────────
+
+export function computeSleepAnalytics(
+  wellbeingEntries: WellbeingEntry[],
+  habits: Habit[],
+  habitEntries: HabitEntry[],
+  _categories: Category[],
+  referenceDayKey: string,
+  days: number,
+  timeZone: string,
+  targets: SleepTargets = DEFAULT_SLEEP_TARGETS
+): SleepAnalyticsSummary {
+  const currentStart = startDayKeyForRange(referenceDayKey, days);
+  const previousStart = startDayKeyForRange(referenceDayKey, days * 2);
+  const previousEnd = format(subDays(parseISO(currentStart), 1), 'yyyy-MM-dd');
+
+  const currentDayKeys = generateDayKeyRange(currentStart, referenceDayKey);
+  const previousDayKeys = generateDayKeyRange(previousStart, previousEnd);
+
+  const currentNights = buildSleepNights(wellbeingEntries, currentDayKeys);
+  const previousNights = buildSleepNights(wellbeingEntries, previousDayKeys);
+
+  // headline stats
+  const avgDurationMinutes = buildStat(pickNonNull(currentNights, 'durationMinutes'), pickNonNull(previousNights, 'durationMinutes'), 'higher');
+  const avgLatencyMinutes = buildStat(pickNonNull(currentNights, 'latencyMinutes'), pickNonNull(previousNights, 'latencyMinutes'), 'lower');
+  const avgBedtimeMinutes = buildStat(pickNonNull(currentNights, 'bedtimeMinutes'), pickNonNull(previousNights, 'bedtimeMinutes'), 'closeness', targets.bedtimeMinutes);
+  const avgWakeMinutes = buildStat(pickNonNull(currentNights, 'wakeMinutes'), pickNonNull(previousNights, 'wakeMinutes'), 'closeness', targets.wakeMinutes);
+  const avgAppleSleepScore = buildStat(pickNonNull(currentNights, 'appleSleepScore'), pickNonNull(previousNights, 'appleSleepScore'), 'higher');
+  const qual10Current = pickNonNull(currentNights, 'sleepQuality0to4').map((q) => q * 2.5);
+  const qual10Previous = pickNonNull(previousNights, 'sleepQuality0to4').map((q) => q * 2.5);
+  const avgSleepQuality0to10 = buildStat(qual10Current, qual10Previous, 'higher');
+
+  // consistency
+  const consistency = computeConsistency(currentNights);
+  const prevConsistency = computeConsistency(previousNights);
+  const consistencyTrendDelta = consistency.overall !== null && prevConsistency.overall !== null
+    ? consistency.overall - prevConsistency.overall
+    : null;
+
+  // independence
+  const independence = computeIndependence(currentNights, previousNights);
+
+  // factors + correlations
+  const wellbeingByDay = pivotByDayKey(wellbeingEntries);
+  const series = buildFactorSeries(wellbeingByDay, habits, habitEntries, timeZone, currentDayKeys);
+  const topFactors = correlate(currentNights, series, currentDayKeys);
+
+  const nightsWithData = currentNights.filter((n) => n.hasData).length;
+
+  return {
+    avgDurationMinutes,
+    avgLatencyMinutes,
+    avgBedtimeMinutes,
+    avgWakeMinutes,
+    avgSleepQuality0to10,
+    avgAppleSleepScore,
+    consistencyScore: consistency.overall,
+    consistencyBedtime: consistency.bedtime,
+    consistencyWake: consistency.wake,
+    consistencyTrendDelta,
+    independence,
+    trend: buildTrend(currentNights),
+    weeklySummary: buildWeeklySummary(currentNights, targets),
+    topFactors,
+    achievements: buildAchievements(currentNights, consistency.overall, independence, targets),
+    nights: currentNights,
+    targets,
+    rangeDays: days,
+    coverage: { nightsWithData, nightsInRange: currentDayKeys.length },
+  };
+}


### PR DESCRIPTION
Extend WELLBEING_METRIC_KEYS with sleep outcome keys (Apple Watch overall
+ 3 sub-scores, bedtime/wake minutes-after-noon, duration, latency,
awakenings, sleep-aid) and behavioral factor keys (phone-in-bed, blue
light, wind-down, late-night eating, caffeine). Make METRIC_UI partial so
sleep-form-only keys are excluded from the generic check-in sliders, and
document the new keys + minutes-after-noon encoding in the data contract.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01STPBPVgcBrqE3FrR82GH2k