### PR TITLE
feat(ai): add grounded Weekly AI Review server route

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ HabitFlowAI lets you:
 - Log **wellbeing** check-ins (anxiety, mood, energy, stress) and view them as heatmaps or weekly summaries.
 - Sync selected **Apple Health** metrics to auto-log habits based on rules (beta).
 - Get **AI weekly recaps** via your own Gemini API key (BYOK, stored client-side only).
+- Generate a **Weekly AI Review** — a grounded, structured review (Summary / Wins / Struggles / Patterns with confidence / Recommendations / Data Limitations) built from your real habit, sleep, mood, journal, and goal data.
 
 Full feature inventory: [`docs/FEATURES.md`](docs/FEATURES.md).
 
@@ -33,6 +34,42 @@ Full feature inventory: [`docs/FEATURES.md`](docs/FEATURES.md).
 - **Identity-scoped multi-tenant from day one:** Every API request carries `X-Household-Id` and `X-User-Id` headers; all repositories filter by userId. Production refuses unauthenticated requests.
 - **CI-enforced beta gate:** A narrower lint + test suite runs against `src/server`, `src/shared`, and `src/domain` to keep the canonical layers clean without blocking the fast-moving UI code.
 - **Tests never touch a real DB:** The default Vitest config uses `mongodb-memory-server`; opting into a live DB requires `ALLOW_LIVE_DB_TESTS=true` **and** a DB name containing `_test`.
+
+## Weekly AI Review (applied AI feature)
+
+The **Weekly AI Review** turns a week of structured habit, sleep, mood, journal, and goal
+data into grounded weekly feedback. The system deliberately separates **observed facts**,
+**inferred patterns**, and **recommendations** so the model produces useful coaching without
+hallucinating advice.
+
+**Data / AI flow:**
+
+```
+Dashboard card (this week / last week)
+   → POST /api/ai/weekly-review  (Gemini BYOK)
+      → collect one week, scoped by (householdId, userId):
+          habitEntries · wellbeingEntries (sleep & mood) · journalEntries · goals
+      → aggregate into compact OBSERVED FACTS
+          per-habit days-logged vs. cadence · per-day breakdown (habits/sleep/mood/journaled)
+          weekly wellbeing averages · journal consistency · active goals
+      → Gemini 2.5 Flash with a JSON responseSchema + grounding rules
+      → validate & normalize → typed WeeklyAIReview
+   → render: Summary · Wins · Struggles · Patterns (confidence) · Recommendations · Data Limitations
+```
+
+**Grounding guarantees:**
+- Only facts derived from the database are sent to the model — no raw collections, no free-form dumps.
+- The prompt forbids inventing data and requires every win/struggle to cite specific numbers.
+- The server (not the model) owns the week boundaries; a response schema enforces a stable shape.
+- Thin weeks surface honest **Data Limitations** instead of low-evidence patterns; pattern
+  confidence (`low`/`medium`/`high`) is tied to how much supporting data exists.
+
+**Implementation notes:**
+- Server route: [`src/server/routes/aiWeeklyReview.ts`](src/server/routes/aiWeeklyReview.ts);
+  shared contract: [`src/shared/weeklyAiReview.ts`](src/shared/weeklyAiReview.ts).
+- Client + UI: `fetchWeeklyAIReview` in [`src/lib/geminiClient.ts`](src/lib/geminiClient.ts) and
+  [`src/components/dashboard/WeeklyAIReviewCard.tsx`](src/components/dashboard/WeeklyAIReviewCard.tsx).
+- BYOK Gemini, consistent with the existing AI routes — no server-side API key and no new dependencies.
 
 ## Architecture overview
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -120,6 +120,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 
 - **API Key Management** — Store Gemini API key in localStorage (never persisted server-side); configure via Settings
 - **AI Weekly Summary** — General recap of habits and journal entries from the past week (Dashboard)
+- **Weekly AI Review** — Structured, grounded review of a selected week (this week / last week) on the Dashboard. Aggregates habit entries, sleep & mood from wellbeing check-ins, journal activity, and goals into observed facts, then returns a typed review: Summary, Wins, Struggles, Patterns (each with a low/medium/high confidence), Recommendations, and Data Limitations. The prompt separates observed facts from inferred patterns from suggestions and forbids inventing data; low-data weeks are reported honestly via Data Limitations rather than fabricated patterns
 - **AI Journal Summary** — Auto-generated weekly journal summary shown as a dismissible banner; persisted as a journal entry in history
 - **AI Variant Suggestions** — Generate routine variants based on routine title and steps
 - **Persona-Driven Journaling** — Template personas guide journaling prompts
@@ -139,6 +140,7 @@ Canonical inventory of all user-facing features. Keep this document in sync with
 - **Daily Check-In Card** — Quick access to morning/evening wellbeing check-in
 - **Goals at a Glance** — Pinned goals with progress bars (configurable which goals to pin)
 - **Pinned Routines Card** — Quick-start buttons for favorite routines
+- **Weekly AI Review Card** — Generate a structured, grounded review (Summary, Wins, Struggles, Patterns with confidence, Recommendations, Data Limitations) for this week or last week
 - **AI Weekly Summary Card** — Generate AI recap of the week
 - **Journal Card** — Recent entries and shortcuts to Free Write / Templates / History
 - **Tasks Card** — Today's task completion status

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -46,6 +46,7 @@ HabitFlow App
 │   │   ├── Pinned Routines (→ Routine Runner)
 │   │   ├── Tasks Card (→ Tasks Page)
 │   │   ├── Journal Card (→ Journal Page)
+│   │   ├── Weekly AI Review (structured: Summary / Wins / Struggles / Patterns / Recommendations / Data Limitations; this-week / last-week)
 │   │   ├── Weekly Summary
 │   │   └── Heatmap (30d / 90d / year)
 │   │

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -426,6 +426,10 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                 <p className="text-sm text-neutral-300 mt-1">AI-powered tools to enhance your experience (uses your own API key):</p>
                 <ul className="mt-2 space-y-2">
                   <li className="text-xs text-neutral-400 pl-2">
