### PR TITLE
Make SleepEntryForm editable for any previous night

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -143,6 +143,7 @@ Every feature area below is **Shipped** unless an item notes otherwise.
   - **Weekly summary & achievements** — Per-week duration/latency/on-target/aid-free/energy rollups and milestone cards
   - **Configurable targets** — User-set target bedtime / wake / duration (default 10 PM / 6 AM / 8h)
   - Data captured via a dedicated **Sleep entry form** on the Daily Check-in (morning), stored as wellbeing entries
+  - **Edit any previous night** — The sleep form has a "Night of" date picker (capped at today), and the Sleep tab shows an "Edit a night" list of recent nights; tapping a night opens the form pre-filled to log or correct that day's data
 
 ## AI Features (Gemini BYOK)
 

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -144,7 +144,7 @@ HabitFlow App
 | Routine Runner | Modal | "Play" button on routine card | Step-by-step routine execution with timers | Routines, Habits, Entries |
 | Routine Preview | Modal | Preview button on routine card | Read-only routine view before starting | Routines |
 | Daily Check-in | Modal | Dashboard check-in card | Wellbeing metrics entry (sleep, mood, stress); morning tab has a "Log Sleep" entry point | Wellbeing Entries |
-| Log Sleep | Modal | "Log Sleep" button on Daily Check-in morning tab | Apple Watch sleep score + sub-scores, bedtime/wake pickers, duration, quality, last-night habit toggles, and configurable sleep targets | Wellbeing Entries, Dashboard Prefs |
+| Log Sleep | Modal | "Log Sleep" button on Daily Check-in morning tab, or "Edit a night" list on Analytics → Sleep tab | Apple Watch sleep score + sub-scores, bedtime/wake pickers, duration, quality, last-night habit toggles, and configurable sleep targets; a "Night of" date picker (capped at today) lets any previous night be logged or corrected | Wellbeing Entries, Dashboard Prefs |
 | Edit Goal | Modal | Goal context menu "Edit" | Modify goal title, target, deadline | Goals |
 | Delete Goal Confirm | Modal | Goal context menu "Delete" | Deletion confirmation dialog | Goals |
 | Remove Habit | Modal | Trash button on a habit that is linked to one or more goals (shown after the click-twice confirm so the user sees which goals are affected) | Lists the affected goals and offers two paths: **Archive** (recommended, restorable from Settings) or **Delete permanently** (soft-delete, not restorable). For unlinked habits the trash icon archives directly without opening this modal | Habits, Goals |
@@ -305,7 +305,7 @@ graph TB
 | **Goal progress charts** | Goal Detail Page (cumulative, trend, weekly summary) |
 | **Wellbeing trends** | Wellbeing History Page |
 | **Weekly summary** | Dashboard weekly summary card |
-| **Sleep analytics** | Analytics Page → Sleep tab (Habits / Routines / Goals / Sleep) — Apple Watch score, consistency, independence, bedtime/wake & duration trends, correlation factors, weekly summary, achievements |
+| **Sleep analytics** | Analytics Page → Sleep tab (Habits / Routines / Goals / Sleep) — Apple Watch score, consistency, independence, bedtime/wake & duration trends, correlation factors, weekly summary, achievements, and an "Edit a night" list to log/correct previous nights |
 
 ### Category
 

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -367,7 +367,7 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                 <p className="text-sm text-neutral-200">
                   <span className="font-bold text-emerald-400">Sleep Analytics</span>
                 </p>
-                <p className="text-sm text-neutral-300 mt-1">A dedicated Sleep tab in Analytics built around your Apple Watch Sleep Score (overall plus bedtime, duration, and interruption sub-scores). Use the "Log Sleep" button on the morning check-in to record your score, bedtime/wake times, duration, quality, and last-night habits.</p>
+                <p className="text-sm text-neutral-300 mt-1">A dedicated Sleep tab in Analytics built around your Apple Watch Sleep Score (overall plus bedtime, duration, and interruption sub-scores). Use the "Log Sleep" button on the morning check-in to record your score, bedtime/wake times, duration, quality, and last-night habits. Forgot a night? Use the "Night of" date picker in the form — or the "Edit a night" list on the Sleep tab — to log or correct any previous day.</p>
                 <ul className="mt-1.5 space-y-1.5">
                   <li className="text-xs text-neutral-400 pl-2 flex items-start gap-1.5">
                     <Activity size={13} className="text-emerald-400 mt-0.5 shrink-0" />

