### PR TITLE
fix(numeric-popover): reliably display value on iOS

### DIFF
--- a/src/components/NumericInputPopover.test.tsx
+++ b/src/components/NumericInputPopover.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tests for NumericInputPopover.
+ *
+ * Regression: on iOS the popover sometimes opened without displaying the value
+ * (existing values appeared blank and the first typed digit was swallowed).
+ * The fix shows existing values reliably, leaves new entries blank so the
+ * placeholder shows, and selects via the native onFocus instead of a delayed
+ * programmatic select().
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NumericInputPopover } from './NumericInputPopover';
+
+const baseProps = {
+    isOpen: true,
+    onClose: () => {},
+    onSubmit: () => {},
+    position: { top: 0, left: 0 },
+};
+
+describe('NumericInputPopover', () => {
+    it('displays the existing value when opened for an entry that has one', () => {
+        render(<NumericInputPopover {...baseProps} initialValue={40} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        expect(input.value).toBe('40');
+    });
+
+    it('starts blank (placeholder visible) for a new entry', () => {
+        render(<NumericInputPopover {...baseProps} initialValue={0} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        expect(input.value).toBe('');
+        expect(input).toHaveAttribute('placeholder', '0');
+    });
+
+    it('reflects the typed number', () => {
+        render(<NumericInputPopover {...baseProps} initialValue={0} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '7' } });
+        expect(input.value).toBe('7');
+    });
+
+    it('submits the typed numeric value', () => {
+        const onSubmit = vi.fn();
+        render(<NumericInputPopover {...baseProps} initialValue={0} onSubmit={onSubmit} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '12' } });
+        fireEvent.submit(input.closest('form')!);
+        expect(onSubmit).toHaveBeenCalledWith(12);
+    });
+});

--- a/src/components/NumericInputPopover.tsx
+++ b/src/components/NumericInputPopover.tsx
@@ -20,17 +20,21 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
     unit,
     position,
 }) => {
-    const [value, setValue] = useState(initialValue.toString());
+    const [value, setValue] = useState(initialValue > 0 ? initialValue.toString() : '');
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         if (isOpen) {
-            setValue(initialValue.toString());
-            // Double-rAF ensures DOM is painted before focus (more reliable than setTimeout on iOS)
+            // Existing values are shown for editing; new entries start blank so the
+            // placeholder ("0") shows and the first typed digit always appears.
+            setValue(initialValue > 0 ? initialValue.toString() : '');
+            // Double-rAF ensures DOM is painted before focus (more reliable than setTimeout on iOS).
+            // Selection is handled by the input's onFocus (below) rather than a delayed select()
+            // call here: on iOS a late, programmatic select() races with the on-screen keyboard
+            // and can swallow the user's first keystroke, leaving the field looking empty.
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     inputRef.current?.focus();
-                    inputRef.current?.select();
                 });
             });
         }
@@ -81,6 +85,7 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
                     pattern="[0-9]*\.?[0-9]*"
                     value={value}
                     onChange={(e) => setValue(e.target.value)}
+                    onFocus={(e) => e.currentTarget.select()}
                     className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-1.5 text-white text-sm focus:outline-none focus:border-emerald-500"
                     placeholder="0"
                 />


### PR DESCRIPTION
The numeric input popover sometimes showed an empty field when entering a
value: existing values appeared blank and the first typed digit could be
swallowed. Root cause was a delayed, programmatic focus()+select() in a
double-requestAnimationFrame that races with the iOS on-screen keyboard and
the controlled re-render.

- Show existing values for editing; start new entries blank so the "0"
  placeholder shows and the first typed digit always appears.
- Move text selection to the input's native onFocus so it stays in sync with
  iOS focus handling and can't clobber the user's first keystroke.
- Add NumericInputPopover tests covering display/typing/submit.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018T1kC4ibaP3Z19grug94Do