+                    <span className="font-semibold text-neutral-300">Weekly AI Review</span>
+                    <p className="mt-0.5">A grounded, structured review of your week (this week or last week) on the Dashboard. It reads your real habit, sleep, mood, journal, and goal data and returns a Summary, Wins, Struggles, Patterns (each with a confidence level), Recommendations, and Data Limitations. It only uses your actual data and keeps facts, patterns, and suggestions separate — if a week is thin on data, it says so instead of inventing patterns.</p>
+                  </li>
+                  <li className="text-xs text-neutral-400 pl-2">
                     <span className="font-semibold text-neutral-300">Variant Suggestions</span>
                     <p className="mt-0.5">AI analyzes your routine and suggests Quick/Standard/Deep variants with full step lists.</p>
                   </li>

--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -10,6 +10,7 @@ import { JournalCard } from './dashboard/JournalCard';
 import { TasksCard } from './dashboard/TasksCard';
 import { PinnedRoutinesCard } from './dashboard/PinnedRoutinesCard';
 import { WeeklySummaryCard } from './dashboard/WeeklySummaryCard';
+import { WeeklyAIReviewCard } from './dashboard/WeeklyAIReviewCard';
 import { JournalSummaryCard } from './Journal/JournalSummaryCard';
 import { SetupDashboard } from './dashboard/SetupDashboard';
 import { useSetupProgress } from '../hooks/useSetupProgress';
@@ -212,6 +213,9 @@ export const ProgressDashboard: React.FC<ProgressDashboardProps> = ({
                     onViewAllRoutines={onNavigateToRoutines}
                 />
             )}
+
+            {/* AI Weekly Review (structured, grounded) */}
+            <WeeklyAIReviewCard />
 
             {/* AI Weekly Summary */}
             <WeeklySummaryCard />