--- a/src/components/SleepEntryForm.tsx
+++ b/src/components/SleepEntryForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { X, Save, Watch, Clock, Sunrise, Moon, Settings2 } from 'lucide-react';
+import { X, Save, Watch, Clock, Sunrise, Moon, Settings2, CalendarDays } from 'lucide-react';
 import { format } from 'date-fns';
 import {
   fetchWellbeingEntries,
@@ -18,6 +18,8 @@ interface SleepEntryFormProps {
   isOpen: boolean;
   onClose: () => void;
   onSaved?: () => void;
+  /** Day to log/edit (YYYY-MM-DD). Defaults to today; used to edit previous nights. */
+  initialDayKey?: string;
 }
 
 const DEFAULT_TARGETS = { bedtimeMinutes: 600, wakeMinutes: 1080, durationMinutes: 480 };
@@ -25,8 +27,11 @@ const DEFAULT_TARGETS = { bedtimeMinutes: 600, wakeMinutes: 1080, durationMinute
 /** numeric field state stored as string for controlled inputs */
 type NumStr = string;
 
-export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose, onSaved }) => {
+export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose, onSaved, initialDayKey }) => {
   const today = format(new Date(), 'yyyy-MM-dd');
+
+  // The night being logged/edited (morning dayKey). Editable so past days can be corrected.
+  const [dayKey, setDayKey] = useState(initialDayKey ?? today);
 
   // Sleep results
   const [bedtime, setBedtime] = useState('');     // "HH:MM" 24h
@@ -55,13 +60,18 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
 
   const [saving, setSaving] = useState(false);
 
+  // When (re)opened, sync the editable day to the requested night.
+  useEffect(() => {
+    if (isOpen) setDayKey(initialDayKey ?? today);
+  }, [isOpen, initialDayKey, today]);
+
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
     (async () => {
       try {
         const [entries, prefs] = await Promise.all([
-          fetchWellbeingEntries({ startDayKey: today, endDayKey: today }),
+          fetchWellbeingEntries({ startDayKey: dayKey, endDayKey: dayKey }),
           fetchDashboardPrefs(),
         ]);
         if (cancelled) return;
@@ -69,9 +79,10 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
         for (const e of entries) {
           if (e.timeOfDay === 'morning' && typeof e.value === 'number') byKey.set(e.metricKey, e.value);
         }
+        // Reset every field from this day's entries so switching days never leaks stale values.
         const num = (k: string) => (byKey.has(k) ? String(byKey.get(k)) : '');
-        if (byKey.has('sleepBedtimeMinutes')) setBedtime(minutesAfterNoonToTimeString(byKey.get('sleepBedtimeMinutes')!));
-        if (byKey.has('sleepWakeMinutes')) setWake(minutesAfterNoonToTimeString(byKey.get('sleepWakeMinutes')!));
+        setBedtime(byKey.has('sleepBedtimeMinutes') ? minutesAfterNoonToTimeString(byKey.get('sleepBedtimeMinutes')!) : '');
+        setWake(byKey.has('sleepWakeMinutes') ? minutesAfterNoonToTimeString(byKey.get('sleepWakeMinutes')!) : '');
         setAppleScore(num('appleSleepScore'));
         setBedtimeScore(num('appleSleepBedtimeScore'));
         setDurationScore(num('appleSleepDurationScore'));
@@ -80,8 +91,11 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
           const d = byKey.get('sleepDurationMinutes')!;
           setDurationH(String(Math.floor(d / 60)));
           setDurationM(String(d % 60));
+        } else {
+          setDurationH('');
+          setDurationM('');
         }
-        if (byKey.has('sleepQuality')) setQuality(byKey.get('sleepQuality')!);
+        setQuality(byKey.has('sleepQuality') ? byKey.get('sleepQuality')! : 2);
         setAidUsed((byKey.get('sleepAidUsed') ?? 0) >= 1);
         setPhoneInBed((byKey.get('factorPhoneInBed') ?? 0) >= 1);
         setWindDown((byKey.get('factorWindDown') ?? 0) >= 1);
@@ -98,7 +112,7 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
       }
     })();
     return () => { cancelled = true; };
-  }, [isOpen, today]);
+  }, [isOpen, dayKey]);
 
   if (!isOpen) return null;
 
@@ -147,7 +161,7 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
     const entries: Array<{ dayKey: string; timeOfDay: 'morning'; metricKey: WellbeingMetricKey; value: number; source: 'checkin' }> = [];
     const push = (metricKey: WellbeingMetricKey, value: number | null) => {
       if (value === null) return;
-      entries.push({ dayKey: today, timeOfDay: 'morning', metricKey, value, source: 'checkin' });
+      entries.push({ dayKey, timeOfDay: 'morning', metricKey, value, source: 'checkin' });
     };
 
     const bedMin = timeStringToMinutesAfterNoon(bedtime);
@@ -200,7 +214,7 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
       <div className="bg-neutral-900 border border-white/10 rounded-2xl w-full max-w-md max-h-[90dvh] shadow-2xl overflow-hidden flex flex-col">
         <div className="flex items-center justify-between p-4 border-b border-white/5 bg-neutral-800/50">
           <h2 className="text-lg font-semibold text-white flex items-center gap-2">
-            <Moon size={18} className="text-indigo-400" /> Log Sleep
+            <Moon size={18} className="text-indigo-400" /> {dayKey === today ? 'Log Sleep' : 'Edit Sleep'}
           </h2>
           <button onClick={onClose} className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full hover:bg-white/10 text-neutral-400 hover:text-white" aria-label="Close">
             <X size={20} />