--- a/src/components/dashboard/WeeklyAIReviewCard.tsx
+++ b/src/components/dashboard/WeeklyAIReviewCard.tsx
@@ -1,0 +1,291 @@
+import React, { useState } from 'react';
+import {
+  Sparkles,
+  Loader2,
+  Trophy,
+  AlertTriangle,
+  LineChart,
+  Lightbulb,
+  Info,
+  RefreshCw,
+} from 'lucide-react';
+import { hasGeminiApiKey, fetchWeeklyAIReview } from '../../lib/geminiClient';
+import type { WeeklyAIReview, ReviewConfidence } from '../../shared/weeklyAiReview';
+
+type WeekChoice = 'this' | 'last';
+
+/** Monday (local) of the current week, optionally going back `weeksAgo` weeks. */
+function mondayOf(weeksAgo: number): string {
+  const d = new Date();
+  const day = d.getDay(); // 0 = Sun .. 6 = Sat
+  const diffToMonday = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diffToMonday - weeksAgo * 7);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+const CONFIDENCE_STYLES: Record<ReviewConfidence, string> = {
+  high: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  medium: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  low: 'bg-neutral-500/15 text-neutral-300 border-neutral-500/30',
+};
+
+const Section: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+}> = ({ icon, title, children }) => (
+  <div>
+    <div className="flex items-center gap-2 mb-2">
+      {icon}
+      <h4 className="text-sm font-semibold text-white">{title}</h4>
+    </div>
+    {children}
+  </div>
+);
+
+export const WeeklyAIReviewCard: React.FC = () => {
+  const [review, setReview] = useState<WeeklyAIReview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [week, setWeek] = useState<WeekChoice>('this');
+
+  const hasKey = hasGeminiApiKey();
+
+  const handleGenerate = async (choice: WeekChoice = week) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const weekStart = mondayOf(choice === 'this' ? 0 : 1);
+      const result = await fetchWeeklyAIReview(weekStart);
+      setReview(result.review);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate weekly review');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const selectWeek = (choice: WeekChoice) => {
+    setWeek(choice);
+    setReview(null);
+    setError(null);
+  };
+
+  if (!hasKey) {
+    return (
+      <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
+        <div className="flex items-center gap-2 mb-2">
+          <Sparkles size={18} className="text-indigo-400" />
+          <h3 className="text-lg font-semibold text-white">Weekly AI Review</h3>
+        </div>
+        <p className="text-sm text-neutral-400">
+          Add your Gemini API key in Settings to generate a grounded, data-driven review of your week.
+        </p>
+      </div>
+    );
+  }
+
+  const isEmptyReview =
+    review &&
+    review.wins.length === 0 &&
+    review.struggles.length === 0 &&
+    review.patterns.length === 0 &&
+    review.recommendations.length === 0;
+
+  return (
+    <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
+      <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div className="flex items-center gap-2">
+          <Sparkles size={18} className="text-indigo-400" />
+          <h3 className="text-lg font-semibold text-white">Weekly AI Review</h3>
+        </div>
+        <div className="flex items-center gap-1 rounded-lg bg-white/5 p-0.5">
+          {(['this', 'last'] as WeekChoice[]).map((choice) => (
+            <button
+              key={choice}
+              onClick={() => selectWeek(choice)}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                week === choice ? 'bg-indigo-600/80 text-white' : 'text-neutral-400 hover:text-white'
+              }`}
+            >
+              {choice === 'this' ? 'This week' : 'Last week'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Idle / empty-of-results */}
+      {!review && !loading && !error && (
+        <div>
+          <p className="text-sm text-neutral-400 mb-4">
+            Generate a grounded review of your habits, sleep, mood, journaling, and goals. Facts,
+            patterns, and recommendations are kept separate so the feedback stays honest.
+          </p>
+          <button
+            onClick={() => handleGenerate()}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-600/80 text-white hover:bg-indigo-600 text-sm font-medium transition-colors"
+          >
+            <Sparkles size={14} />
+            Generate Weekly Review
+          </button>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center gap-3 py-4">
+          <Loader2 size={18} className="text-indigo-400 animate-spin" />
+          <span className="text-sm text-neutral-400">Analyzing your week…</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="space-y-3">
+          <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-3">
+            <p className="text-sm text-red-300">{error}</p>
+          </div>
+          <button
+            onClick={() => handleGenerate()}
+            className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {review && (
+        <div className="space-y-5">
+          <p className="text-[11px] text-neutral-500">
+            {review.weekStart} to {review.weekEnd}
+          </p>
+
+          {isEmptyReview ? (
+            <div className="rounded-lg bg-white/5 border border-white/10 p-4">
+              <p className="text-sm text-neutral-300">
+                There isn’t enough data this week to produce a confident review.
+              </p>
+            </div>
+          ) : (
+            <>
+              {/* Summary */}
+              {review.summary && (
+                <p className="text-sm text-neutral-200 leading-relaxed">{review.summary}</p>
+              )}
+
+              {/* Wins */}
+              {review.wins.length > 0 && (
+                <Section
+                  icon={<Trophy size={15} className="text-emerald-400" />}
+                  title="Wins"
+                >
+                  <ul className="space-y-1.5">
+                    {review.wins.map((w, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-neutral-300">
+                        <span className="text-emerald-400 mt-0.5">•</span>
+                        <span>{w}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Section>
+              )}
+
+              {/* Struggles */}
+              {review.struggles.length > 0 && (
+                <Section
+                  icon={<AlertTriangle size={15} className="text-amber-400" />}
+                  title="Struggles"
+                >
+                  <ul className="space-y-1.5">
+                    {review.struggles.map((s, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-neutral-300">
+                        <span className="text-amber-400 mt-0.5">•</span>
+                        <span>{s}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Section>
+              )}
+
+              {/* Patterns */}
+              {review.patterns.length > 0 && (
+                <Section
+                  icon={<LineChart size={15} className="text-sky-400" />}
+                  title="Patterns Detected"
+                >
+                  <div className="space-y-2.5">
+                    {review.patterns.map((p, i) => (
+                      <div
+                        key={i}
+                        className="rounded-lg bg-white/5 border border-white/10 p-3"
+                      >
+                        <div className="flex items-start justify-between gap-2 mb-1">
+                          <span className="text-sm font-medium text-white">{p.title}</span>
+                          <span
+                            className={`shrink-0 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border ${CONFIDENCE_STYLES[p.confidence]}`}
+                          >
+                            {p.confidence}
+                          </span>
+                        </div>
+                        <p className="text-xs text-neutral-400 leading-relaxed">{p.evidence}</p>
+                      </div>
+                    ))}
+                  </div>
+                </Section>
+              )}
+
+              {/* Recommendations */}
+              {review.recommendations.length > 0 && (
+                <Section
+                  icon={<Lightbulb size={15} className="text-indigo-400" />}
+                  title="Recommendations for Next Week"
+                >
+                  <div className="space-y-2.5">
+                    {review.recommendations.map((r, i) => (
+                      <div key={i} className="rounded-lg bg-white/5 border border-white/10 p-3">
+                        <p className="text-sm font-medium text-white mb-0.5">{r.title}</p>
+                        {r.reason && (
+                          <p className="text-xs text-neutral-400 leading-relaxed">{r.reason}</p>
+                        )}
+                        {r.suggestedAction && (
+                          <p className="text-xs text-indigo-300 mt-1 leading-relaxed">
+                            → {r.suggestedAction}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </Section>
+              )}
+            </>
+          )}
+
+          {/* Data limitations — always shown when present */}
+          {review.dataLimitations.length > 0 && (
+            <Section icon={<Info size={15} className="text-neutral-400" />} title="Data Limitations">
+              <ul className="space-y-1.5">
+                {review.dataLimitations.map((d, i) => (
+                  <li key={i} className="flex gap-2 text-xs text-neutral-400">
+                    <span className="text-neutral-500 mt-0.5">•</span>
+                    <span>{d}</span>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          <div className="pt-2 border-t border-white/5">
+            <button
+              onClick={() => handleGenerate()}
+              className="flex items-center gap-1.5 text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              <RefreshCw size={12} />
+              Regenerate
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/lib/geminiClient.ts
+++ b/src/lib/geminiClient.ts
@@ -9,6 +9,7 @@ import { API_BASE_URL } from './persistenceConfig';
 import { getIdentityHeaders } from './persistenceClient';
 import { fetchEntries } from '../api/journal';
 import type { JournalEntry } from '../models/persistenceTypes';
+import type { WeeklyAIReviewResponse } from '../shared/weeklyAiReview';
 
 const GEMINI_KEY_STORAGE = 'habitflow_gemini_api_key';
 
@@ -82,6 +83,41 @@ export async function fetchLatestJournalSummaryEntry(): Promise<JournalEntry | n
   const startDate = sevenDaysAgo.toISOString().slice(0, 10);
   const entries = await fetchEntries({ startDate });
   return entries.find(e => e.templateId === 'ai-weekly-summary') ?? null;
+}
+
+/**
+ * Generate a structured, grounded Weekly AI Review.
+ *
+ * @param weekStart Any day within the desired week (YYYY-MM-DD). Omit for the current week.
+ */
+export async function fetchWeeklyAIReview(weekStart?: string): Promise<WeeklyAIReviewResponse> {
+  const geminiApiKey = getGeminiApiKey();
+  if (!geminiApiKey) {
+    throw new Error('No Gemini API key configured. Add your key in Settings.');
+  }
+
+  const timeZone =
+    typeof Intl !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : undefined;
+
+  const url = `${API_BASE_URL}/ai/weekly-review`;
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getIdentityHeaders(),
+    },
+    body: JSON.stringify({ geminiApiKey, weekStart, timeZone }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      errorData?.error?.message || `Failed to generate weekly review (${response.status})`,
+    );
+  }
+
+  return response.json();
 }
 
 export async function fetchWeeklySummary(): Promise<WeeklySummaryResponse> {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -66,6 +66,7 @@ import healthSuggestionRoutes from './routes/healthSuggestions';
 import { requireHealthFeature } from './middleware/requireHealthFeature';
 import { deleteUserData } from './routes/userData';
 import { postWeeklySummary } from './routes/aiSummary';
+import { postWeeklyReview } from './routes/aiWeeklyReview';
 import { postSuggestVariants } from './routes/aiVariantSuggestion';
 import { postJournalSummary } from './routes/aiJournalSummary';
 import {
@@ -231,6 +232,7 @@ export function createApp(): Express {
   app.get('/api/dayView', getDayView);
   app.use('/api/evidence', habitPotentialEvidenceRoutes);
   app.post('/api/ai/weekly-summary', postWeeklySummary);
+  app.post('/api/ai/weekly-review', postWeeklyReview);
   app.post('/api/ai/suggest-variants', postSuggestVariants);
   app.post('/api/ai/journal-summary', postJournalSummary);
   app.get('/api/analytics/habits/all', getAllHabitAnalytics);

--- a/src/server/routes/__tests__/aiWeeklyReview.test.ts
+++ b/src/server/routes/__tests__/aiWeeklyReview.test.ts
@@ -112,7 +112,7 @@ describe('postWeeklyReview', () => {
   });
 
   it('sends only grounded observed facts to Gemini and returns a normalized review', async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
       geminiOk({
         summary: 'Solid week overall.',
         wins: ['Logged Walk 5 of 7 days', ''], // empty string should be filtered out
@@ -138,7 +138,7 @@ describe('postWeeklyReview', () => {
     expect(res.status).toHaveBeenCalledWith(200);
 
     // --- Grounding: the prompt contains DB-derived facts, not invented content ---
-    const promptBody = JSON.parse(vi.mocked(fetchMock).mock.calls[0][1]!.body as string);
+    const promptBody = JSON.parse(vi.mocked(fetchMock).mock.calls[0][1].body as string);
     const promptText = promptBody.contents[0].parts[0].text as string;
     expect(promptText).toContain('Walk');
     expect(promptText).toContain('daysLogged');

--- a/src/server/routes/__tests__/aiWeeklyReview.test.ts
+++ b/src/server/routes/__tests__/aiWeeklyReview.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { startOfWeek, endOfWeek, parseISO, format, getDay } from 'date-fns';
+
+// --- Mock identity (route reads it from the request via middleware helper) ---
+vi.mock('../../middleware/identity', () => ({
+  getRequestIdentity: () => ({ householdId: 'hh-1', userId: 'user-1' }),
+}));
+
+// --- Mock data sources ---
+const habitsData = [
+  {
+    id: 'h-walk',
+    name: 'Walk',
+    archived: false,
+    timesPerWeek: undefined,
+    assignedDays: undefined,
+  },
+  {
+    id: 'h-archived',
+    name: 'Old Habit',
+    archived: true,
+  },
+];
+
+// dayKeys for the reviewed week, filled in beforeEach from the resolved Monday.
+let weekDays: string[] = [];
+let habitEntriesData: Array<Record<string, unknown>> = [];
+let wellbeingData: Array<Record<string, unknown>> = [];
+let journalData: Array<Record<string, unknown>> = [];
+
+vi.mock('../../lib/mongoClient', () => ({
+  getDb: vi.fn(async () => ({
+    collection: (name: string) => ({
+      find: () => ({
+        toArray: async () => (name === 'habits' ? habitsData : habitEntriesData),
+      }),
+    }),
+  })),
+}));
+
+vi.mock('../../repositories/journal', () => ({
+  getEntriesByUser: vi.fn(async () => journalData),
+}));
+
+vi.mock('../../repositories/wellbeingEntryRepository', () => ({
+  getWellbeingEntries: vi.fn(async () => wellbeingData),
+}));
+
+vi.mock('../../repositories/goalRepository', () => ({
+  getGoalsByUser: vi.fn(async () => [
+    { id: 'g-1', title: 'Run a 10k', type: 'onetime', linkedHabitIds: ['h-walk'], completedAt: null },
+  ]),
+}));
+
+import { postWeeklyReview } from '../aiWeeklyReview';
+
+function createRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  } as unknown as Response;
+}
+
+const REQUESTED_WEEK = '2026-06-17';
+
+function geminiOk(modelOutput: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: JSON.stringify(modelOutput) }] } }],
+    }),
+  } as unknown as Response;
+}
+
+describe('postWeeklyReview', () => {
+  beforeEach(() => {
+    const monday = startOfWeek(parseISO(REQUESTED_WEEK), { weekStartsOn: 1 });
+    weekDays = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(monday);
+      d.setDate(d.getDate() + i);
+      return format(d, 'yyyy-MM-dd');
+    });
+
+    // Walk logged on 5 of 7 days.
+    habitEntriesData = weekDays.slice(0, 5).map((dayKey, i) => ({
+      id: `e-${i}`,
+      habitId: 'h-walk',
+      dayKey,
+      value: 1,
+    }));
+
+    // Sleep score recorded on two days.
+    wellbeingData = [
+      { metricKey: 'appleSleepScore', dayKey: weekDays[0], value: 82 },
+      { metricKey: 'appleSleepScore', dayKey: weekDays[1], value: 60 },
+    ];
+
+    journalData = [{ date: weekDays[0], templateId: 'free-write', content: { body: 'Felt good today.' } }];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('rejects a missing/short Gemini API key with 400', async () => {
+    const res = createRes();
+    await postWeeklyReview({ body: { geminiApiKey: 'x' } } as unknown as Request, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('sends only grounded observed facts to Gemini and returns a normalized review', async () => {
+    const fetchMock = vi.fn(async () =>
+      geminiOk({
+        summary: 'Solid week overall.',
+        wins: ['Logged Walk 5 of 7 days', ''], // empty string should be filtered out
+        struggles: ['Skipped Walk on two days'],
+        patterns: [
+          { title: 'Sleep vs. activity', evidence: 'Fewer habits after a low sleep score', confidence: 'banana' },
+        ],
+        recommendations: [
+          { title: 'Protect sleep', reason: 'Low-sleep days had fewer habits', suggestedAction: 'Set a wind-down alarm' },
+        ],
+        dataLimitations: ['Only two days of sleep data this week'],
+        // Note: model does NOT supply weekStart/weekEnd — the server must own them.
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createRes();
+    await postWeeklyReview(
+      { body: { geminiApiKey: 'a-valid-key-123', weekStart: REQUESTED_WEEK, timeZone: 'UTC' } } as unknown as Request,
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+
+    // --- Grounding: the prompt contains DB-derived facts, not invented content ---
+    const promptBody = JSON.parse(vi.mocked(fetchMock).mock.calls[0][1]!.body as string);
+    const promptText = promptBody.contents[0].parts[0].text as string;
+    expect(promptText).toContain('Walk');
+    expect(promptText).toContain('daysLogged');
+    expect(promptText).toContain('Sleep score'); // friendly wellbeing label
+    expect(promptText).toContain('Run a 10k'); // active goal
+    expect(promptText).not.toContain('Old Habit'); // archived habit excluded
+    // Structured JSON output requested.
+    expect(promptBody.generationConfig.responseMimeType).toBe('application/json');
+
+    const body = vi.mocked(res.json).mock.calls[0][0];
+    const review = body.review;
+
+    // Server owns the week boundaries (Monday..Sunday), regardless of model output.
+    const expectedStart = format(startOfWeek(parseISO(REQUESTED_WEEK), { weekStartsOn: 1 }), 'yyyy-MM-dd');
+    const expectedEnd = format(endOfWeek(parseISO(REQUESTED_WEEK), { weekStartsOn: 1 }), 'yyyy-MM-dd');
+    expect(review.weekStart).toBe(expectedStart);
+    expect(review.weekEnd).toBe(expectedEnd);
+    expect(getDay(parseISO(review.weekStart))).toBe(1); // Monday
+
+    // Empty strings filtered, bad confidence coerced to 'low'.
+    expect(review.wins).toEqual(['Logged Walk 5 of 7 days']);
+    expect(review.patterns[0].confidence).toBe('low');
+
+    // Metadata reflects real aggregates (archived habit excluded).
+    expect(body.meta.habitsTracked).toBe(1);
+    expect(body.meta.daysWithHabitData).toBe(5);
+    expect(body.meta.journalEntries).toBe(1);
+    expect(body.meta.wellbeingDaysRecorded).toBe(2);
+  });
+
+  it('returns a well-formed review even when Gemini reports only data limitations', async () => {
+    habitEntriesData = [];
+    wellbeingData = [];
+    journalData = [];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        geminiOk({
+          summary: 'Not much was tracked this week.',
+          wins: [],
+          struggles: [],
+          patterns: [],
+          recommendations: [],
+          dataLimitations: ['There is not enough data this week to identify patterns confidently.'],
+        }),
+      ),
+    );
+
+    const res = createRes();
+    await postWeeklyReview(
+      { body: { geminiApiKey: 'a-valid-key-123', weekStart: REQUESTED_WEEK, timeZone: 'UTC' } } as unknown as Request,
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const review = vi.mocked(res.json).mock.calls[0][0].review;
+    expect(review.wins).toEqual([]);
+    expect(review.dataLimitations.length).toBeGreaterThan(0);
+    expect(review.weekStart).toBeTruthy();
+  });
+});

--- a/src/server/routes/aiWeeklyReview.ts
+++ b/src/server/routes/aiWeeklyReview.ts
@@ -1,0 +1,431 @@
+/**
+ * Weekly AI Review Route (Gemini BYOK)
+ *
+ * POST /api/ai/weekly-review
+ *
+ * Gathers a single week of the user's real data (habit entries, sleep & mood
+ * from wellbeing check-ins, journal activity, and goals), aggregates it into
+ * a compact set of *observed facts*, and asks Gemini to produce a grounded,
+ * structured weekly review.
+ *
+ * Grounding strategy:
+ *  - Only aggregated facts derived from the database are sent to the model.
+ *  - The prompt explicitly separates observed facts, inferred patterns, and
+ *    suggestions, and instructs the model never to invent data.
+ *  - The week boundaries in the response are set by the server, not the model.
+ *  - A structured JSON response schema is enforced so the UI gets a stable shape.
+ */
+
+import type { Request, Response } from 'express';
+import { startOfWeek, endOfWeek, parseISO, format, getDay } from 'date-fns';
+import { getRequestIdentity } from '../middleware/identity';
+import { getDb } from '../lib/mongoClient';
+import { getEntriesByUser } from '../repositories/journal';
+import { getWellbeingEntries } from '../repositories/wellbeingEntryRepository';
+import { getGoalsByUser } from '../repositories/goalRepository';
+import { resolveTimeZone, getNowDayKey } from '../utils/dayKey';
+import { isValidDayKey } from '../../domain/time/dayKey';
+import type {
+  WeeklyAIReview,
+  WeeklyReviewPattern,
+  WeeklyReviewRecommendation,
+  ReviewConfidence,
+} from '../../shared/weeklyAiReview';
+
+interface WeeklyReviewRequest {
+  geminiApiKey: string;
+  /** Any day within the desired week (YYYY-MM-DD). Defaults to the current week. */
+  weekStart?: string;
+  timeZone?: string;
+}
+
+const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/** Wellbeing metrics worth surfacing to the model, with friendly labels. */
+const WELLBEING_LABELS: Record<string, string> = {
+  appleSleepScore: 'Sleep score (0-100)',
+  sleepScore: 'Sleep score',
+  sleepQuality: 'Sleep quality',
+  sleepDurationMinutes: 'Sleep duration (minutes)',
+  energy: 'Energy',
+  calm: 'Calm',
+  stress: 'Stress',
+  anxiety: 'Anxiety',
+  lowMood: 'Low mood',
+  depression: 'Depression',
+  focus: 'Focus',
+  satisfaction: 'Satisfaction',
+  readiness: 'Readiness',
+  recovery: 'Recovery',
+};
+
+function avg(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 10) / 10;
+}
+
+/**
+ * POST /api/ai/weekly-review
+ */
+export async function postWeeklyReview(req: Request, res: Response): Promise<void> {
+  try {
+    const { geminiApiKey, weekStart: requestedWeek, timeZone: tzInput } =
+      req.body as WeeklyReviewRequest;
+
+    if (!geminiApiKey || typeof geminiApiKey !== 'string' || geminiApiKey.trim().length < 10) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'A valid Gemini API key is required' },
+      });
+      return;
+    }
+
+    const { userId, householdId } = getRequestIdentity(req);
+    const timeZone = resolveTimeZone(typeof tzInput === 'string' ? tzInput : undefined);
+
+    // ---- Resolve the week window (Monday..Sunday) ----
+    const referenceKey =
+      typeof requestedWeek === 'string' && isValidDayKey(requestedWeek)
+        ? requestedWeek
+        : getNowDayKey(timeZone);
+    const refDate = parseISO(referenceKey);
+    const weekStartDate = startOfWeek(refDate, { weekStartsOn: 1 });
+    const weekEndDate = endOfWeek(refDate, { weekStartsOn: 1 });
+    const startDayKey = format(weekStartDate, 'yyyy-MM-dd');
+    const endDayKey = format(weekEndDate, 'yyyy-MM-dd');
+
+    const weekDayKeys: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(weekStartDate);
+      d.setDate(d.getDate() + i);
+      weekDayKeys.push(format(d, 'yyyy-MM-dd'));
+    }
+
+    // ---- Collect raw data for the week ----
+    const db = await getDb();
+    const [habits, habitEntries, allJournal, wellbeingEntries, goals] = await Promise.all([
+      db.collection('habits').find({ userId, householdId }).toArray(),
+      db
+        .collection('habitEntries')
+        .find({
+          userId,
+          householdId,
+          dayKey: { $gte: startDayKey, $lte: endDayKey },
+          deletedAt: { $exists: false },
+        })
+        .toArray(),
+      getEntriesByUser(userId, { startDate: startDayKey, endDate: endDayKey }),
+      getWellbeingEntries({ userId, startDayKey, endDayKey }),
+      getGoalsByUser(householdId, userId),
+    ]);
+
+    const activeHabits = habits.filter((h) => !h.archived && !h.deletedAt);
+    const habitNameMap = new Map<string, string>();
+    for (const h of habits) habitNameMap.set(h.id, h.name);
+
+    // ---- Per-habit weekly aggregation (days logged vs. target) ----
+    const daysLoggedByHabit = new Map<string, Set<string>>();
+    for (const entry of habitEntries) {
+      if (!daysLoggedByHabit.has(entry.habitId)) daysLoggedByHabit.set(entry.habitId, new Set());
+      daysLoggedByHabit.get(entry.habitId)!.add(entry.dayKey);
+    }
+
+    const habitFacts = activeHabits.map((h) => {
+      const daysLogged = daysLoggedByHabit.get(h.id)?.size ?? 0;
+      // Target days this week: weekly habits use timesPerWeek; otherwise daily (7) or assigned days.
+      let targetDays = 7;
+      if (typeof h.timesPerWeek === 'number' && h.timesPerWeek > 0) targetDays = h.timesPerWeek;
+      else if (Array.isArray(h.assignedDays) && h.assignedDays.length > 0)
+        targetDays = h.assignedDays.length;
+      return {
+        name: h.name as string,
+        daysLogged,
+        targetDays,
+        cadence:
+          typeof h.timesPerWeek === 'number' && h.timesPerWeek > 0
+            ? `${h.timesPerWeek}x/week`
+            : 'daily',
+      };
+    });
+
+    // ---- Per-day breakdown (enables correlation patterns) ----
+    const journalDays = new Set(allJournal.map((j) => j.date));
+    const wellbeingByDay = new Map<string, Map<string, number[]>>();
+    for (const w of wellbeingEntries) {
+      if (typeof w.value !== 'number') continue;
+      if (!WELLBEING_LABELS[w.metricKey]) continue;
+      if (!wellbeingByDay.has(w.dayKey)) wellbeingByDay.set(w.dayKey, new Map());
+      const m = wellbeingByDay.get(w.dayKey)!;
+      if (!m.has(w.metricKey)) m.set(w.metricKey, []);
+      m.get(w.metricKey)!.push(w.value);
+    }
+
+    const habitDaysByDay = new Map<string, Set<string>>();
+    for (const entry of habitEntries) {
+      if (!habitDaysByDay.has(entry.dayKey)) habitDaysByDay.set(entry.dayKey, new Set());
+      habitDaysByDay.get(entry.dayKey)!.add(entry.habitId);
+    }
+
+    const dayBreakdown = weekDayKeys.map((dayKey) => {
+      const weekday = WEEKDAY_NAMES[getDay(parseISO(dayKey))];
+      const habitsCompleted = habitDaysByDay.get(dayKey)?.size ?? 0;
+      const metrics: Record<string, number> = {};
+      const dayMetrics = wellbeingByDay.get(dayKey);
+      if (dayMetrics) {
+        for (const [key, vals] of dayMetrics) {
+          const a = avg(vals);
+          if (a !== null) metrics[WELLBEING_LABELS[key]] = a;
+        }
+      }
+      return {
+        date: dayKey,
+        weekday,
+        habitsCompleted,
+        journaled: journalDays.has(dayKey),
+        wellbeing: Object.keys(metrics).length > 0 ? metrics : undefined,
+      };
+    });
+
+    // ---- Weekly wellbeing averages ----
+    const wellbeingTotals = new Map<string, number[]>();
+    for (const w of wellbeingEntries) {
+      if (typeof w.value !== 'number' || !WELLBEING_LABELS[w.metricKey]) continue;
+      if (!wellbeingTotals.has(w.metricKey)) wellbeingTotals.set(w.metricKey, []);
+      wellbeingTotals.get(w.metricKey)!.push(w.value);
+    }
+    const wellbeingAverages: Array<{ metric: string; average: number; daysRecorded: number }> = [];
+    for (const [key, vals] of wellbeingTotals) {
+      const a = avg(vals);
+      if (a !== null) {
+        wellbeingAverages.push({ metric: WELLBEING_LABELS[key], average: a, daysRecorded: vals.length });
+      }
+    }
+
+    // ---- Journal facts (consistency-focused, with short snippets) ----
+    const journalFacts = allJournal.map((j) => {
+      const snippet = Object.values(j.content)
+        .filter((v) => typeof v === 'string' && v.trim().length > 0)
+        .join(' • ')
+        .slice(0, 280);
+      return { date: j.date, template: j.templateId, snippet };
+    });
+
+    // ---- Goal facts ----
+    const goalFacts = goals
+      .filter((g) => !g.completedAt)
+      .map((g) => ({
+        title: g.title,
+        type: g.type,
+        target: g.targetValue ?? null,
+        unit: g.unit ?? null,
+        deadline: g.deadline ?? null,
+        linkedHabits: (g.linkedHabitIds ?? []).map((id) => habitNameMap.get(id) ?? id),
+      }));
+
+    const wellbeingDaysRecorded = new Set(
+      wellbeingEntries.filter((w) => WELLBEING_LABELS[w.metricKey]).map((w) => w.dayKey),
+    ).size;
+
+    const observedFacts = {
+      weekStart: startDayKey,
+      weekEnd: endDayKey,
+      habits: habitFacts,
+      dayByDay: dayBreakdown,
+      wellbeingAverages,
+      journal: journalFacts,
+      goals: goalFacts,
+      totals: {
+        activeHabits: activeHabits.length,
+        daysWithHabitData: habitDaysByDay.size,
+        journalEntries: journalFacts.length,
+        wellbeingDaysRecorded,
+      },
+    };
+
+    // ---- Build the grounded prompt ----
+    const prompt = `You are an analytical wellness coach for a habit-tracking app called HabitFlow.
+You will be given OBSERVED FACTS derived directly from one user's database for a single week.
+Produce a grounded weekly review.
+
+STRICT GROUNDING RULES:
+- Use ONLY the observed facts below. Never invent habits, numbers, sleep data, moods, or events that are not present.
+- Clearly distinguish observed facts (what happened) from inferred patterns (relationships you noticed) from recommendations (suggestions).
+- In "patterns", set "confidence" to "low", "medium", or "high" based ONLY on how much supporting data exists. If there are few data points, use "low".
+- If a category has little or no data (e.g. no journal entries, no sleep/mood data), DO NOT fabricate patterns about it. Instead add an honest note to "dataLimitations".
+- Wins and struggles must each cite specific numbers from the facts (e.g. "logged X 5 of 7 days").
+- Recommendations must be small and behaviorally realistic (e.g. "move your workout earlier on Thursdays"), never generic ("be more disciplined").
+- Keep the summary to 2-4 sentences. Provide 2-5 wins, 2-5 struggles. It is fine to provide fewer if the data does not support more.
+
+OBSERVED FACTS (JSON):
+${JSON.stringify(observedFacts, null, 2)}
+
+Notes for interpretation:
+- "daysLogged" vs "targetDays" reflects how often each habit was completed relative to its cadence this week.
+- "dayByDay" lets you look for relationships (e.g. sleep score vs. next-day habits completed, mood vs. journaling).
+- Wellbeing values are on the user's own check-in scales; treat them as relative within this week, not absolute.
+
+Return the review as JSON matching the provided schema.`;
+
+    const responseSchema = {
+      type: 'object',
+      properties: {
+        summary: { type: 'string' },
+        wins: { type: 'array', items: { type: 'string' } },
+        struggles: { type: 'array', items: { type: 'string' } },
+        patterns: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              evidence: { type: 'string' },
+              confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+            },
+            required: ['title', 'evidence', 'confidence'],
+          },
+        },
+        recommendations: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              reason: { type: 'string' },
+              suggestedAction: { type: 'string' },
+            },
+            required: ['title', 'reason', 'suggestedAction'],
+          },
+        },
+        dataLimitations: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['summary', 'wins', 'struggles', 'patterns', 'recommendations', 'dataLimitations'],
+    };
+
+    // ---- Call Gemini (structured JSON output) ----
+    const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(
+      geminiApiKey.trim(),
+    )}`;
+
+    const geminiResponse = await fetch(geminiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: {
+          temperature: 0.4,
+          maxOutputTokens: 2048,
+          responseMimeType: 'application/json',
+          responseSchema,
+          thinkingConfig: { thinkingBudget: 0 },
+        },
+      }),
+    });
+
+    if (!geminiResponse.ok) {
+      const errorBody = await geminiResponse.text();
+      console.error('[AI Weekly Review] Gemini API error:', geminiResponse.status, errorBody);
+      if (geminiResponse.status === 400 || geminiResponse.status === 403) {
+        res.status(401).json({
+          error: {
+            code: 'GEMINI_AUTH_ERROR',
+            message: 'Invalid Gemini API key. Please check your key in Settings.',
+          },
+        });
+        return;
+      }
+      res.status(502).json({
+        error: {
+          code: 'GEMINI_API_ERROR',
+          message: 'Failed to get response from Gemini. Please try again later.',
+        },
+      });
+      return;
+    }
+
+    const geminiData = (await geminiResponse.json()) as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string; thought?: boolean }> } }>;
+    };
+    const parts = geminiData?.candidates?.[0]?.content?.parts || [];
+    const outputPart = parts.find((p) => !p.thought && p.text) || parts[0];
+    const rawText = outputPart?.text;
+
+    if (!rawText) {
+      res.status(502).json({
+        error: { code: 'GEMINI_EMPTY_RESPONSE', message: 'Gemini returned an empty review.' },
+      });
+      return;
+    }
+
+    let parsed: Partial<WeeklyAIReview>;
+    try {
+      parsed = JSON.parse(rawText) as Partial<WeeklyAIReview>;
+    } catch {
+      console.error('[AI Weekly Review] Failed to parse Gemini JSON:', rawText.slice(0, 500));
+      res.status(502).json({
+        error: { code: 'GEMINI_PARSE_ERROR', message: 'Gemini returned an unexpected format.' },
+      });
+      return;
+    }
+
+    // ---- Normalize / validate (server owns the week boundaries) ----
+    const strArray = (v: unknown): string[] =>
+      Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0) : [];
+
+    const validConfidence = (c: unknown): ReviewConfidence =>
+      c === 'high' || c === 'medium' || c === 'low' ? c : 'low';
+
+    const patterns: WeeklyReviewPattern[] = Array.isArray(parsed.patterns)
+      ? parsed.patterns
+          .filter((p): p is WeeklyReviewPattern => !!p && typeof p === 'object')
+          .map((p) => ({
+            title: String(p.title ?? ''),
+            evidence: String(p.evidence ?? ''),
+            confidence: validConfidence(p.confidence),
+          }))
+          .filter((p) => p.title.length > 0)
+      : [];
+
+    const recommendations: WeeklyReviewRecommendation[] = Array.isArray(parsed.recommendations)
+      ? parsed.recommendations
+          .filter((r): r is WeeklyReviewRecommendation => !!r && typeof r === 'object')
+          .map((r) => ({
+            title: String(r.title ?? ''),
+            reason: String(r.reason ?? ''),
+            suggestedAction: String(r.suggestedAction ?? ''),
+          }))
+          .filter((r) => r.title.length > 0)
+      : [];
+
+    const review: WeeklyAIReview = {
+      weekStart: startDayKey,
+      weekEnd: endDayKey,
+      summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+      wins: strArray(parsed.wins),
+      struggles: strArray(parsed.struggles),
+      patterns,
+      recommendations,
+      dataLimitations: strArray(parsed.dataLimitations),
+    };
+
+    res.status(200).json({
+      review,
+      meta: {
+        weekStart: startDayKey,
+        weekEnd: endDayKey,
+        habitsTracked: activeHabits.length,
+        daysWithHabitData: habitDaysByDay.size,
+        journalEntries: journalFacts.length,
+        wellbeingDaysRecorded,
+      },
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[AI Weekly Review] Error:', errorMessage);
+    res.status(500).json({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to generate weekly review',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      },
+    });
+  }
+}