@@ -208,6 +222,21 @@ export const SleepEntryForm: React.FC<SleepEntryFormProps> = ({ isOpen, onClose,
         </div>
 
         <div className="flex-1 overflow-y-auto modal-scroll p-5 space-y-6">
+          {/* Night being edited — change to log/correct a previous day */}
+          <div className="flex items-center justify-between gap-3">
+            <label htmlFor="sleep-day" className="text-xs text-neutral-400 flex items-center gap-1.5">
+              <CalendarDays size={14} className="text-indigo-400" /> Night of
+            </label>
+            <input
+              id="sleep-day"
+              type="date"
+              value={dayKey}
+              max={today}
+              onChange={(e) => { if (e.target.value) setDayKey(e.target.value); }}
+              className="bg-neutral-800 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-emerald-500 outline-none"
+            />
+          </div>
+
           {/* Apple Watch Sleep Score */}
           <section className="space-y-3">
             <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wide flex items-center gap-2">

--- a/src/components/analytics/sleep/SleepAnalytics.tsx
+++ b/src/components/analytics/sleep/SleepAnalytics.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { SleepAnalyticsSummary } from '../../../lib/analyticsClient';
 import { SleepSummaryCards } from './SleepSummaryCards';
 import { SleepDurationTrendChart } from './SleepDurationTrendChart';
@@ -6,21 +6,35 @@ import { SleepScheduleTrendChart } from './SleepScheduleTrendChart';
 import { SleepWeeklySummary } from './SleepWeeklySummary';
 import { SleepFactorsPanel } from './SleepFactorsPanel';
 import { SleepAchievements } from './SleepAchievements';
+import { SleepNightsEditor } from './SleepNightsEditor';
+import { SleepEntryForm } from '../../SleepEntryForm';
 
 interface Props {
   data: SleepAnalyticsSummary | null;
   loading: boolean;
+  /** Called after a night is saved so the dashboard can refresh. */
+  onReload?: () => void;
 }
 
-export const SleepAnalytics: React.FC<Props> = ({ data, loading }) => {
+export const SleepAnalytics: React.FC<Props> = ({ data, loading, onReload }) => {
+  const [editDayKey, setEditDayKey] = useState<string | null>(null);
+
   return (
     <div className="space-y-4">
       <SleepSummaryCards data={data} loading={loading} />
+      <SleepNightsEditor nights={data?.nights ?? []} onEditNight={setEditDayKey} />
       <SleepScheduleTrendChart data={data} loading={loading} />
       <SleepDurationTrendChart data={data} loading={loading} />
       <SleepFactorsPanel data={data} loading={loading} />
       <SleepWeeklySummary data={data} loading={loading} />
       <SleepAchievements data={data} loading={loading} />
+
+      <SleepEntryForm
+        isOpen={editDayKey !== null}
+        initialDayKey={editDayKey ?? undefined}
+        onClose={() => setEditDayKey(null)}
+        onSaved={() => onReload?.()}
+      />
     </div>
   );
 };

--- a/src/components/analytics/sleep/SleepNightsEditor.tsx
+++ b/src/components/analytics/sleep/SleepNightsEditor.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { format, parseISO } from 'date-fns';
+import { Moon, Pencil } from 'lucide-react';
+import type { SleepNight } from '../../../lib/analyticsClient';
+import { minutesAfterNoonToClock, formatDurationMinutes, quality4to10 } from './sleepFormat';
+
+interface Props {
+  nights: SleepNight[];
+  onEditNight: (dayKey: string) => void;
+}
+
+/**
+ * Browse-and-edit list of recent nights. Each row opens the SleepEntryForm
+ * pre-set to that night so previous days can be corrected. Nights without any
+ * logged data are still shown so a missed night can be filled in.
+ */
+export const SleepNightsEditor: React.FC<Props> = ({ nights, onEditNight }) => {
+  // Most recent night first.
+  const sorted = [...nights].sort((a, b) => (a.dayKey < b.dayKey ? 1 : -1));
+
+  return (
+    <section className="bg-neutral-900/60 border border-white/5 rounded-2xl p-4">
+      <h3 className="text-sm font-semibold text-white flex items-center gap-2 mb-1">
+        <Moon size={16} className="text-indigo-400" /> Edit a night
+      </h3>
+      <p className="text-xs text-neutral-400 mb-3">Tap any night to log or correct its sleep data.</p>
+
+      {sorted.length === 0 ? (
+        <p className="text-xs text-neutral-500 py-2">No nights in this range yet.</p>
+      ) : (
+        <ul className="divide-y divide-white/5 max-h-80 overflow-y-auto modal-scroll -mx-1">
+          {sorted.map((n) => {
+            const q = quality4to10(n.sleepQuality0to4);
+            return (
+              <li key={n.dayKey}>
+                <button
+                  type="button"
+                  onClick={() => onEditNight(n.dayKey)}
+                  className="w-full flex items-center justify-between gap-3 px-1 py-2.5 text-left hover:bg-white/5 rounded-lg transition-colors group"
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm text-white font-medium">
+                      {format(parseISO(n.dayKey), 'EEE, MMM d')}
+                    </div>
+                    <div className="text-xs text-neutral-400 truncate">
+                      {n.hasData ? (
+                        <>
+                          {formatDurationMinutes(n.durationMinutes)}
+                          {(n.bedtimeMinutes != null || n.wakeMinutes != null) && (
+                            <> · {minutesAfterNoonToClock(n.bedtimeMinutes)} → {minutesAfterNoonToClock(n.wakeMinutes)}</>
+                          )}
+                          {n.appleSleepScore != null && <> · score {n.appleSleepScore}</>}
+                          {q != null && <> · quality {q}/10</>}
+                        </>
+                      ) : (
+                        <span className="text-neutral-500">No data — tap to add</span>
+                      )}
+                    </div>
+                  </div>
+                  <Pencil size={15} className="shrink-0 text-neutral-500 group-hover:text-indigo-300" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/src/pages/AnalyticsPage.tsx
+++ b/src/pages/AnalyticsPage.tsx
@@ -248,7 +248,11 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({ onBack }) => {
       )}
 
       {activeTab === 'sleep' && (
-        <SleepAnalytics data={sleepData} loading={loading} />
+        <SleepAnalytics
+          data={sleepData}
+          loading={loading}
+          onReload={() => loadSleepData(getDaysFromRange(timeRange, customStart, customEnd))}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Add an editable 'Night of' date picker (capped at today) to the sleep
form and parameterize it with an optional initialDayKey prop. Fetch and
save now key off the selected day, and all fields reset on day-switch so
stale values never leak between nights. No backend changes: the wellbeing
upsert endpoint already accepts an arbitrary dayKey.