--- a/src/shared/weeklyAiReview.ts
+++ b/src/shared/weeklyAiReview.ts
@@ -1,0 +1,61 @@
+/**
+ * Weekly AI Review — shared contract
+ *
+ * Used by both the server route that generates the review (Gemini BYOK)
+ * and the frontend that renders it. The shape deliberately separates
+ * observed facts (summary/wins/struggles), inferred patterns (with an
+ * explicit confidence level), and forward-looking recommendations so the
+ * UI can present grounded feedback without conflating the three.
+ */
+
+export type ReviewConfidence = 'low' | 'medium' | 'high';
+
+export interface WeeklyReviewPattern {
+  /** Short headline for the pattern, e.g. "Workouts dip after poor sleep". */
+  title: string;
+  /** The specific observed data that supports the pattern. */
+  evidence: string;
+  /** How strongly the data supports the pattern. */
+  confidence: ReviewConfidence;
+}
+
+export interface WeeklyReviewRecommendation {
+  /** Short, concrete action headline. */
+  title: string;
+  /** Why this is suggested, tied to the observed data. */
+  reason: string;
+  /** A small, behaviorally realistic next step. */
+  suggestedAction: string;
+}
+
+export interface WeeklyAIReview {
+  /** Monday of the reviewed week (YYYY-MM-DD). */
+  weekStart: string;
+  /** Sunday of the reviewed week (YYYY-MM-DD). */
+  weekEnd: string;
+  /** Short, human-readable narrative of the week. */
+  summary: string;
+  /** 2–5 positive patterns grounded in the data. */
+  wins: string[];
+  /** 2–5 obstacles or weak spots grounded in the data. */
+  struggles: string[];
+  /** Inferred relationships in the data, each with a confidence level. */
+  patterns: WeeklyReviewPattern[];
+  /** Practical, specific suggestions for next week. */
+  recommendations: WeeklyReviewRecommendation[];
+  /** Honest notes about where data was too thin to draw conclusions. */
+  dataLimitations: string[];
+}
+
+/** Server response wrapper: the review plus lightweight metadata. */
+export interface WeeklyAIReviewResponse {
+  review: WeeklyAIReview;
+  meta: {
+    weekStart: string;
+    weekEnd: string;
+    habitsTracked: number;
+    daysWithHabitData: number;
+    journalEntries: number;
+    wellbeingDaysRecorded: number;
+  };
+}


### PR DESCRIPTION
Adds POST /api/ai/weekly-review (Gemini BYOK). Collects one week of real
user data — habit entries, sleep & mood from wellbeing check-ins, journal
activity, and goals — aggregates it into compact observed facts, and asks
Gemini for a structured JSON review (summary, wins, struggles, patterns
with confidence, recommendations, dataLimitations).

Grounding: only DB-derived facts are sent; the prompt separates observed
facts from inferred patterns from suggestions and forbids inventing data;
the server owns the week boundaries; a response schema enforces shape.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M4Ha2JT7yoqHfC33WHHgS9