### PR TITLE
Phase 5: shared correlation engine + cross-domain insights service

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -137,11 +137,26 @@ Every feature area below is **Shipped** unless an item notes otherwise.
   - **Weight** — one daily weight reading (lbs), stored as the `weight` wellbeing metric key
   - **Caffeine** — total daily caffeine (mg) with additive drink presets, stored as the
     `caffeineMg` wellbeing metric key
-- **Insights** (formerly "Wellbeing History") — Three visualization modes:
-  - **Heatmap** — Calendar grid showing metric intensity over time
-  - **Weekly Summary** — Stacked bars showing weekly proportions
-  - **Small Multiples** — Individual heatmap per metric
-- **Time Window Selection** — View 30, 90, or 180 day periods
+- **Insights** (formerly "Wellbeing History") — A tabbed analytics page (beta-gated)
+  driven by a cross-domain insights engine (`/api/insights/*`), computed from canonical
+  truth at read time. All correlations use the same statistical approach as Sleep
+  Analytics (present/absent day-group split + Cohen's d effect size) and are always
+  framed as correlation, never causation. Six tabs:
+  - **Overview** — Discoveries & milestones, a top-correlations preview, metric averages,
+    plus the original wellbeing visualizations (Heatmap, Weekly Summary, Small Multiples)
+  - **Correlations** — Factor↔outcome relationships across habits, medications, supplements,
+    symptoms, and behavioral factors vs subjective wellbeing metrics, split into "what's
+    helping" and "what's holding you back"
+  - **Habits** — Habit performance headline stats (reused from Habit Analytics) plus
+    habit↔wellbeing correlations
+  - **Medications** — Per-medication adherence (%, taken/logged days, current streak) plus
+    medication↔wellbeing correlations
+  - **Predictions** — Simple least-squares linear-trend projections per wellbeing metric
+    (current → projected, change/week, confidence) with inline sparklines
+  - **AI Review** — Gemini BYOK narrative grounded only on the computed insights
+    (correlations, predictions, adherence); structured into summary, key findings,
+    confidence-tagged patterns, outlook, recommendations, and data limitations
+- **Time Window Selection** — View 30, 90, or 180 day periods (applies to all Insights tabs)
 
 ## Analytics
 
@@ -171,6 +186,7 @@ Every feature area below is **Shipped** unless an item notes otherwise.
 
 - **API Key Management** — Store Gemini API key in localStorage (never persisted server-side); configure via Settings
 - **Weekly AI Review** — The single, comprehensive weekly report for a selected week (this week / last week), shown on the Habits page (Grid view, below the habit grid). It both tells the story of the week and provides evidence-based analysis. Aggregates habit entries, sleep & mood from wellbeing check-ins, journal activity, and goals into observed facts, then returns a typed review with seven sections: **Week at a Glance** (a natural-language narrative recap, 1–3 paragraphs), **Facts** (objective, measurable observations), **Patterns** (each with a low/medium/high confidence), **Journal Themes** (recurring topics and emotional trends), **Wins**, **Areas for Attention**, and **Recommendations** (max 3–5) — plus honest **Data Limitations**. The prompt separates observed facts from inferred patterns from suggestions and forbids inventing data; low-data weeks are reported honestly via Data Limitations rather than fabricated patterns. (Consolidates the former standalone AI Weekly Summary.)
+- **Insights AI Review** — On-demand narrative for the Insights page (AI Review tab). Computes the user's cross-domain insights (correlations, linear-trend predictions, medication adherence, metric averages) and asks Gemini to explain them in plain language. Returns a typed review: **Summary**, **Key Findings** (objective, cited from the computed numbers), **Patterns** (each with a low/medium/high confidence), **Outlook** (caveated read of the trend predictions), **Recommendations** (max 5), and **Data Limitations**. Grounded only on already-computed facts; everything framed as correlation, never causation; the window is server-owned. Generated on demand (not persisted)
 - **AI Journal Summary** — Auto-generated weekly journal summary shown as a dismissible banner; persisted as a journal entry in history
 - **AI Report History (archive)** — Every generated Weekly AI Review and Journal Summary is saved to a dedicated `aiReports` archive (scoped per user, soft-deleted). The Weekly AI Review card (Habits page) and Journal Summary card expose a wand icon to (re)generate and a clock icon that opens a browsable history of past reports by date; any saved report can be reopened in full or deleted. Reading history requires no Gemini call.
 - **AI Journal Review** — On-demand, structured review of journal entries over a user-selected date range (Journal → AI Review tab; presets for last 7/30 days plus custom range). Grounded only in the user's own entries, it returns a typed review: Overview, Emotional Themes, Recurring Stressors, and Self-Talk Patterns (each with paraphrased evidence; themes/stressors carry a low/medium/high confidence), Wins, Reflection Questions, Suggested Next Steps, and Data Limitations. The prompt separates observed evidence from inferred themes from next steps, forbids inventing facts or long quotes, and is deliberately non-clinical (no diagnoses). Empty ranges show a helpful empty state, sparse ranges show a low-data warning, and entries suggesting crisis surface a gentle support notice rather than counseling. Generated on demand (not persisted); regenerate at any time

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -94,7 +94,13 @@ HabitFlow App
 │   ├── Today column
 │   └── Inbox column
 │
-├── Wellbeing History (via dashboard link)
+├── Insights (via Wellbeing card → 📈 Insights; beta-gated)
+│   ├── Overview tab (discoveries, top correlations, metric averages, heatmap/weekly/multiples)
+│   ├── Correlations tab (what's helping / what's holding you back)
+│   ├── Habits tab (habit stats + habit↔wellbeing correlations)
+│   ├── Medications tab (adherence + medication↔wellbeing correlations)
+│   ├── Predictions tab (linear-trend projections)
+│   └── AI Review tab (Gemini BYOK narrative)
 │
 └── Debug Entries (dev only)
 ```
@@ -122,7 +128,7 @@ HabitFlow App
 | Create Goal (Step 2) | Modal | Next from Step 1 | Link habits to goal (filtered by category if selected) | Goals, Habits | Goals List (on submit) |
 | Journal | Page | Dashboard card / `?view=journal` (`&tab=` deep-links Free/Template/History/AI Review) | Free-write, templates, history, and AI Review tabs; auto-generated AI summary banner | Journal Entries | — |
 | Tasks | Page | Dashboard card / `?view=tasks` | Today + Inbox columns; click a task title or pencil icon to rename inline | Tasks | — |
-| Wellbeing History | Page | Dashboard link | Historical wellbeing charts and trends | Wellbeing Entries | — |
+| Insights | Page | Wellbeing card → 📈 Insights (`?view=wellbeing-history`); beta-gated | Tabbed analytics: Overview, Correlations, Habits, Medications, Predictions, AI Review. Cross-domain correlations (Cohen's d), linear-trend predictions, and a Gemini AI narrative, all from canonical truth at read time | Wellbeing Entries, Habit Entries, Medication/Supplement/Symptom Logs | — |
 | Debug Entries | Page (dev) | `?view=debug-entries` | Testing entry data | Entries | — |
 | Login | Page | Default for unauthenticated users | Email + password sign in. Includes "Forgot password?" link and switch to invite redeem | — | Invite Redeem, Forgot Password |
 | Invite Redeem | Page | "Have an invite code?" link on Login | Create an account with an invite code | Users | Login |

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -464,6 +464,10 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                     <p className="mt-0.5">The single, comprehensive weekly report on the Habits page (this week or last week). It reads your real habit, sleep, mood, journal, and goal data and returns seven sections: a Week at a Glance narrative recap, Facts, Patterns (each with a confidence level), Journal Themes, Wins, Areas for Attention, and Recommendations — plus honest Data Limitations. It only uses your actual data and keeps facts, patterns, and suggestions separate — if a week is thin on data, it says so instead of inventing patterns. Use the wand icon to generate and the clock icon to browse your saved review history.</p>
                   </li>
                   <li className="text-xs text-neutral-400 pl-2">
+                    <span className="font-semibold text-neutral-300">Insights AI Review</span>
+                    <p className="mt-0.5">On the Insights page's "AI Review" tab, turn your computed correlations and trend predictions into a plain-language narrative: a Summary, Key Findings, Patterns (each with a confidence level), an Outlook on where things are heading, Recommendations, and honest Data Limitations. It reads only the numbers the app already computed, frames everything as correlation (never cause and effect), and you can regenerate anytime.</p>
+                  </li>
+                  <li className="text-xs text-neutral-400 pl-2">
                     <span className="font-semibold text-neutral-300">Variant Suggestions</span>
                     <p className="mt-0.5">AI analyzes your routine and suggests Quick/Standard/Deep variants with full step lists.</p>
                   </li>

--- a/src/lib/insightsClient.ts
+++ b/src/lib/insightsClient.ts
@@ -1,0 +1,154 @@
+/**
+ * Insights API Client
+ *
+ * Frontend client for the cross-domain Insights endpoints (/api/insights/*) and
+ * the Insights AI Review (Gemini BYOK). Response shapes mirror the server's
+ * insightsService output structurally.
+ */
+
+import { API_BASE_URL } from './persistenceConfig';
+import { getLocalTimeZone, getIdentityHeaders } from './persistenceClient';
+import { getGeminiApiKey } from './geminiClient';
+import type { InsightsAIReview } from '../shared/insightsAiReview';
+
+async function insightsRequest<T>(endpoint: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...getIdentityHeaders() },
+  });
+  if (!response.ok) {
+    throw new Error(`Insights API error: ${response.status}`);
+  }
+  return response.json();
+}
+
+function buildParams(days: number): string {
+  return `?days=${days}&timeZone=${encodeURIComponent(getLocalTimeZone())}`;
+}
+
+// ─── Types (mirror src/server/services/insightsService.ts) ───────────────────────
+
+export interface InsightsCorrelation {
+  factorId: string;
+  factorName: string;
+  factorSource: string;
+  outcomeKey: string;
+  outcomeLabel: string;
+  factorPresentMean: number;
+  factorAbsentMean: number;
+  meanDifference: number;
+  effectSize: number;
+  direction: 'improves' | 'worsens';
+  nPresent: number;
+  nAbsent: number;
+  message: string;
+}
+
+export interface MetricAverage {
+  metricKey: string;
+  label: string;
+  average: number;
+  sampleSize: number;
+  higherIsBetter: boolean;
+}
+
+export interface Discovery {
+  id: string;
+  type: 'positive' | 'negative' | 'milestone' | 'info';
+  title: string;
+  message: string;
+}
+
+export interface InsightsOverview {
+  rangeDays: number;
+  daysWithCheckins: number;
+  metricAverages: MetricAverage[];
+  topCorrelations: InsightsCorrelation[];
+  discoveries: Discovery[];
+}
+
+export interface MetricPredictionPoint {
+  dayKey: string;
+  value: number;
+}
+
+export interface MetricPrediction {
+  metricKey: string;
+  label: string;
+  higherIsBetter: boolean;
+  sampleSize: number;
+  currentValue: number | null;
+  slopePerWeek: number | null;
+  predictedValue: number | null;
+  horizonDays: number;
+  direction: 'improving' | 'declining' | 'stable' | null;
+  confidence: 'low' | 'medium' | 'high';
+  fitQuality: number | null;
+  trend: MetricPredictionPoint[];
+}
+
+export interface MedicationAdherence {
+  medicationId: string;
+  name: string;
+  dosage: string | null;
+  takenDays: number;
+  loggedDays: number;
+  adherencePercent: number | null;
+  currentTakenStreak: number;
+}
+
+export interface MedicationInsights {
+  rangeDays: number;
+  adherence: MedicationAdherence[];
+  correlations: InsightsCorrelation[];
+}
+
+// ─── API functions ───────────────────────────────────────────────────────────
+
+export async function fetchInsightsOverview(days = 90): Promise<InsightsOverview> {
+  return insightsRequest(`/insights/overview${buildParams(days)}`);
+}
+
+export async function fetchInsightsCorrelations(
+  days = 90,
+): Promise<{ correlations: InsightsCorrelation[]; rangeDays: number }> {
+  return insightsRequest(`/insights/correlations${buildParams(days)}`);
+}
+
+export async function fetchInsightsHabits(
+  days = 90,
+): Promise<{ correlations: InsightsCorrelation[]; rangeDays: number }> {
+  return insightsRequest(`/insights/habits${buildParams(days)}`);
+}
+
+export async function fetchInsightsMedications(days = 90): Promise<MedicationInsights> {
+  return insightsRequest(`/insights/medications${buildParams(days)}`);
+}
+
+export async function fetchInsightsPredictions(
+  days = 90,
+): Promise<{ predictions: MetricPrediction[]; rangeDays: number }> {
+  return insightsRequest(`/insights/predictions${buildParams(days)}`);
+}
+
+/**
+ * Generate a grounded, forward-looking Insights AI Review (Gemini BYOK).
+ */
+export async function fetchInsightsAIReview(days = 90): Promise<{ review: InsightsAIReview }> {
+  const geminiApiKey = getGeminiApiKey();
+  if (!geminiApiKey) {
+    throw new Error('No Gemini API key configured. Add your key in Settings.');
+  }
+  const timeZone = getLocalTimeZone();
+  const response = await fetch(`${API_BASE_URL}/ai/insights-review`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...getIdentityHeaders() },
+    body: JSON.stringify({ geminiApiKey, days, timeZone }),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData?.error?.message || `Failed to generate insights review (${response.status})`);
+  }
+  return response.json();
+}

--- a/src/pages/WellbeingHistoryPage.tsx
+++ b/src/pages/WellbeingHistoryPage.tsx
@@ -6,6 +6,7 @@ import { CorrelationsTab } from './insights/CorrelationsTab';
 import { PredictionsTab } from './insights/PredictionsTab';
 import { HabitInsightsTab } from './insights/HabitInsightsTab';
 import { MedicationInsightsTab } from './insights/MedicationInsightsTab';
+import { AIReviewTab } from './insights/AIReviewTab';
 
 const BETA_EMAIL = 'tj.galloway1@gmail.com';
 
@@ -24,12 +25,6 @@ const TABS: Array<{ id: InsightsTab; label: string; icon: React.ComponentType<{ 
   { id: 'predictions', label: 'Predictions', icon: TrendingUp },
   { id: 'ai-review', label: 'AI Review', icon: Sparkles },
 ];
-
-const ComingSoon: React.FC<{ label: string }> = ({ label }) => (
-  <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-8 text-center text-sm text-neutral-500">
-    {label} tab coming up.
-  </div>
-);
 
 export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
   const { user } = useAuth();
@@ -109,7 +104,7 @@ export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
         ) : tab === 'predictions' ? (
           <PredictionsTab days={windowDays} />
         ) : (
-          <ComingSoon label="AI Review" />
+          <AIReviewTab days={windowDays} />
         )}
       </div>
     </div>

--- a/src/pages/WellbeingHistoryPage.tsx
+++ b/src/pages/WellbeingHistoryPage.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Activity, Battery, Target, Brain, Wind, Grid3X3, CalendarRange, BarChart3 } from 'lucide-react';
-import type { WellbeingMetricKey } from '../models/persistenceTypes';
-import { useWellbeingEntriesRange } from '../hooks/useWellbeingEntriesRange';
+import React, { useEffect, useState } from 'react';
+import { ArrowLeft, LayoutDashboard, GitCompareArrows, Activity, Pill, TrendingUp, Sparkles } from 'lucide-react';
 import { useAuth } from '../store/AuthContext';
+import { OverviewTab } from './insights/OverviewTab';
 
 const BETA_EMAIL = 'tj.galloway1@gmail.com';
 
@@ -10,190 +9,36 @@ type Props = {
   onBack: () => void;
 };
 
-type SelectableMetric = Extract<WellbeingMetricKey, 'anxiety' | 'lowMood' | 'calm' | 'energy' | 'stress'>;
-type HistoryView = 'heatmap' | 'weekly' | 'multiples';
+export type InsightsTab = 'overview' | 'correlations' | 'habits' | 'medications' | 'predictions' | 'ai-review';
+export type InsightsWindow = 30 | 90 | 180;
 
-const METRICS: Array<{ key: SelectableMetric; label: string; icon: React.ReactNode }> = [
-  { key: 'anxiety', label: 'Anxiety', icon: <Activity size={14} className="text-purple-400" /> },
-  { key: 'lowMood', label: 'Low Mood', icon: <Brain size={14} className="text-blue-400" /> },
-  { key: 'calm', label: 'Calm', icon: <Wind size={14} className="text-emerald-400" /> },
-  { key: 'energy', label: 'Energy', icon: <Battery size={14} className="text-emerald-400" /> },
-  { key: 'stress', label: 'Stress', icon: <Target size={14} className="text-orange-400" /> },
+const TABS: Array<{ id: InsightsTab; label: string; icon: React.ComponentType<{ size?: number; className?: string }> }> = [
+  { id: 'overview', label: 'Overview', icon: LayoutDashboard },
+  { id: 'correlations', label: 'Correlations', icon: GitCompareArrows },
+  { id: 'habits', label: 'Habits', icon: Activity },
+  { id: 'medications', label: 'Medications', icon: Pill },
+  { id: 'predictions', label: 'Predictions', icon: TrendingUp },
+  { id: 'ai-review', label: 'AI Review', icon: Sparkles },
 ];
 
-function clampInt(n: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, Math.round(n)));
-}
-
-function intensityFromValue(metric: SelectableMetric, value: number): number {
-  // Heatmap scale is always 0..4 intensity.
-  // Map legacy 1..5 metrics down to 0..4 by subtracting 1.
-  if (metric === 'anxiety' || metric === 'energy') {
-    return clampInt(value - 1, 0, 4);
-  }
-  // New subjective superset is already 0..4.
-  return clampInt(value, 0, 4);
-}
-
-function heatClass(intensity: number | null): string {
-  // Missing -> neutral gray
-  if (intensity === null) return 'bg-neutral-800/60 border-white/5';
-  // 0..4 -> increasing intensity
-  switch (intensity) {
-    case 0:
-      return 'bg-sky-900/20 border-white/5';
-    case 1:
-      return 'bg-sky-800/30 border-sky-500/10';
-    case 2:
-      return 'bg-sky-700/40 border-sky-500/15';
-    case 3:
-      return 'bg-sky-600/55 border-sky-400/20';
-    default:
-      return 'bg-sky-500/70 border-sky-300/25';
-  }
-}
-
-function formatWeekLabel(weekStartDayKey: string): string {
-  // Render compact label like "Jan 06"
-  const d = new Date(`${weekStartDayKey}T00:00:00.000Z`);
-  return d.toLocaleDateString(undefined, { month: 'short', day: '2-digit' });
-}
+const ComingSoon: React.FC<{ label: string }> = ({ label }) => (
+  <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-8 text-center text-sm text-neutral-500">
+    {label} tab coming up.
+  </div>
+);
 
 export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
   const { user } = useAuth();
   const isAuthorized = user?.email?.toLowerCase() === BETA_EMAIL;
 
-  const [windowDays, setWindowDays] = useState<30 | 90 | 180>(90);
-  const [view, setView] = useState<HistoryView>('heatmap');
-  const [metric, setMetric] = useState<SelectableMetric>('anxiety');
-  const [hover, setHover] = useState<{ dayKey: string; value: number | null } | null>(null);
-
-  const { loading, error, getDailyAverage, startDayKey, endDayKey } = useWellbeingEntriesRange(windowDays);
+  const [windowDays, setWindowDays] = useState<InsightsWindow>(90);
+  const [tab, setTab] = useState<InsightsTab>('overview');
 
   useEffect(() => {
-    if (!isAuthorized) {
-      onBack();
-    }
+    if (!isAuthorized) onBack();
   }, [isAuthorized, onBack]);
 
   if (!isAuthorized) return null;
-
-  const cellsForMetric = useMemo(() => {
-    // Calendar-style grid: 7 columns (Sun..Sat), rows are weeks.
-    // We align the start to the previous Sunday to make a clean grid.
-    const start = new Date(`${startDayKey}T00:00:00.000Z`);
-    const end = new Date(`${endDayKey}T00:00:00.000Z`);
-
-    const startDow = start.getUTCDay(); // 0=Sun
-    const gridStart = new Date(start);
-    gridStart.setUTCDate(gridStart.getUTCDate() - startDow);
-
-    const days: Array<{ dayKey: string; value: number | null; intensity: number | null }> = [];
-    for (let d = new Date(gridStart); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
-      const dayKey = d.toISOString().slice(0, 10);
-      // only compute values inside requested window (start..end); outside is null/neutral
-      const inRange = d >= start && d <= end;
-      const raw = inRange ? getDailyAverage(dayKey, metric as any) : null;
-      const value = typeof raw === 'number' ? raw : null;
-      const intensity = value === null ? null : intensityFromValue(metric, value);
-      days.push({ dayKey, value, intensity });
-    }
-    return days;
-  }, [startDayKey, endDayKey, getDailyAverage, metric]);
-
-  const weeksForMetric = useMemo(() => {
-    const rows: Array<Array<{ dayKey: string; value: number | null; intensity: number | null }>> = [];
-    for (let i = 0; i < cellsForMetric.length; i += 7) {
-      rows.push(cellsForMetric.slice(i, i + 7));
-    }
-    return rows;
-  }, [cellsForMetric]);
-
-  const weeklySummary = useMemo(() => {
-    // Each week is a stacked band of calm/anxiety/lowMood (relative proportions).
-    // Uses 0..4 intensities (anxiety mapped down from 1..5).
-    const start = new Date(`${startDayKey}T00:00:00.000Z`);
-    const end = new Date(`${endDayKey}T00:00:00.000Z`);
-
-    // Align to Monday for week bands (Mon-based)
-    const startDow = start.getUTCDay(); // Sun=0
-    const diffToMonday = (startDow + 6) % 7;
-    const weekStart = new Date(start);
-    weekStart.setUTCDate(weekStart.getUTCDate() - diffToMonday);
-
-    const rows: Array<{
-      weekStartDayKey: string;
-      calm: number;
-      anxiety: number;
-      lowMood: number;
-      total: number;
-      calmPct: number;
-      anxietyPct: number;
-      lowMoodPct: number;
-    }> = [];
-
-    for (let w = new Date(weekStart); w <= end; w.setUTCDate(w.getUTCDate() + 7)) {
-      const weekStartDayKey = w.toISOString().slice(0, 10);
-      let calmSum = 0;
-      let anxietySum = 0;
-      let lowMoodSum = 0;
-
-      for (let i = 0; i < 7; i++) {
-        const d = new Date(w);
-        d.setUTCDate(w.getUTCDate() + i);
-        if (d < start || d > end) continue;
-        const dayKey = d.toISOString().slice(0, 10);
-
-        const calmRaw = getDailyAverage(dayKey, 'calm' as any);
-        const anxietyRaw = getDailyAverage(dayKey, 'anxiety' as any);
-        const lowMoodRaw = getDailyAverage(dayKey, 'lowMood' as any);
-
-        if (typeof calmRaw === 'number') calmSum += intensityFromValue('calm', calmRaw);
-        if (typeof anxietyRaw === 'number') anxietySum += intensityFromValue('anxiety', anxietyRaw);
-        if (typeof lowMoodRaw === 'number') lowMoodSum += intensityFromValue('lowMood', lowMoodRaw);
-      }
-
-      const total = calmSum + anxietySum + lowMoodSum;
-      rows.push({
-        weekStartDayKey,
-        calm: calmSum,
-        anxiety: anxietySum,
-        lowMood: lowMoodSum,
-        total,
-        calmPct: total === 0 ? 0 : calmSum / total,
-        anxietyPct: total === 0 ? 0 : anxietySum / total,
-        lowMoodPct: total === 0 ? 0 : lowMoodSum / total,
-      });
-    }
-
-    return rows.slice(-Math.ceil(windowDays / 7) - 1);
-  }, [startDayKey, endDayKey, getDailyAverage, windowDays]);
-
-  const miniHeatmaps = useMemo(() => {
-    // One mini heatmap per metric (no combined lines).
-    return METRICS.map((m) => {
-      const start = new Date(`${startDayKey}T00:00:00.000Z`);
-      const end = new Date(`${endDayKey}T00:00:00.000Z`);
-      const startDow = start.getUTCDay();
-      const gridStart = new Date(start);
-      gridStart.setUTCDate(gridStart.getUTCDate() - startDow);
-
-      const days: Array<{ dayKey: string; value: number | null; intensity: number | null }> = [];
-      for (let d = new Date(gridStart); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
-        const dayKey = d.toISOString().slice(0, 10);
-        const inRange = d >= start && d <= end;
-        const raw = inRange ? getDailyAverage(dayKey, m.key as any) : null;
-        const value = typeof raw === 'number' ? raw : null;
-        const intensity = value === null ? null : intensityFromValue(m.key, value);
-        days.push({ dayKey, value, intensity });
-      }
-
-      const weeks: Array<typeof days> = [];
-      for (let i = 0; i < days.length; i += 7) weeks.push(days.slice(i, i + 7));
-
-      return { metric: m, weeks };
-    });
-  }, [startDayKey, endDayKey, getDailyAverage]);
 
   return (
     <div className="space-y-6 pb-20">
@@ -216,203 +61,53 @@ export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
               }`}
             >
               {d}d
-              {windowDays === d && (
-                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />
-              )}
+              {windowDays === d && <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />}
             </button>
           ))}
         </div>
       </div>
 
       <div className="bg-neutral-900/50 rounded-2xl border border-white/5 p-6 backdrop-blur-sm">
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-4">
-          <div>
-            <h2 className="text-xl font-bold text-white">Insights</h2>
-            <div className="text-xs text-neutral-500 mt-1">
-              Universal view (persona-agnostic). Powered by <code className="text-neutral-400">/api/wellbeingEntries</code>.
-            </div>
-          </div>
-
-          <div className="flex flex-wrap gap-2 items-center">
-            <div className="flex gap-4 border-b border-white/5 mr-2">
-              {([
-                { id: 'heatmap' as const, label: 'Heat Map', icon: Grid3X3 },
-                { id: 'weekly' as const, label: 'Weekly Summary', icon: CalendarRange },
-                { id: 'multiples' as const, label: 'Small Multiples', icon: BarChart3 },
-              ]).map(({ id, label, icon: Icon }) => (
-                <button
-                  key={id}
-                  onClick={() => setView(id)}
-                  className={`pb-3 px-2 text-xs font-semibold transition-colors relative ${
-                    view === id ? 'text-emerald-400' : 'text-white/40 hover:text-white/60'
-                  }`}
-                >
-                  <div className="flex items-center gap-1.5">
-                    <Icon size={14} />
-                    {label}
-                  </div>
-                  {view === id && (
-                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />
-                  )}
-                </button>
-              ))}
-            </div>
-
-            {view === 'heatmap' && (
-              <>
-                <div className="text-[11px] text-neutral-500 font-semibold mr-2">Metric:</div>
-                {METRICS.map((m) => {
-                  const active = metric === m.key;
-                  return (
-                    <button
-                      key={m.key}
-                      onClick={() => setMetric(m.key)}
-                      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors ${
-                        active ? 'bg-white/10 text-white border-white/20' : 'bg-neutral-800/60 text-neutral-300 border-white/10 hover:text-white'
-                      }`}
-                    >
-                      {m.icon}
-                      {m.label}
-                    </button>
-                  );
-                })}
-              </>
-            )}
+        <div className="mb-5">
+          <h2 className="text-xl font-bold text-white">Insights</h2>
+          <div className="text-xs text-neutral-500 mt-1">
+            Patterns, correlations, and predictions from your check-ins, habits, and health tracking.
           </div>
         </div>
 
-        {loading ? (
-          <div className="text-sm text-neutral-400">Loading…</div>
-        ) : error ? (
-          <div className="text-sm text-red-300">{error}</div>
+        {/* Tab bar */}
+        <div className="flex gap-1 overflow-x-auto border-b border-white/5 mb-6 -mx-1 px-1">
+          {TABS.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              onClick={() => setTab(id)}
+              className={`shrink-0 pb-3 px-3 text-xs font-semibold transition-colors relative ${
+                tab === id ? 'text-emerald-400' : 'text-white/40 hover:text-white/60'
+              }`}
+            >
+              <div className="flex items-center gap-1.5">
+                <Icon size={14} />
+                {label}
+              </div>
+              {tab === id && <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />}
+            </button>
+          ))}
+        </div>
+
+        {tab === 'overview' ? (
+          <OverviewTab days={windowDays} />
+        ) : tab === 'correlations' ? (
+          <ComingSoon label="Correlations" />
+        ) : tab === 'habits' ? (
+          <ComingSoon label="Habits" />
+        ) : tab === 'medications' ? (
+          <ComingSoon label="Medications" />
+        ) : tab === 'predictions' ? (
+          <ComingSoon label="Predictions" />
         ) : (
-          <>
-            {view === 'heatmap' ? (
-              <div>
-                <div className="flex items-center justify-between mb-3">
-                  <div className="text-xs text-neutral-500">Color shows intensity (0–4). Missing days are neutral.</div>
-                  {hover ? (
-                    <div className="text-xs text-neutral-300">
-                      <span className="text-neutral-500 mr-2">{hover.dayKey}</span>
-                      <span className="font-semibold text-white">{hover.value === null ? '—' : hover.value}</span>
-                    </div>
-                  ) : (
-                    <div className="text-xs text-neutral-500">Hover a day to see details</div>
-                  )}
-                </div>
-
-                <div className="inline-flex gap-3">
-                  {/* Day labels */}
-                  <div className="flex flex-col gap-1">
-                    <div className="h-5" />
-                    {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, idx) => (
-                      <div key={`${d}-${idx}`} className="h-4 text-[10px] text-neutral-600 flex items-center">
-                        {d}
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Grid */}
-                  <div className="flex flex-col gap-1">
-                    <div className="h-5" />
-                    {/* weeks as columns (horizontal), days stacked vertically */}
-                    <div className="flex gap-1 overflow-x-auto">
-                      {weeksForMetric.map((week, i) => (
-                        <div key={week[0]?.dayKey ?? i} className="flex flex-col gap-1">
-                          {week.map((cell) => (
-                            <button
-                              key={cell.dayKey}
-                              type="button"
-                              className={`w-4 h-4 rounded border ${heatClass(cell.intensity)} hover:border-white/20 transition-colors`}
-                              onMouseEnter={() => setHover({ dayKey: cell.dayKey, value: cell.value })}
-                              onMouseLeave={() => setHover(null)}
-                              title={`${cell.dayKey}: ${cell.value === null ? '—' : cell.value}`}
-                            />
-                          ))}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ) : view === 'weekly' ? (
-              <div className="space-y-3">
-                <div className="text-xs text-neutral-500">
-                  Each week is a simple mix of <span className="text-emerald-300">Calm</span>,{' '}
-                  <span className="text-purple-300">Anxiety</span>, and <span className="text-sky-300">Low Mood</span>.
-                </div>
-                <div className="space-y-2">
-                  {weeklySummary.map((w) => {
-                    const calmW = `${Math.round(w.calmPct * 100)}%`;
-                    const anxietyW = `${Math.round(w.anxietyPct * 100)}%`;
-                    const lowMoodW = `${Math.round(w.lowMoodPct * 100)}%`;
-                    const title = `${w.weekStartDayKey}: Calm ${calmW}, Anxiety ${anxietyW}, Low Mood ${lowMoodW}`;
-                    return (
-                      <div key={w.weekStartDayKey} className="flex items-center gap-3">
-                        <div className="w-14 text-[11px] text-neutral-500">{formatWeekLabel(w.weekStartDayKey)}</div>
-                        <div className="flex-1 h-3 rounded-full overflow-hidden border border-white/5 bg-neutral-800/60" title={title}>
-                          <div className="h-full flex">
-                            <div className="h-full bg-emerald-400/70" style={{ width: `${w.calmPct * 100}%` }} />
-                            <div className="h-full bg-purple-400/70" style={{ width: `${w.anxietyPct * 100}%` }} />
-                            <div className="h-full bg-sky-400/70" style={{ width: `${w.lowMoodPct * 100}%` }} />
-                          </div>
-                        </div>
-                        <div className="hidden md:flex items-center gap-3 text-[11px] text-neutral-500">
-                          <span className="inline-flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-emerald-400/70" /> Calm</span>
-                          <span className="inline-flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-purple-400/70" /> Anxiety</span>
-                          <span className="inline-flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-sky-400/70" /> Low Mood</span>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {miniHeatmaps.map(({ metric: m, weeks }) => (
-                  <div key={m.key} className="p-4 rounded-xl bg-neutral-900/40 border border-white/5">
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="inline-flex items-center gap-2 text-sm font-semibold text-white">
-                        {m.icon}
-                        {m.label}
-                      </div>
-                      <div className="text-[11px] text-neutral-500">{windowDays}d</div>
-                    </div>
-                    <div className="flex gap-2">
-                      <div className="flex flex-col gap-1 pt-5">
-                        {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, idx) => (
-                          <div key={`${d}-${idx}`} className="h-3 text-[9px] text-neutral-700 flex items-center">
-                            {d}
-                          </div>
-                        ))}
-                      </div>
-                      <div className="flex flex-col gap-1">
-                        <div className="h-5" />
-                        {/* weeks as columns (horizontal), days stacked vertically */}
-                        <div className="flex gap-1 overflow-x-auto">
-                          {weeks.map((week, i) => (
-                            <div key={week[0]?.dayKey ?? i} className="flex flex-col gap-1">
-                              {week.map((cell) => (
-                                <div
-                                  key={cell.dayKey}
-                                  className={`w-3 h-3 rounded border ${heatClass(cell.intensity)} border-white/5`}
-                                  title={`${cell.dayKey}: ${cell.value === null ? '—' : cell.value}`}
-                                />
-                              ))}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
+          <ComingSoon label="AI Review" />
         )}
       </div>
     </div>
   );
 };
-
-

--- a/src/pages/WellbeingHistoryPage.tsx
+++ b/src/pages/WellbeingHistoryPage.tsx
@@ -4,6 +4,8 @@ import { useAuth } from '../store/AuthContext';
 import { OverviewTab } from './insights/OverviewTab';
 import { CorrelationsTab } from './insights/CorrelationsTab';
 import { PredictionsTab } from './insights/PredictionsTab';
+import { HabitInsightsTab } from './insights/HabitInsightsTab';
+import { MedicationInsightsTab } from './insights/MedicationInsightsTab';
 
 const BETA_EMAIL = 'tj.galloway1@gmail.com';
 
@@ -101,9 +103,9 @@ export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
         ) : tab === 'correlations' ? (
           <CorrelationsTab days={windowDays} />
         ) : tab === 'habits' ? (
-          <ComingSoon label="Habits" />
+          <HabitInsightsTab days={windowDays} />
         ) : tab === 'medications' ? (
-          <ComingSoon label="Medications" />
+          <MedicationInsightsTab days={windowDays} />
         ) : tab === 'predictions' ? (
           <PredictionsTab days={windowDays} />
         ) : (

--- a/src/pages/WellbeingHistoryPage.tsx
+++ b/src/pages/WellbeingHistoryPage.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { ArrowLeft, LayoutDashboard, GitCompareArrows, Activity, Pill, TrendingUp, Sparkles } from 'lucide-react';
 import { useAuth } from '../store/AuthContext';
 import { OverviewTab } from './insights/OverviewTab';
+import { CorrelationsTab } from './insights/CorrelationsTab';
+import { PredictionsTab } from './insights/PredictionsTab';
 
 const BETA_EMAIL = 'tj.galloway1@gmail.com';
 
@@ -97,13 +99,13 @@ export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
         {tab === 'overview' ? (
           <OverviewTab days={windowDays} />
         ) : tab === 'correlations' ? (
-          <ComingSoon label="Correlations" />
+          <CorrelationsTab days={windowDays} />
         ) : tab === 'habits' ? (
           <ComingSoon label="Habits" />
         ) : tab === 'medications' ? (
           <ComingSoon label="Medications" />
         ) : tab === 'predictions' ? (
-          <ComingSoon label="Predictions" />
+          <PredictionsTab days={windowDays} />
         ) : (
           <ComingSoon label="AI Review" />
         )}

--- a/src/pages/insights/AIReviewTab.tsx
+++ b/src/pages/insights/AIReviewTab.tsx
@@ -1,0 +1,201 @@
+import React, { useState } from 'react';
+import { Sparkles, Loader2, RefreshCw, LineChart, Lightbulb, Info, ClipboardList, Telescope } from 'lucide-react';
+import { hasGeminiApiKey } from '../../lib/geminiClient';
+import { fetchInsightsAIReview } from '../../lib/insightsClient';
+import type { InsightsAIReview } from '../../shared/insightsAiReview';
+import type { ReviewConfidence } from '../../shared/weeklyAiReview';
+
+const CONFIDENCE_STYLES: Record<ReviewConfidence, string> = {
+  high: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  medium: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  low: 'bg-neutral-500/15 text-neutral-300 border-neutral-500/30',
+};
+
+const Section: React.FC<{ icon: React.ReactNode; title: string; children: React.ReactNode }> = ({ icon, title, children }) => (
+  <div>
+    <div className="flex items-center gap-2 mb-2">
+      {icon}
+      <h4 className="text-sm font-semibold text-white">{title}</h4>
+    </div>
+    {children}
+  </div>
+);
+
+const Bullets: React.FC<{ items: string[]; dot?: string }> = ({ items, dot = 'text-neutral-500' }) => (
+  <ul className="space-y-1.5">
+    {items.map((item, i) => (
+      <li key={i} className="flex gap-2 text-sm text-neutral-300">
+        <span className={`${dot} mt-0.5`}>•</span>
+        <span>{item}</span>
+      </li>
+    ))}
+  </ul>
+);
+
+const ReviewBody: React.FC<{ review: InsightsAIReview }> = ({ review }) => (
+  <div className="space-y-5">
+    <p className="text-[11px] text-neutral-500">
+      {review.rangeStart} to {review.rangeEnd} · {review.rangeDays}-day window
+    </p>
+
+    {review.summary && (
+      <Section icon={<Sparkles size={15} className="text-indigo-400" />} title="Summary">
+        <div className="space-y-2">
+          {review.summary
+            .split('\n')
+            .map((p) => p.trim())
+            .filter((p) => p.length > 0)
+            .map((p, i) => (
+              <p key={i} className="text-sm text-neutral-200 leading-relaxed">
+                {p}
+              </p>
+            ))}
+        </div>
+      </Section>
+    )}
+
+    {review.keyFindings.length > 0 && (
+      <Section icon={<ClipboardList size={15} className="text-neutral-300" />} title="Key Findings">
+        <Bullets items={review.keyFindings} />
+      </Section>
+    )}
+
+    {review.patterns.length > 0 && (
+      <Section icon={<LineChart size={15} className="text-sky-400" />} title="Patterns">
+        <div className="space-y-2.5">
+          {review.patterns.map((p, i) => (
+            <div key={i} className="rounded-lg bg-white/5 border border-white/10 p-3">
+              <div className="flex items-start justify-between gap-2 mb-1">
+                <span className="text-sm font-medium text-white">{p.title}</span>
+                <span className={`shrink-0 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border ${CONFIDENCE_STYLES[p.confidence]}`}>
+                  {p.confidence}
+                </span>
+              </div>
+              <p className="text-xs text-neutral-400 leading-relaxed">{p.evidence}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+    )}
+
+    {review.outlook.length > 0 && (
+      <Section icon={<Telescope size={15} className="text-purple-400" />} title="Outlook">
+        <Bullets items={review.outlook} dot="text-purple-400" />
+      </Section>
+    )}
+
+    {review.recommendations.length > 0 && (
+      <Section icon={<Lightbulb size={15} className="text-indigo-400" />} title="Recommendations">
+        <div className="space-y-2.5">
+          {review.recommendations.map((r, i) => (
+            <div key={i} className="rounded-lg bg-white/5 border border-white/10 p-3">
+              <p className="text-sm font-medium text-white mb-0.5">{r.title}</p>
+              {r.reason && <p className="text-xs text-neutral-400 leading-relaxed">{r.reason}</p>}
+              {r.suggestedAction && <p className="text-xs text-indigo-300 mt-1 leading-relaxed">→ {r.suggestedAction}</p>}
+            </div>
+          ))}
+        </div>
+      </Section>
+    )}
+
+    {review.dataLimitations.length > 0 && (
+      <Section icon={<Info size={15} className="text-neutral-400" />} title="Data Limitations">
+        <ul className="space-y-1.5">
+          {review.dataLimitations.map((d, i) => (
+            <li key={i} className="flex gap-2 text-xs text-neutral-400">
+              <span className="text-neutral-500 mt-0.5">•</span>
+              <span>{d}</span>
+            </li>
+          ))}
+        </ul>
+      </Section>
+    )}
+  </div>
+);
+
+export const AIReviewTab: React.FC<{ days: number }> = ({ days }) => {
+  const [review, setReview] = useState<InsightsAIReview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hasKey = hasGeminiApiKey();
+
+  const generate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchInsightsAIReview(days);
+      setReview(result.review);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate insights review');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!hasKey) {
+    return (
+      <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-6">
+        <div className="flex items-center gap-2 mb-2">
+          <Sparkles size={18} className="text-indigo-400" />
+          <h3 className="text-base font-semibold text-white">AI Review</h3>
+        </div>
+        <p className="text-sm text-neutral-400">
+          Add your Gemini API key in Settings to generate a grounded, plain-language review of your insights.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {!review && !loading && !error && (
+        <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-6">
+          <p className="text-sm text-neutral-400 mb-4">
+            Turn your computed correlations and trend predictions into a clear, forward-looking narrative — grounded in
+            your data, framed as correlation (never causation), with small, realistic suggestions.
+          </p>
+          <button
+            onClick={generate}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-600/80 text-white hover:bg-indigo-600 text-sm font-medium transition-colors"
+          >
+            <Sparkles size={14} />
+            Generate AI Review
+          </button>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center gap-3 py-4">
+          <Loader2 size={18} className="text-indigo-400 animate-spin" />
+          <span className="text-sm text-neutral-400">Analyzing your insights…</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="space-y-3">
+          <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-3">
+            <p className="text-sm text-red-300">{error}</p>
+          </div>
+          <button onClick={generate} className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
+            Try again
+          </button>
+        </div>
+      )}
+
+      {review && (
+        <>
+          <ReviewBody review={review} />
+          <div className="pt-2 border-t border-white/5">
+            <button
+              onClick={generate}
+              className="flex items-center gap-1.5 text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              <RefreshCw size={12} />
+              Regenerate
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/pages/insights/CorrelationsTab.tsx
+++ b/src/pages/insights/CorrelationsTab.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+import { fetchInsightsCorrelations, type InsightsCorrelation } from '../../lib/insightsClient';
+import { CorrelationCard, CorrelationCaveat, SectionTitle, TabLoading, TabError, TabEmpty } from './insightsShared';
+
+export const CorrelationsTab: React.FC<{ days: number }> = ({ days }) => {
+  const [correlations, setCorrelations] = useState<InsightsCorrelation[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchInsightsCorrelations(days)
+      .then((data) => {
+        if (!cancelled) setCorrelations(data.correlations);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load correlations');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  if (loading) return <TabLoading label="Computing correlations…" />;
+  if (error) return <TabError message={error} />;
+  if (!correlations || correlations.length === 0) {
+    return (
+      <TabEmpty
+        title="No correlations yet"
+        message="Once you've logged enough check-ins alongside habits, medications, or health factors, the strongest relationships will appear here."
+      />
+    );
+  }
+
+  const improving = correlations.filter((c) => c.direction === 'improves');
+  const worsening = correlations.filter((c) => c.direction === 'worsens');
+
+  return (
+    <div className="space-y-8">
+      <CorrelationCaveat />
+
+      {improving.length > 0 && (
+        <section>
+          <SectionTitle icon={<TrendingUp size={15} className="text-emerald-400" />} hint="Factors linked to better outcomes.">
+            What's helping
+          </SectionTitle>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {improving.map((c) => (
+              <CorrelationCard key={`${c.factorId}-${c.outcomeKey}`} correlation={c} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {worsening.length > 0 && (
+        <section>
+          <SectionTitle icon={<TrendingDown size={15} className="text-rose-400" />} hint="Factors linked to worse outcomes.">
+            What's holding you back
+          </SectionTitle>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {worsening.map((c) => (
+              <CorrelationCard key={`${c.factorId}-${c.outcomeKey}`} correlation={c} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+};

--- a/src/pages/insights/HabitInsightsTab.tsx
+++ b/src/pages/insights/HabitInsightsTab.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Flame, Target, CheckCircle2, Trophy } from 'lucide-react';
+import { fetchInsightsHabits, type InsightsCorrelation } from '../../lib/insightsClient';
+import { fetchHabitSummary, type HabitAnalyticsSummary } from '../../lib/analyticsClient';
+import { CorrelationCard, CorrelationCaveat, SectionTitle, TabLoading, TabError, TabEmpty } from './insightsShared';
+
+const StatCard: React.FC<{ icon: React.ReactNode; label: string; value: string | number }> = ({ icon, label, value }) => (
+  <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-3">
+    <div className="flex items-center gap-1.5 text-[11px] text-neutral-500">
+      {icon}
+      {label}
+    </div>
+    <div className="text-xl font-bold text-white mt-1">{value}</div>
+  </div>
+);
+
+export const HabitInsightsTab: React.FC<{ days: number }> = ({ days }) => {
+  const [summary, setSummary] = useState<HabitAnalyticsSummary | null>(null);
+  const [correlations, setCorrelations] = useState<InsightsCorrelation[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    Promise.all([fetchHabitSummary(days), fetchInsightsHabits(days)])
+      .then(([s, h]) => {
+        if (!cancelled) {
+          setSummary(s);
+          setCorrelations(h.correlations);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load habit insights');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  if (loading) return <TabLoading label="Analyzing habits…" />;
+  if (error) return <TabError message={error} />;
+
+  return (
+    <div className="space-y-8">
+      {summary && (
+        <section>
+          <SectionTitle hint="Your habit performance over this window.">Habit performance</SectionTitle>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <StatCard icon={<Target size={12} />} label="Consistency" value={`${summary.consistencyScore}%`} />
+            <StatCard icon={<CheckCircle2 size={12} />} label="Completion" value={`${summary.completionRate}%`} />
+            <StatCard icon={<Flame size={12} />} label="Current streak" value={`${summary.currentStreak}d`} />
+            <StatCard icon={<Trophy size={12} />} label="Longest streak" value={`${summary.longestStreak}d`} />
+          </div>
+        </section>
+      )}
+
+      <section>
+        <SectionTitle hint="How your habits relate to how you feel.">Habits ↔ wellbeing</SectionTitle>
+        {correlations && correlations.length > 0 ? (
+          <div className="space-y-4">
+            <CorrelationCaveat />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {correlations.map((c) => (
+                <CorrelationCard key={`${c.factorId}-${c.outcomeKey}`} correlation={c} />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <TabEmpty
+            title="No habit↔wellbeing links yet"
+            message="Keep logging habits alongside your check-ins and the relationships will show up here."
+          />
+        )}
+      </section>
+    </div>
+  );
+};

--- a/src/pages/insights/MedicationInsightsTab.tsx
+++ b/src/pages/insights/MedicationInsightsTab.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import { Pill, Flame } from 'lucide-react';
+import { fetchInsightsMedications, type MedicationInsights } from '../../lib/insightsClient';
+import { CorrelationCard, CorrelationCaveat, SectionTitle, TabLoading, TabError, TabEmpty } from './insightsShared';
+
+function adherenceColor(percent: number | null): string {
+  if (percent === null) return 'text-neutral-400';
+  if (percent >= 90) return 'text-emerald-400';
+  if (percent >= 70) return 'text-amber-400';
+  return 'text-rose-400';
+}
+
+export const MedicationInsightsTab: React.FC<{ days: number }> = ({ days }) => {
+  const [data, setData] = useState<MedicationInsights | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchInsightsMedications(days)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load medication insights');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  if (loading) return <TabLoading label="Analyzing medications…" />;
+  if (error) return <TabError message={error} />;
+
+  if (!data || (data.adherence.length === 0 && data.correlations.length === 0)) {
+    return (
+      <TabEmpty
+        title="No medication data yet"
+        message="Add medications in the Health Hub and log them daily to see adherence and how they relate to your wellbeing."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {data.adherence.length > 0 && (
+        <section>
+          <SectionTitle icon={<Pill size={15} className="text-sky-400" />} hint="How consistently you've taken each medication this window.">
+            Adherence
+          </SectionTitle>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {data.adherence.map((a) => (
+              <div key={a.medicationId} className="rounded-xl border border-white/5 bg-neutral-900/40 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-white truncate">{a.name}</div>
+                    {a.dosage && <div className="text-[11px] text-neutral-500">{a.dosage}</div>}
+                  </div>
+                  <div className={`text-2xl font-bold ${adherenceColor(a.adherencePercent)}`}>
+                    {a.adherencePercent === null ? '—' : `${a.adherencePercent}%`}
+                  </div>
+                </div>
+                <div className="mt-2 flex items-center gap-4 text-[11px] text-neutral-500">
+                  <span>
+                    {a.takenDays}/{a.loggedDays} days taken
+                  </span>
+                  {a.currentTakenStreak > 0 && (
+                    <span className="inline-flex items-center gap-1 text-amber-300">
+                      <Flame size={11} /> {a.currentTakenStreak}d streak
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <SectionTitle hint="How taking your medications relates to how you feel.">Medications ↔ wellbeing</SectionTitle>
+        {data.correlations.length > 0 ? (
+          <div className="space-y-4">
+            <CorrelationCaveat />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {data.correlations.map((c) => (
+                <CorrelationCard key={`${c.factorId}-${c.outcomeKey}`} correlation={c} />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="text-xs text-neutral-500">
+            Not enough variation yet to link medications to wellbeing. This needs days both with and without each
+            medication logged.
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/src/pages/insights/OverviewTab.tsx
+++ b/src/pages/insights/OverviewTab.tsx
@@ -1,0 +1,379 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Activity, Battery, Target, Brain, Wind, Grid3X3, CalendarRange, BarChart3, Sparkles, Trophy } from 'lucide-react';
+import type { WellbeingMetricKey } from '../../models/persistenceTypes';
+import { useWellbeingEntriesRange } from '../../hooks/useWellbeingEntriesRange';
+import { fetchInsightsOverview, type InsightsOverview } from '../../lib/insightsClient';
+import { DiscoveryCard, CorrelationCard, SectionTitle, TabLoading } from './insightsShared';
+
+type SelectableMetric = Extract<WellbeingMetricKey, 'anxiety' | 'lowMood' | 'calm' | 'energy' | 'stress'>;
+type HistoryView = 'heatmap' | 'weekly' | 'multiples';
+
+const METRICS: Array<{ key: SelectableMetric; label: string; icon: React.ReactNode }> = [
+  { key: 'anxiety', label: 'Anxiety', icon: <Activity size={14} className="text-purple-400" /> },
+  { key: 'lowMood', label: 'Low Mood', icon: <Brain size={14} className="text-blue-400" /> },
+  { key: 'calm', label: 'Calm', icon: <Wind size={14} className="text-emerald-400" /> },
+  { key: 'energy', label: 'Energy', icon: <Battery size={14} className="text-emerald-400" /> },
+  { key: 'stress', label: 'Stress', icon: <Target size={14} className="text-orange-400" /> },
+];
+
+function clampInt(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.round(n)));
+}
+
+function intensityFromValue(metric: SelectableMetric, value: number): number {
+  // Heatmap scale is always 0..4 intensity. Map legacy 1..5 metrics down by subtracting 1.
+  if (metric === 'anxiety' || metric === 'energy') return clampInt(value - 1, 0, 4);
+  return clampInt(value, 0, 4);
+}
+
+function heatClass(intensity: number | null): string {
+  if (intensity === null) return 'bg-neutral-800/60 border-white/5';
+  switch (intensity) {
+    case 0:
+      return 'bg-sky-900/20 border-white/5';
+    case 1:
+      return 'bg-sky-800/30 border-sky-500/10';
+    case 2:
+      return 'bg-sky-700/40 border-sky-500/15';
+    case 3:
+      return 'bg-sky-600/55 border-sky-400/20';
+    default:
+      return 'bg-sky-500/70 border-sky-300/25';
+  }
+}
+
+function formatWeekLabel(weekStartDayKey: string): string {
+  const d = new Date(`${weekStartDayKey}T00:00:00.000Z`);
+  return d.toLocaleDateString(undefined, { month: 'short', day: '2-digit' });
+}
+
+export const OverviewTab: React.FC<{ days: 30 | 90 | 180 }> = ({ days }) => {
+  const [view, setView] = useState<HistoryView>('heatmap');
+  const [metric, setMetric] = useState<SelectableMetric>('anxiety');
+  const [hover, setHover] = useState<{ dayKey: string; value: number | null } | null>(null);
+
+  const [overview, setOverview] = useState<InsightsOverview | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(true);
+
+  const { loading, error, getDailyAverage, startDayKey, endDayKey } = useWellbeingEntriesRange(days);
+
+  useEffect(() => {
+    let cancelled = false;
+    setOverviewLoading(true);
+    fetchInsightsOverview(days)
+      .then((data) => {
+        if (!cancelled) setOverview(data);
+      })
+      .catch(() => {
+        if (!cancelled) setOverview(null);
+      })
+      .finally(() => {
+        if (!cancelled) setOverviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const cellsForMetric = useMemo(() => {
+    const start = new Date(`${startDayKey}T00:00:00.000Z`);
+    const end = new Date(`${endDayKey}T00:00:00.000Z`);
+    const startDow = start.getUTCDay();
+    const gridStart = new Date(start);
+    gridStart.setUTCDate(gridStart.getUTCDate() - startDow);
+
+    const cells: Array<{ dayKey: string; value: number | null; intensity: number | null }> = [];
+    for (let d = new Date(gridStart); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      const dayKey = d.toISOString().slice(0, 10);
+      const inRange = d >= start && d <= end;
+      const raw = inRange ? getDailyAverage(dayKey, metric as WellbeingMetricKey) : null;
+      const value = typeof raw === 'number' ? raw : null;
+      const intensity = value === null ? null : intensityFromValue(metric, value);
+      cells.push({ dayKey, value, intensity });
+    }
+    return cells;
+  }, [startDayKey, endDayKey, getDailyAverage, metric]);
+
+  const weeksForMetric = useMemo(() => {
+    const rows: Array<typeof cellsForMetric> = [];
+    for (let i = 0; i < cellsForMetric.length; i += 7) rows.push(cellsForMetric.slice(i, i + 7));
+    return rows;
+  }, [cellsForMetric]);
+
+  const weeklySummary = useMemo(() => {
+    const start = new Date(`${startDayKey}T00:00:00.000Z`);
+    const end = new Date(`${endDayKey}T00:00:00.000Z`);
+    const startDow = start.getUTCDay();
+    const diffToMonday = (startDow + 6) % 7;
+    const weekStart = new Date(start);
+    weekStart.setUTCDate(weekStart.getUTCDate() - diffToMonday);
+
+    const rows: Array<{ weekStartDayKey: string; calmPct: number; anxietyPct: number; lowMoodPct: number }> = [];
+    for (let w = new Date(weekStart); w <= end; w.setUTCDate(w.getUTCDate() + 7)) {
+      const weekStartDayKey = w.toISOString().slice(0, 10);
+      let calmSum = 0;
+      let anxietySum = 0;
+      let lowMoodSum = 0;
+      for (let i = 0; i < 7; i++) {
+        const d = new Date(w);
+        d.setUTCDate(w.getUTCDate() + i);
+        if (d < start || d > end) continue;
+        const dayKey = d.toISOString().slice(0, 10);
+        const calmRaw = getDailyAverage(dayKey, 'calm' as WellbeingMetricKey);
+        const anxietyRaw = getDailyAverage(dayKey, 'anxiety' as WellbeingMetricKey);
+        const lowMoodRaw = getDailyAverage(dayKey, 'lowMood' as WellbeingMetricKey);
+        if (typeof calmRaw === 'number') calmSum += intensityFromValue('calm', calmRaw);
+        if (typeof anxietyRaw === 'number') anxietySum += intensityFromValue('anxiety', anxietyRaw);
+        if (typeof lowMoodRaw === 'number') lowMoodSum += intensityFromValue('lowMood', lowMoodRaw);
+      }
+      const total = calmSum + anxietySum + lowMoodSum;
+      rows.push({
+        weekStartDayKey,
+        calmPct: total === 0 ? 0 : calmSum / total,
+        anxietyPct: total === 0 ? 0 : anxietySum / total,
+        lowMoodPct: total === 0 ? 0 : lowMoodSum / total,
+      });
+    }
+    return rows.slice(-Math.ceil(days / 7) - 1);
+  }, [startDayKey, endDayKey, getDailyAverage, days]);
+
+  const miniHeatmaps = useMemo(() => {
+    return METRICS.map((m) => {
+      const start = new Date(`${startDayKey}T00:00:00.000Z`);
+      const end = new Date(`${endDayKey}T00:00:00.000Z`);
+      const startDow = start.getUTCDay();
+      const gridStart = new Date(start);
+      gridStart.setUTCDate(gridStart.getUTCDate() - startDow);
+
+      const cells: Array<{ dayKey: string; value: number | null; intensity: number | null }> = [];
+      for (let d = new Date(gridStart); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+        const dayKey = d.toISOString().slice(0, 10);
+        const inRange = d >= start && d <= end;
+        const raw = inRange ? getDailyAverage(dayKey, m.key as WellbeingMetricKey) : null;
+        const value = typeof raw === 'number' ? raw : null;
+        const intensity = value === null ? null : intensityFromValue(m.key, value);
+        cells.push({ dayKey, value, intensity });
+      }
+      const weeks: Array<typeof cells> = [];
+      for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+      return { metric: m, weeks };
+    });
+  }, [startDayKey, endDayKey, getDailyAverage]);
+
+  return (
+    <div className="space-y-8">
+      {/* ── Discoveries & milestones ────────────────────────────────── */}
+      <section>
+        <SectionTitle icon={<Trophy size={15} className="text-amber-400" />} hint="What stood out in your check-ins this window.">
+          Discoveries
+        </SectionTitle>
+        {overviewLoading ? (
+          <TabLoading />
+        ) : overview && overview.discoveries.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {overview.discoveries.map((d) => (
+              <DiscoveryCard key={d.id} discovery={d} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-xs text-neutral-500">Keep checking in to surface discoveries.</div>
+        )}
+      </section>
+
+      {/* ── Top correlations preview ────────────────────────────────── */}
+      {overview && overview.topCorrelations.length > 0 && (
+        <section>
+          <SectionTitle icon={<Sparkles size={15} className="text-indigo-400" />} hint="Strongest relationships — see the Correlations tab for the full list.">
+            Top correlations
+          </SectionTitle>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {overview.topCorrelations.map((c) => (
+              <CorrelationCard key={`${c.factorId}-${c.outcomeKey}`} correlation={c} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Metric averages ─────────────────────────────────────────── */}
+      {overview && overview.metricAverages.length > 0 && (
+        <section>
+          <SectionTitle hint="Average of your check-in values over this window.">Metric averages</SectionTitle>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {overview.metricAverages.slice(0, 12).map((m) => (
+              <div key={m.metricKey} className="rounded-xl border border-white/5 bg-neutral-900/40 p-3">
+                <div className="text-[11px] text-neutral-500 capitalize">{m.label}</div>
+                <div className="text-lg font-bold text-white">{m.average}</div>
+                <div className="text-[10px] text-neutral-600">{m.sampleSize} days</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Wellbeing history visualizations (heatmap / weekly / multiples) ── */}
+      <section>
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-3 mb-4">
+          <SectionTitle hint="Universal view (persona-agnostic).">Wellbeing history</SectionTitle>
+          <div className="flex flex-wrap gap-2 items-center">
+            <div className="flex gap-4 border-b border-white/5 mr-2">
+              {(
+                [
+                  { id: 'heatmap' as const, label: 'Heat Map', icon: Grid3X3 },
+                  { id: 'weekly' as const, label: 'Weekly', icon: CalendarRange },
+                  { id: 'multiples' as const, label: 'Small Multiples', icon: BarChart3 },
+                ]
+              ).map(({ id, label, icon: Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => setView(id)}
+                  className={`pb-2 px-1 text-xs font-semibold transition-colors relative ${
+                    view === id ? 'text-emerald-400' : 'text-white/40 hover:text-white/60'
+                  }`}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <Icon size={14} />
+                    {label}
+                  </div>
+                  {view === id && <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-emerald-400 rounded-t-full" />}
+                </button>
+              ))}
+            </div>
+            {view === 'heatmap' && (
+              <div className="flex flex-wrap gap-2 items-center">
+                {METRICS.map((m) => {
+                  const active = metric === m.key;
+                  return (
+                    <button
+                      key={m.key}
+                      onClick={() => setMetric(m.key)}
+                      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors ${
+                        active ? 'bg-white/10 text-white border-white/20' : 'bg-neutral-800/60 text-neutral-300 border-white/10 hover:text-white'
+                      }`}
+                    >
+                      {m.icon}
+                      {m.label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="text-sm text-neutral-400">Loading…</div>
+        ) : error ? (
+          <div className="text-sm text-red-300">{error}</div>
+        ) : view === 'heatmap' ? (
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <div className="text-xs text-neutral-500">Color shows intensity (0–4). Missing days are neutral.</div>
+              {hover ? (
+                <div className="text-xs text-neutral-300">
+                  <span className="text-neutral-500 mr-2">{hover.dayKey}</span>
+                  <span className="font-semibold text-white">{hover.value === null ? '—' : hover.value}</span>
+                </div>
+              ) : (
+                <div className="text-xs text-neutral-500">Hover a day to see details</div>
+              )}
+            </div>
+            <div className="inline-flex gap-3">
+              <div className="flex flex-col gap-1">
+                <div className="h-5" />
+                {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, idx) => (
+                  <div key={`${d}-${idx}`} className="h-4 text-[10px] text-neutral-600 flex items-center">
+                    {d}
+                  </div>
+                ))}
+              </div>
+              <div className="flex flex-col gap-1">
+                <div className="h-5" />
+                <div className="flex gap-1 overflow-x-auto">
+                  {weeksForMetric.map((week, i) => (
+                    <div key={week[0]?.dayKey ?? i} className="flex flex-col gap-1">
+                      {week.map((cell) => (
+                        <button
+                          key={cell.dayKey}
+                          type="button"
+                          className={`w-4 h-4 rounded border ${heatClass(cell.intensity)} hover:border-white/20 transition-colors`}
+                          onMouseEnter={() => setHover({ dayKey: cell.dayKey, value: cell.value })}
+                          onMouseLeave={() => setHover(null)}
+                          title={`${cell.dayKey}: ${cell.value === null ? '—' : cell.value}`}
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : view === 'weekly' ? (
+          <div className="space-y-3">
+            <div className="text-xs text-neutral-500">
+              Each week is a simple mix of <span className="text-emerald-300">Calm</span>,{' '}
+              <span className="text-purple-300">Anxiety</span>, and <span className="text-sky-300">Low Mood</span>.
+            </div>
+            <div className="space-y-2">
+              {weeklySummary.map((w) => {
+                const title = `${w.weekStartDayKey}: Calm ${Math.round(w.calmPct * 100)}%, Anxiety ${Math.round(
+                  w.anxietyPct * 100,
+                )}%, Low Mood ${Math.round(w.lowMoodPct * 100)}%`;
+                return (
+                  <div key={w.weekStartDayKey} className="flex items-center gap-3">
+                    <div className="w-14 text-[11px] text-neutral-500">{formatWeekLabel(w.weekStartDayKey)}</div>
+                    <div className="flex-1 h-3 rounded-full overflow-hidden border border-white/5 bg-neutral-800/60" title={title}>
+                      <div className="h-full flex">
+                        <div className="h-full bg-emerald-400/70" style={{ width: `${w.calmPct * 100}%` }} />
+                        <div className="h-full bg-purple-400/70" style={{ width: `${w.anxietyPct * 100}%` }} />
+                        <div className="h-full bg-sky-400/70" style={{ width: `${w.lowMoodPct * 100}%` }} />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {miniHeatmaps.map(({ metric: m, weeks }) => (
+              <div key={m.key} className="p-4 rounded-xl bg-neutral-900/40 border border-white/5">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="inline-flex items-center gap-2 text-sm font-semibold text-white">
+                    {m.icon}
+                    {m.label}
+                  </div>
+                  <div className="text-[11px] text-neutral-500">{days}d</div>
+                </div>
+                <div className="flex gap-2">
+                  <div className="flex flex-col gap-1 pt-5">
+                    {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, idx) => (
+                      <div key={`${d}-${idx}`} className="h-3 text-[9px] text-neutral-700 flex items-center">
+                        {d}
+                      </div>
+                    ))}
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <div className="h-5" />
+                    <div className="flex gap-1 overflow-x-auto">
+                      {weeks.map((week, i) => (
+                        <div key={week[0]?.dayKey ?? i} className="flex flex-col gap-1">
+                          {week.map((cell) => (
+                            <div
+                              key={cell.dayKey}
+                              className={`w-3 h-3 rounded border ${heatClass(cell.intensity)} border-white/5`}
+                              title={`${cell.dayKey}: ${cell.value === null ? '—' : cell.value}`}
+                            />
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/src/pages/insights/PredictionsTab.tsx
+++ b/src/pages/insights/PredictionsTab.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { fetchInsightsPredictions, type MetricPrediction } from '../../lib/insightsClient';
+import { SectionTitle, TabLoading, TabError, TabEmpty } from './insightsShared';
+
+/** Minimal inline sparkline for a metric's observed daily values. */
+const Sparkline: React.FC<{ values: number[]; color: string }> = ({ values, color }) => {
+  if (values.length < 2) return null;
+  const w = 120;
+  const h = 32;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const points = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * w;
+      const y = h - ((v - min) / span) * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  return (
+    <svg width={w} height={h} className="overflow-visible">
+      <polyline points={points} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+const confidenceBadge: Record<MetricPrediction['confidence'], string> = {
+  high: 'bg-emerald-500/10 text-emerald-300',
+  medium: 'bg-amber-500/10 text-amber-300',
+  low: 'bg-neutral-700/40 text-neutral-400',
+};
+
+const PredictionCard: React.FC<{ prediction: MetricPrediction }> = ({ prediction: p }) => {
+  const improving = p.direction === 'improving';
+  const declining = p.direction === 'declining';
+  const Icon = improving ? TrendingUp : declining ? TrendingDown : Minus;
+  const accent = improving ? 'text-emerald-400' : declining ? 'text-rose-400' : 'text-neutral-400';
+  const strokeColor = improving ? '#34d399' : declining ? '#fb7185' : '#a3a3a3';
+
+  return (
+    <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Icon size={16} className={accent} />
+          <div className="text-sm font-semibold text-white capitalize">{p.label}</div>
+        </div>
+        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${confidenceBadge[p.confidence]}`}>
+          {p.confidence} confidence
+        </span>
+      </div>
+
+      <div className="mt-3 flex items-end justify-between gap-3">
+        <div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-bold text-white">{p.currentValue ?? '—'}</span>
+            {p.predictedValue !== null && (
+              <span className="text-sm text-neutral-400">
+                <span className="text-neutral-600">→</span> {p.predictedValue}
+              </span>
+            )}
+          </div>
+          <div className="text-[11px] text-neutral-500 mt-0.5">
+            now → projected in {p.horizonDays}d
+            {p.slopePerWeek !== null && p.slopePerWeek !== 0 && (
+              <> · {p.slopePerWeek > 0 ? '+' : ''}{p.slopePerWeek}/week</>
+            )}
+          </div>
+        </div>
+        <Sparkline values={p.trend.map((t) => t.value)} color={strokeColor} />
+      </div>
+
+      <div className="mt-2 text-[10px] text-neutral-600">{p.sampleSize} days of data</div>
+    </div>
+  );
+};
+
+export const PredictionsTab: React.FC<{ days: number }> = ({ days }) => {
+  const [predictions, setPredictions] = useState<MetricPrediction[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchInsightsPredictions(days)
+      .then((data) => {
+        if (!cancelled) setPredictions(data.predictions);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load predictions');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  if (loading) return <TabLoading label="Projecting trends…" />;
+  if (error) return <TabError message={error} />;
+
+  const usable = (predictions ?? []).filter((p) => p.predictedValue !== null);
+  if (usable.length === 0) {
+    return (
+      <TabEmpty
+        title="Not enough data to predict"
+        message="Predictions need at least a handful of logged days for a metric. Keep checking in and trends will appear here."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded-lg bg-neutral-800/40 border border-white/5 p-3 text-[11px] text-neutral-500">
+        Simple linear projections from your recent check-ins — a guide to where things are heading, not a guarantee.
+      </div>
+      <SectionTitle hint="Projected value if your current trend continues.">Trend projections</SectionTitle>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {usable.map((p) => (
+          <PredictionCard key={p.metricKey} prediction={p} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/insights/insightsShared.tsx
+++ b/src/pages/insights/insightsShared.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { TrendingUp, TrendingDown, Sparkles, Trophy, Info, Loader2 } from 'lucide-react';
+import type { InsightsCorrelation, Discovery } from '../../lib/insightsClient';
+
+/** Map |Cohen's d| to a plain-language strength label. */
+export function effectSizeLabel(d: number): 'small' | 'moderate' | 'strong' {
+  const abs = Math.abs(d);
+  if (abs >= 0.8) return 'strong';
+  if (abs >= 0.5) return 'moderate';
+  return 'small';
+}
+
+/** Friendly label for a factor's source. */
+export function sourceLabel(source: string): string {
+  switch (source) {
+    case 'habit':
+      return 'Habit';
+    case 'medication':
+      return 'Medication';
+    case 'supplement':
+      return 'Supplement';
+    case 'symptom':
+      return 'Symptom';
+    case 'wellbeingFactor':
+      return 'Factor';
+    default:
+      return source;
+  }
+}
+
+export const TabLoading: React.FC<{ label?: string }> = ({ label = 'Loading insights…' }) => (
+  <div className="flex items-center gap-3 py-8 text-sm text-neutral-400">
+    <Loader2 size={18} className="animate-spin text-emerald-400" />
+    {label}
+  </div>
+);
+
+export const TabError: React.FC<{ message: string }> = ({ message }) => (
+  <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-4 text-sm text-red-300">{message}</div>
+);
+
+export const TabEmpty: React.FC<{ title: string; message: string }> = ({ title, message }) => (
+  <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-8 text-center">
+    <div className="text-sm font-semibold text-white">{title}</div>
+    <div className="mt-1 text-xs text-neutral-500">{message}</div>
+  </div>
+);
+
+/** A single factor↔outcome correlation, rendered as a card. */
+export const CorrelationCard: React.FC<{ correlation: InsightsCorrelation }> = ({ correlation: c }) => {
+  const improves = c.direction === 'improves';
+  const Icon = improves ? TrendingUp : TrendingDown;
+  const accent = improves ? 'text-emerald-400' : 'text-rose-400';
+  const ring = improves ? 'border-emerald-500/20' : 'border-rose-500/20';
+  return (
+    <div className={`rounded-xl border ${ring} bg-neutral-900/40 p-4`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <Icon size={16} className={`${accent} shrink-0`} />
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-white truncate">
+              {c.factorName} <span className="text-neutral-500 font-normal">→</span> {c.outcomeLabel}
+            </div>
+            <div className="text-[11px] text-neutral-500">{sourceLabel(c.factorSource)}</div>
+          </div>
+        </div>
+        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${improves ? 'bg-emerald-500/10 text-emerald-300' : 'bg-rose-500/10 text-rose-300'}`}>
+          {effectSizeLabel(c.effectSize)} {improves ? 'improvement' : 'decline'}
+        </span>
+      </div>
+      <p className="mt-2 text-xs text-neutral-400 leading-relaxed">{c.message}</p>
+    </div>
+  );
+};
+
+/** A single discovery / milestone, rendered as a card. */
+export const DiscoveryCard: React.FC<{ discovery: Discovery }> = ({ discovery: d }) => {
+  const config = {
+    positive: { Icon: TrendingUp, color: 'text-emerald-400', ring: 'border-emerald-500/20' },
+    negative: { Icon: TrendingDown, color: 'text-rose-400', ring: 'border-rose-500/20' },
+    milestone: { Icon: Trophy, color: 'text-amber-400', ring: 'border-amber-500/20' },
+    info: { Icon: Info, color: 'text-sky-400', ring: 'border-sky-500/20' },
+  }[d.type];
+  const { Icon, color, ring } = config;
+  return (
+    <div className={`rounded-xl border ${ring} bg-neutral-900/40 p-4`}>
+      <div className="flex items-center gap-2">
+        <Icon size={16} className={color} />
+        <div className="text-sm font-semibold text-white">{d.title}</div>
+      </div>
+      <p className="mt-1.5 text-xs text-neutral-400 leading-relaxed">{d.message}</p>
+    </div>
+  );
+};
+
+/** Section heading used across tabs. */
+export const SectionTitle: React.FC<{ icon?: React.ReactNode; children: React.ReactNode; hint?: string }> = ({
+  icon,
+  children,
+  hint,
+}) => (
+  <div className="mb-3">
+    <div className="flex items-center gap-2">
+      {icon}
+      <h3 className="text-sm font-semibold text-white">{children}</h3>
+    </div>
+    {hint && <div className="text-[11px] text-neutral-500 mt-0.5">{hint}</div>}
+  </div>
+);
+
+export const CorrelationCaveat: React.FC = () => (
+  <div className="flex items-start gap-2 rounded-lg bg-neutral-800/40 border border-white/5 p-3 text-[11px] text-neutral-500">
+    <Sparkles size={13} className="mt-0.5 shrink-0 text-neutral-400" />
+    <span>
+      These are statistical correlations from your own check-ins, not proof of cause and effect. More data means
+      sharper signals.
+    </span>
+  </div>
+);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -72,6 +72,7 @@ import { postWeeklyReview } from './routes/aiWeeklyReview';
 import { postSuggestVariants } from './routes/aiVariantSuggestion';
 import { postJournalSummary } from './routes/aiJournalSummary';
 import { postJournalReview } from './routes/aiJournalReview';
+import { postInsightsReview } from './routes/aiInsightsReview';
 import { getAIReportsRoute, getAIReportRoute, deleteAIReportRoute } from './routes/aiReports';
 import {
   getHabitAnalyticsSummary,
@@ -270,6 +271,7 @@ export function createApp(): Express {
   app.post('/api/ai/suggest-variants', postSuggestVariants);
   app.post('/api/ai/journal-summary', postJournalSummary);
   app.post('/api/ai/journal-review', postJournalReview);
+  app.post('/api/ai/insights-review', postInsightsReview);
   app.get('/api/ai/reports', getAIReportsRoute);
   app.get('/api/ai/reports/:id', getAIReportRoute);
   app.delete('/api/ai/reports/:id', deleteAIReportRoute);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -84,6 +84,13 @@ import {
   getGoalAnalyticsSummary,
   getSleepAnalyticsSummary,
 } from './routes/analytics';
+import {
+  getInsightsOverview,
+  getInsightsCorrelations,
+  getInsightsHabits,
+  getInsightsMedications,
+  getInsightsPredictions,
+} from './routes/insights';
 
 export function createApp(): Express {
   const app = express();
@@ -275,6 +282,11 @@ export function createApp(): Express {
   app.get('/api/analytics/routines/summary', getRoutineAnalyticsSummary);
   app.get('/api/analytics/goals/summary', getGoalAnalyticsSummary);
   app.get('/api/analytics/sleep/summary', getSleepAnalyticsSummary);
+  app.get('/api/insights/overview', getInsightsOverview);
+  app.get('/api/insights/correlations', getInsightsCorrelations);
+  app.get('/api/insights/habits', getInsightsHabits);
+  app.get('/api/insights/medications', getInsightsMedications);
+  app.get('/api/insights/predictions', getInsightsPredictions);
   app.get('/api/admin/integrity-report', getIntegrityReport);
   app.post('/api/admin/dedup-habits', requireAdmin, dedupHabits);
   app.post('/api/admin/recover-habits', requireAdmin, recoverHabits);

--- a/src/server/routes/aiInsightsReview.ts
+++ b/src/server/routes/aiInsightsReview.ts
@@ -1,0 +1,328 @@
+/**
+ * Insights AI Review Route (Gemini BYOK)
+ *
+ * POST /api/ai/insights-review
+ *
+ * Computes the user's cross-domain insights (correlations, linear-trend
+ * predictions, medication adherence, metric averages, discoveries) from
+ * canonical truth, then asks Gemini to turn those *already-computed facts* into
+ * a grounded, plain-language narrative with caveated patterns and small,
+ * realistic recommendations.
+ *
+ * Grounding strategy mirrors the Weekly AI Review:
+ *  - Only aggregated facts derived from the database are sent to the model.
+ *  - The window boundaries are set by the server, not the model.
+ *  - A structured JSON response schema keeps the UI shape stable.
+ *  - The model is told everything is correlation, never causation.
+ */
+
+import type { Request, Response } from 'express';
+import { getRequestIdentity } from '../middleware/identity';
+import { resolveTimeZone, getNowDayKey } from '../utils/dayKey';
+import { getWellbeingEntries } from '../repositories/wellbeingEntryRepository';
+import { getHabitsByUser } from '../repositories/habitRepository';
+import { getHabitEntriesByUserInRange } from '../repositories/habitEntryRepository';
+import { listMedications, getMedicationLogsInRange } from '../repositories/medicationRepository';
+import { listSupplements, getSupplementLogsInRange } from '../repositories/supplementRepository';
+import { listSymptoms, getSymptomLogsInRange } from '../repositories/symptomRepository';
+import {
+  computeInsightsOverview,
+  computeCorrelationsForSources,
+  computePredictionsForSources,
+  computeMedicationInsights,
+  startDayKeyForRange,
+  type InsightsSources,
+} from '../services/insightsService';
+import { GEMINI_MODEL, buildGeminiUrl, GEMINI_THINKING_CONFIG, extractGeminiText } from '../lib/gemini';
+import type { ReviewConfidence } from '../../shared/weeklyAiReview';
+import type {
+  InsightsAIReview,
+  InsightsReviewPattern,
+  InsightsReviewRecommendation,
+} from '../../shared/insightsAiReview';
+
+interface InsightsReviewRequest {
+  geminiApiKey: string;
+  days?: number;
+  timeZone?: string;
+}
+
+function parseDays(value: unknown, fallback = 90): number {
+  const raw = typeof value === 'number' ? value : typeof value === 'string' ? parseInt(value, 10) : NaN;
+  if (isNaN(raw) || raw < 1 || raw > 365) return fallback;
+  return raw;
+}
+
+/**
+ * POST /api/ai/insights-review
+ */
+export async function postInsightsReview(req: Request, res: Response): Promise<void> {
+  try {
+    const { geminiApiKey, days: daysInput, timeZone: tzInput } = req.body as InsightsReviewRequest;
+
+    if (!geminiApiKey || typeof geminiApiKey !== 'string' || geminiApiKey.trim().length < 10) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'A valid Gemini API key is required' },
+      });
+      return;
+    }
+
+    const { userId, householdId } = getRequestIdentity(req);
+    const timeZone = resolveTimeZone(typeof tzInput === 'string' ? tzInput : undefined);
+    const days = parseDays(daysInput, 90);
+    const referenceDayKey = getNowDayKey(timeZone);
+    const rangeStart = startDayKeyForRange(referenceDayKey, days);
+
+    // ---- Load all sources for the window ----
+    const [
+      wellbeingEntries,
+      habits,
+      habitEntries,
+      medications,
+      medicationLogs,
+      supplements,
+      supplementLogs,
+      symptoms,
+      symptomLogs,
+    ] = await Promise.all([
+      getWellbeingEntries({ userId, startDayKey: rangeStart, endDayKey: referenceDayKey }),
+      getHabitsByUser(householdId, userId),
+      getHabitEntriesByUserInRange(householdId, userId, rangeStart, referenceDayKey),
+      listMedications(householdId, userId),
+      getMedicationLogsInRange(householdId, userId, rangeStart, referenceDayKey),
+      listSupplements(householdId, userId),
+      getSupplementLogsInRange(householdId, userId, rangeStart, referenceDayKey),
+      listSymptoms(householdId, userId),
+      getSymptomLogsInRange(householdId, userId, rangeStart, referenceDayKey),
+    ]);
+
+    const sources: InsightsSources = {
+      wellbeingEntries,
+      habits,
+      habitEntries,
+      medications,
+      medicationLogs,
+      supplements,
+      supplementLogs,
+      symptoms,
+      symptomLogs,
+    };
+
+    // ---- Compute the insights the model will narrate ----
+    const overview = computeInsightsOverview(sources, referenceDayKey, days, timeZone);
+    const correlations = computeCorrelationsForSources(sources, referenceDayKey, days, timeZone);
+    const predictions = computePredictionsForSources(sources, referenceDayKey, days);
+    const medication = computeMedicationInsights(sources, referenceDayKey, days, timeZone);
+
+    const observedInsights = {
+      window: { rangeDays: days, start: rangeStart, end: referenceDayKey, daysWithCheckins: overview.daysWithCheckins },
+      metricAverages: overview.metricAverages.map((m) => ({
+        metric: m.label,
+        average: m.average,
+        daysRecorded: m.sampleSize,
+        higherIsBetter: m.higherIsBetter,
+      })),
+      correlations: correlations.map((c) => ({
+        factor: c.factorName,
+        factorType: c.factorSource,
+        outcome: c.outcomeLabel,
+        direction: c.direction,
+        meanDifference: c.meanDifference,
+        effectSize: c.effectSize,
+        nPresent: c.nPresent,
+        nAbsent: c.nAbsent,
+      })),
+      predictions: predictions
+        .filter((p) => p.predictedValue !== null)
+        .map((p) => ({
+          metric: p.label,
+          current: p.currentValue,
+          predicted: p.predictedValue,
+          horizonDays: p.horizonDays,
+          changePerWeek: p.slopePerWeek,
+          direction: p.direction,
+          confidence: p.confidence,
+        })),
+      medicationAdherence: medication.adherence.map((a) => ({
+        medication: a.name,
+        adherencePercent: a.adherencePercent,
+        loggedDays: a.loggedDays,
+      })),
+    };
+
+    // ---- Build the grounded prompt ----
+    const prompt = `You are an analytical wellness coach for a habit-tracking app called HabitFlow.
+You will be given COMPUTED INSIGHTS derived directly from one user's database over a ${days}-day window.
+These insights are already statistically computed (correlations use Cohen's d effect size on present/absent
+day groups; predictions are simple linear trend lines). Your job is to explain them in plain language and
+suggest small, realistic next steps. Fill in every section of the schema.
+
+SECTIONS (fill each):
+1. "summary" — a natural-language narrative (1-3 short paragraphs) of what the insights show overall:
+   the strongest relationships, the clearest trends, and overall data coverage. No recommendations here.
+2. "keyFindings" — objective findings drawn directly from the computed numbers (e.g.
+   "On days you exercised, mood averaged 1.2 points higher (n=12 vs 9).").
+3. "patterns" — inferred relationships, each with a "confidence" of low/medium/high based ONLY on the
+   sample sizes and effect sizes provided. Use tentative language; never claim causation.
+4. "outlook" — a forward-looking, clearly caveated read of the trend predictions (e.g.
+   "If the current trend holds, your energy may reach ~3.8 in two weeks — a simple linear projection, not a guarantee.").
+5. "recommendations" — a SMALL number (MAXIMUM 5) of grounded, behaviorally realistic suggestions tied to the data.
+
+STRICT GROUNDING RULES:
+- Use ONLY the computed insights below. Never invent factors, outcomes, numbers, or relationships not present.
+- Everything here is CORRELATION, not causation. Never imply one thing causes another.
+- If there are few correlations or thin data, say so honestly in "dataLimitations" and keep sections short.
+- Cite specific numbers (effect sizes, mean differences, sample sizes, predicted values) where relevant.
+- Recommendations must be small and realistic (e.g. "keep your wind-down routine on work nights"), never generic.
+
+COMPUTED INSIGHTS (JSON):
+${JSON.stringify(observedInsights, null, 2)}
+
+Notes for interpretation:
+- "correlations[].direction" is "improves" or "worsens" relative to the outcome's own polarity (higherIsBetter).
+- "effectSize" is Cohen's d (|0.2| small, |0.5| medium, |0.8| large). Larger |effectSize| = stronger signal.
+- "predictions[].direction" already accounts for whether higher is better for that metric.
+- Wellbeing values are on the user's own 1-5 check-in scales; treat them as relative, not absolute.
+
+Return the review as JSON matching the provided schema.`;
+
+    const responseSchema = {
+      type: 'object',
+      properties: {
+        summary: { type: 'string' },
+        keyFindings: { type: 'array', items: { type: 'string' } },
+        patterns: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              evidence: { type: 'string' },
+              confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+            },
+            required: ['title', 'evidence', 'confidence'],
+          },
+        },
+        outlook: { type: 'array', items: { type: 'string' } },
+        recommendations: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              reason: { type: 'string' },
+              suggestedAction: { type: 'string' },
+            },
+            required: ['title', 'reason', 'suggestedAction'],
+          },
+        },
+        dataLimitations: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['summary', 'keyFindings', 'patterns', 'outlook', 'recommendations', 'dataLimitations'],
+    };
+
+    // ---- Call Gemini ----
+    const geminiResponse = await fetch(buildGeminiUrl(geminiApiKey.trim()), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: {
+          maxOutputTokens: 2048,
+          responseMimeType: 'application/json',
+          responseSchema,
+          thinkingConfig: GEMINI_THINKING_CONFIG,
+        },
+      }),
+    });
+
+    if (!geminiResponse.ok) {
+      const errorBody = await geminiResponse.text();
+      console.error('[AI Insights Review] Gemini API error:', geminiResponse.status, errorBody);
+      if (geminiResponse.status === 400 || geminiResponse.status === 403) {
+        res.status(401).json({
+          error: { code: 'GEMINI_AUTH_ERROR', message: 'Invalid Gemini API key. Please check your key in Settings.' },
+        });
+        return;
+      }
+      res.status(502).json({
+        error: {
+          code: 'GEMINI_API_ERROR',
+          message: 'Failed to get response from Gemini. Please try again later.',
+          details: process.env.NODE_ENV === 'development' ? `Gemini upstream status ${geminiResponse.status} (model ${GEMINI_MODEL})` : undefined,
+        },
+      });
+      return;
+    }
+
+    const rawText = extractGeminiText(await geminiResponse.json());
+    if (!rawText) {
+      res.status(502).json({ error: { code: 'GEMINI_EMPTY_RESPONSE', message: 'Gemini returned an empty review.' } });
+      return;
+    }
+
+    let parsed: Partial<InsightsAIReview>;
+    try {
+      parsed = JSON.parse(rawText) as Partial<InsightsAIReview>;
+    } catch {
+      console.error('[AI Insights Review] Failed to parse Gemini JSON:', rawText.slice(0, 500));
+      res.status(502).json({ error: { code: 'GEMINI_PARSE_ERROR', message: 'Gemini returned an unexpected format.' } });
+      return;
+    }
+
+    // ---- Normalize / validate (server owns the window) ----
+    const strArray = (v: unknown): string[] =>
+      Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0) : [];
+    const validConfidence = (c: unknown): ReviewConfidence =>
+      c === 'high' || c === 'medium' || c === 'low' ? c : 'low';
+
+    const patterns: InsightsReviewPattern[] = Array.isArray(parsed.patterns)
+      ? parsed.patterns
+          .filter((p): p is InsightsReviewPattern => !!p && typeof p === 'object')
+          .map((p) => ({ title: String(p.title ?? ''), evidence: String(p.evidence ?? ''), confidence: validConfidence(p.confidence) }))
+          .filter((p) => p.title.length > 0)
+      : [];
+
+    const recommendations: InsightsReviewRecommendation[] = (
+      Array.isArray(parsed.recommendations)
+        ? parsed.recommendations
+            .filter((r): r is InsightsReviewRecommendation => !!r && typeof r === 'object')
+            .map((r) => ({ title: String(r.title ?? ''), reason: String(r.reason ?? ''), suggestedAction: String(r.suggestedAction ?? '') }))
+            .filter((r) => r.title.length > 0)
+        : []
+    ).slice(0, 5);
+
+    const review: InsightsAIReview = {
+      rangeDays: days,
+      rangeStart,
+      rangeEnd: referenceDayKey,
+      summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+      keyFindings: strArray(parsed.keyFindings),
+      patterns,
+      outlook: strArray(parsed.outlook),
+      recommendations,
+      dataLimitations: strArray(parsed.dataLimitations),
+    };
+
+    res.status(200).json({
+      review,
+      meta: {
+        rangeDays: days,
+        rangeStart,
+        rangeEnd: referenceDayKey,
+        daysWithCheckins: overview.daysWithCheckins,
+        correlationsFound: correlations.length,
+      },
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[AI Insights Review] Error:', errorMessage);
+    res.status(500).json({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to generate insights review',
+        details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      },
+    });
+  }
+}

--- a/src/server/routes/insights.ts
+++ b/src/server/routes/insights.ts
@@ -1,0 +1,177 @@
+/**
+ * Insights Routes
+ *
+ * Read-only, cross-domain analytics that power the Insights page tabs. All
+ * derived from canonical truth at read time via insightsService (nothing
+ * stored). Responses are cached briefly (analyticsCache) like the other
+ * analytics endpoints.
+ *
+ *   GET /api/insights/overview      — averages, top correlations, discoveries
+ *   GET /api/insights/correlations  — all factor↔outcome correlations
+ *   GET /api/insights/habits        — habit↔wellbeing correlations
+ *   GET /api/insights/medications   — adherence + medication↔wellbeing correlations
+ *   GET /api/insights/predictions   — linear-trend projections per metric
+ */
+
+import type { Request, Response } from 'express';
+import { getRequestIdentity } from '../middleware/identity';
+import { resolveTimeZone, getNowDayKey } from '../utils/dayKey';
+import { getWellbeingEntries } from '../repositories/wellbeingEntryRepository';
+import { getHabitsByUser } from '../repositories/habitRepository';
+import { getHabitEntriesByUserInRange } from '../repositories/habitEntryRepository';
+import { listMedications, getMedicationLogsInRange } from '../repositories/medicationRepository';
+import { listSupplements, getSupplementLogsInRange } from '../repositories/supplementRepository';
+import { listSymptoms, getSymptomLogsInRange } from '../repositories/symptomRepository';
+import {
+  computeInsightsOverview,
+  computeCorrelationsForSources,
+  computePredictionsForSources,
+  computeMedicationInsights,
+  startDayKeyForRange,
+  type InsightsSources,
+} from '../services/insightsService';
+import { analyticsCache } from '../lib/cacheInstances';
+
+function parseDays(query: unknown, defaultDays = 90): number {
+  const raw = typeof query === 'string' ? parseInt(query, 10) : NaN;
+  if (isNaN(raw) || raw < 1 || raw > 365) return defaultDays;
+  return raw;
+}
+
+interface ResolvedRequest {
+  householdId: string;
+  userId: string;
+  timeZone: string;
+  referenceDayKey: string;
+  days: number;
+}
+
+function resolve(req: Request, defaultDays = 90): ResolvedRequest {
+  const { householdId, userId } = getRequestIdentity(req);
+  const timeZone = resolveTimeZone(typeof req.query.timeZone === 'string' ? req.query.timeZone : undefined);
+  const days = parseDays(req.query.days, defaultDays);
+  const referenceDayKey = getNowDayKey(timeZone);
+  return { householdId, userId, timeZone, referenceDayKey, days };
+}
+
+/**
+ * Load every source the insights engine needs over the requested window.
+ * Habit entries use a 2× window so a future feature could compute
+ * period-over-period deltas; correlations/predictions use the requested window.
+ */
+async function loadSources(r: ResolvedRequest): Promise<InsightsSources> {
+  const rangeStart = startDayKeyForRange(r.referenceDayKey, r.days);
+  const [
+    wellbeingEntries,
+    habits,
+    habitEntries,
+    medications,
+    medicationLogs,
+    supplements,
+    supplementLogs,
+    symptoms,
+    symptomLogs,
+  ] = await Promise.all([
+    getWellbeingEntries({ userId: r.userId, startDayKey: rangeStart, endDayKey: r.referenceDayKey }),
+    getHabitsByUser(r.householdId, r.userId),
+    getHabitEntriesByUserInRange(r.householdId, r.userId, rangeStart, r.referenceDayKey),
+    listMedications(r.householdId, r.userId),
+    getMedicationLogsInRange(r.householdId, r.userId, rangeStart, r.referenceDayKey),
+    listSupplements(r.householdId, r.userId),
+    getSupplementLogsInRange(r.householdId, r.userId, rangeStart, r.referenceDayKey),
+    listSymptoms(r.householdId, r.userId),
+    getSymptomLogsInRange(r.householdId, r.userId, rangeStart, r.referenceDayKey),
+  ]);
+  return {
+    wellbeingEntries,
+    habits,
+    habitEntries,
+    medications,
+    medicationLogs,
+    supplements,
+    supplementLogs,
+    symptoms,
+    symptomLogs,
+  };
+}
+
+async function cached<T>(key: string, compute: () => Promise<T>): Promise<T> {
+  const hit = analyticsCache.get(key) as T | undefined;
+  if (hit !== undefined) return hit;
+  const result = await compute();
+  analyticsCache.set(key, result);
+  return result;
+}
+
+export async function getInsightsOverview(req: Request, res: Response): Promise<void> {
+  try {
+    const r = resolve(req, 90);
+    const result = await cached(`${r.userId}:insights:overview:${r.days}`, async () => {
+      const sources = await loadSources(r);
+      return computeInsightsOverview(sources, r.referenceDayKey, r.days, r.timeZone);
+    });
+    res.json(result);
+  } catch (error) {
+    console.error('[insights] overview error:', error);
+    res.status(500).json({ error: 'Failed to compute insights overview' });
+  }
+}
+
+export async function getInsightsCorrelations(req: Request, res: Response): Promise<void> {
+  try {
+    const r = resolve(req, 90);
+    const result = await cached(`${r.userId}:insights:correlations:${r.days}`, async () => {
+      const sources = await loadSources(r);
+      return { correlations: computeCorrelationsForSources(sources, r.referenceDayKey, r.days, r.timeZone), rangeDays: r.days };
+    });
+    res.json(result);
+  } catch (error) {
+    console.error('[insights] correlations error:', error);
+    res.status(500).json({ error: 'Failed to compute correlations' });
+  }
+}
+
+export async function getInsightsHabits(req: Request, res: Response): Promise<void> {
+  try {
+    const r = resolve(req, 90);
+    const result = await cached(`${r.userId}:insights:habits:${r.days}`, async () => {
+      const sources = await loadSources(r);
+      return {
+        correlations: computeCorrelationsForSources(sources, r.referenceDayKey, r.days, r.timeZone, ['habit']),
+        rangeDays: r.days,
+      };
+    });
+    res.json(result);
+  } catch (error) {
+    console.error('[insights] habits error:', error);
+    res.status(500).json({ error: 'Failed to compute habit insights' });
+  }
+}
+
+export async function getInsightsMedications(req: Request, res: Response): Promise<void> {
+  try {
+    const r = resolve(req, 90);
+    const result = await cached(`${r.userId}:insights:medications:${r.days}`, async () => {
+      const sources = await loadSources(r);
+      return computeMedicationInsights(sources, r.referenceDayKey, r.days, r.timeZone);
+    });
+    res.json(result);
+  } catch (error) {
+    console.error('[insights] medications error:', error);
+    res.status(500).json({ error: 'Failed to compute medication insights' });
+  }
+}
+
+export async function getInsightsPredictions(req: Request, res: Response): Promise<void> {
+  try {
+    const r = resolve(req, 90);
+    const result = await cached(`${r.userId}:insights:predictions:${r.days}`, async () => {
+      const sources = await loadSources(r);
+      return { predictions: computePredictionsForSources(sources, r.referenceDayKey, r.days), rangeDays: r.days };
+    });
+    res.json(result);
+  } catch (error) {
+    console.error('[insights] predictions error:', error);
+    res.status(500).json({ error: 'Failed to compute predictions' });
+  }
+}

--- a/src/server/services/correlationEngine.ts
+++ b/src/server/services/correlationEngine.ts
@@ -1,0 +1,204 @@
+/**
+ * Correlation Engine (shared primitives)
+ *
+ * Pure, dependency-free statistics shared by the Sleep Analytics service and the
+ * cross-domain Insights service. Both surfaces use the SAME approach so the app
+ * speaks one statistical language: a factor↔outcome relationship is summarized as
+ * a present/absent group split plus a Cohen's d effect size.
+ *
+ * This is deliberately simple (no p-values, no regression): it answers
+ * "on days WITH this factor, was the outcome meaningfully different?" and is
+ * always presented to the user as correlation, never causation.
+ */
+
+// ─── Shared types ──────────────────────────────────────────────────────────────
+
+export interface FactorSeries {
+  /** Stable id (metricKey, habitId, medicationId, …). */
+  id: string;
+  /** Human-readable label. */
+  name: string;
+  /** Provenance label for grouping/filtering in the UI. */
+  source: string;
+  /** dayKey -> numeric signal (0/1 for boolean/toggle, raw value for numeric). */
+  byDay: Map<string, number>;
+}
+
+export interface OutcomeSeries {
+  /** Stable key (wellbeing metricKey, etc.). */
+  key: string;
+  /** Human-readable label. */
+  label: string;
+  /** Whether a higher outcome value is "good" (used to derive improves/worsens). */
+  higherIsBetter: boolean;
+  /** dayKey -> outcome value. */
+  byDay: Map<string, number>;
+}
+
+export interface CorrelationResult {
+  factorId: string;
+  factorName: string;
+  factorSource: string;
+  outcomeKey: string;
+  outcomeLabel: string;
+  factorPresentMean: number;
+  factorAbsentMean: number;
+  /** Signed difference (present − absent), in outcome units. */
+  meanDifference: number;
+  /** Cohen's d effect size (present vs absent). */
+  effectSize: number;
+  direction: 'improves' | 'worsens';
+  nPresent: number;
+  nAbsent: number;
+  /** Pre-rendered, caveated sentence including both sample sizes. */
+  message: string;
+}
+
+export interface CorrelateOptions {
+  /** Minimum days per group before a correlation is surfaced. Default 5. */
+  minPerGroup?: number;
+  /** Minimum |Cohen's d| before a correlation is surfaced. Default 0.2. */
+  minEffectSize?: number;
+  /** Max correlations returned overall. Default 12. */
+  maxResults?: number;
+  /** Keep only the strongest outcome per factor when true. Default true. */
+  bestOutcomePerFactor?: boolean;
+}
+
+// ─── Primitives ─────────────────────────────────────────────────────────────────
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Cohen's d effect size between two samples. Returns 0 when either group is too
+ * small to estimate variance. When neither group has within-group spread, the
+ * result saturates to ±4 (a sentinel "maximal" effect) so identical-value groups
+ * with different means are still ranked.
+ */
+export function cohensD(a: number[], b: number[]): number {
+  if (a.length < 2 || b.length < 2) return 0;
+  const ma = a.reduce((x, y) => x + y, 0) / a.length;
+  const mb = b.reduce((x, y) => x + y, 0) / b.length;
+  const va = a.reduce((acc, v) => acc + (v - ma) ** 2, 0) / (a.length - 1);
+  const vb = b.reduce((acc, v) => acc + (v - mb) ** 2, 0) / (b.length - 1);
+  const pooled = Math.sqrt(((a.length - 1) * va + (b.length - 1) * vb) / (a.length + b.length - 2));
+  if (pooled === 0) {
+    if (ma === mb) return 0;
+    return ma > mb ? 4 : -4;
+  }
+  return (ma - mb) / pooled;
+}
+
+/**
+ * Collapse a factor series into present/absent day sets.
+ * Boolean-like series (all 0/1) split on 1 vs 0. Numeric series split on the
+ * median of their non-zero values (high vs low / absent).
+ */
+export function splitByFactor(
+  series: FactorSeries,
+  dayKeys: string[]
+): { present: Set<string>; absent: Set<string> } {
+  const present = new Set<string>();
+  const absent = new Set<string>();
+  const values = dayKeys.map((dk) => series.byDay.get(dk) ?? 0);
+  const isBinary = values.every((v) => v === 0 || v === 1);
+  if (isBinary) {
+    for (const dk of dayKeys) {
+      ((series.byDay.get(dk) ?? 0) >= 1 ? present : absent).add(dk);
+    }
+    return { present, absent };
+  }
+  const nonZero = values.filter((v) => v > 0).sort((a, b) => a - b);
+  const median = nonZero.length ? nonZero[Math.floor(nonZero.length / 2)] : 0;
+  for (const dk of dayKeys) {
+    ((series.byDay.get(dk) ?? 0) >= median && median > 0 ? present : absent).add(dk);
+  }
+  return { present, absent };
+}
+
+// ─── Generic correlation ────────────────────────────────────────────────────────
+
+const DEFAULTS: Required<CorrelateOptions> = {
+  minPerGroup: 5,
+  minEffectSize: 0.2,
+  maxResults: 12,
+  bestOutcomePerFactor: true,
+};
+
+/**
+ * Correlate every factor against every outcome via present/absent group means +
+ * Cohen's d. Returns results ranked by |effect size|, filtered by the options'
+ * minimum group size and minimum effect.
+ */
+export function correlateFactorsToOutcomes(
+  factors: FactorSeries[],
+  outcomes: OutcomeSeries[],
+  dayKeys: string[],
+  options: CorrelateOptions = {}
+): CorrelationResult[] {
+  const opts = { ...DEFAULTS, ...options };
+  const results: CorrelationResult[] = [];
+
+  for (const f of factors) {
+    const { present, absent } = splitByFactor(f, dayKeys);
+    for (const outcome of outcomes) {
+      const presentVals: number[] = [];
+      const absentVals: number[] = [];
+      for (const dk of present) {
+        const v = outcome.byDay.get(dk);
+        if (typeof v === 'number' && Number.isFinite(v)) presentVals.push(v);
+      }
+      for (const dk of absent) {
+        const v = outcome.byDay.get(dk);
+        if (typeof v === 'number' && Number.isFinite(v)) absentVals.push(v);
+      }
+      if (presentVals.length < opts.minPerGroup || absentVals.length < opts.minPerGroup) continue;
+
+      const d = cohensD(presentVals, absentVals);
+      if (Math.abs(d) < opts.minEffectSize) continue;
+
+      const mPresent = presentVals.reduce((a, b) => a + b, 0) / presentVals.length;
+      const mAbsent = absentVals.reduce((a, b) => a + b, 0) / absentVals.length;
+      const diff = mPresent - mAbsent;
+      const improves = outcome.higherIsBetter ? diff > 0 : diff < 0;
+      const dirWord = diff > 0 ? 'higher' : 'lower';
+      const magnitude = Math.abs(round1(diff));
+
+      const message =
+        `On days with "${f.name}", your ${outcome.label} is ${magnitude} ${dirWord} ` +
+        `(n=${presentVals.length} vs ${absentVals.length}). Correlation, not proof.`;
+
+      results.push({
+        factorId: f.id,
+        factorName: f.name,
+        factorSource: f.source,
+        outcomeKey: outcome.key,
+        outcomeLabel: outcome.label,
+        factorPresentMean: round1(mPresent),
+        factorAbsentMean: round1(mAbsent),
+        meanDifference: round1(diff),
+        effectSize: round1(d),
+        direction: improves ? 'improves' : 'worsens',
+        nPresent: presentVals.length,
+        nAbsent: absentVals.length,
+        message,
+      });
+    }
+  }
+
+  let ranked = results;
+  if (opts.bestOutcomePerFactor) {
+    const bestPerFactor = new Map<string, CorrelationResult>();
+    for (const r of results) {
+      const prev = bestPerFactor.get(r.factorId);
+      if (!prev || Math.abs(r.effectSize) > Math.abs(prev.effectSize)) bestPerFactor.set(r.factorId, r);
+    }
+    ranked = Array.from(bestPerFactor.values());
+  }
+
+  return ranked
+    .sort((a, b) => Math.abs(b.effectSize) - Math.abs(a.effectSize))
+    .slice(0, opts.maxResults);
+}

--- a/src/server/services/insightsService.test.ts
+++ b/src/server/services/insightsService.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import { format, parseISO, subDays } from 'date-fns';
+import type { WellbeingEntry } from '../../models/persistenceTypes';
+import { correlateFactorsToOutcomes, cohensD, type FactorSeries, type OutcomeSeries } from './correlationEngine';
+import {
+  buildOutcomeSeries,
+  buildFactorSeries,
+  computeMetricPredictions,
+  computeDiscoveries,
+  computeInsightsOverview,
+  type InsightsSources,
+} from './insightsService';
+
+const REF = '2026-03-31';
+
+function lastNDayKeys(referenceDayKey: string, n: number): string[] {
+  const out: string[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    out.push(format(subDays(parseISO(referenceDayKey), i), 'yyyy-MM-dd'));
+  }
+  return out;
+}
+
+function we(dayKey: string, metricKey: string, value: number, timeOfDay: 'morning' | 'evening' = 'morning'): WellbeingEntry {
+  return {
+    id: `${dayKey}-${metricKey}-${timeOfDay}`,
+    userId: 'u1',
+    timestampUtc: `${dayKey}T12:00:00.000Z`,
+    dayKey,
+    timeOfDay,
+    metricKey: metricKey as WellbeingEntry['metricKey'],
+    value,
+    source: 'test',
+    createdAt: `${dayKey}T12:00:00.000Z`,
+    updatedAt: `${dayKey}T12:00:00.000Z`,
+  };
+}
+
+function emptySources(over: Partial<InsightsSources> = {}): InsightsSources {
+  return {
+    wellbeingEntries: [],
+    habits: [],
+    habitEntries: [],
+    medications: [],
+    medicationLogs: [],
+    supplements: [],
+    supplementLogs: [],
+    symptoms: [],
+    symptomLogs: [],
+    ...over,
+  };
+}
+
+describe('cohensD', () => {
+  it('returns 0 when a group is too small', () => {
+    expect(cohensD([1], [1, 2, 3])).toBe(0);
+  });
+
+  it('is positive when the first group has a higher mean', () => {
+    expect(cohensD([5, 5, 5, 4], [1, 1, 2, 1])).toBeGreaterThan(0);
+  });
+
+  it('saturates to ±4 when groups have no spread but different means', () => {
+    expect(cohensD([5, 5, 5], [1, 1, 1])).toBe(4);
+    expect(cohensD([1, 1, 1], [5, 5, 5])).toBe(-4);
+  });
+});
+
+describe('correlateFactorsToOutcomes', () => {
+  it('surfaces a clear factor→outcome relationship', () => {
+    const dayKeys = lastNDayKeys(REF, 20);
+    // factor present on even-index days; outcome high on those same days.
+    const factorByDay = new Map<string, number>();
+    const outcomeByDay = new Map<string, number>();
+    dayKeys.forEach((dk, i) => {
+      const present = i % 2 === 0;
+      factorByDay.set(dk, present ? 1 : 0);
+      outcomeByDay.set(dk, present ? 5 : 2);
+    });
+    const factors: FactorSeries[] = [{ id: 'f1', name: 'Exercise', source: 'habit', byDay: factorByDay }];
+    const outcomes: OutcomeSeries[] = [{ key: 'mood', label: 'mood', higherIsBetter: true, byDay: outcomeByDay }];
+
+    const results = correlateFactorsToOutcomes(factors, outcomes, dayKeys);
+    expect(results).toHaveLength(1);
+    expect(results[0].factorId).toBe('f1');
+    expect(results[0].direction).toBe('improves');
+    expect(results[0].meanDifference).toBeGreaterThan(0);
+  });
+
+  it('drops relationships below the minimum group size', () => {
+    const dayKeys = lastNDayKeys(REF, 6);
+    const factorByDay = new Map<string, number>();
+    const outcomeByDay = new Map<string, number>();
+    dayKeys.forEach((dk, i) => {
+      factorByDay.set(dk, i === 0 ? 1 : 0); // only 1 "present" day
+      outcomeByDay.set(dk, i === 0 ? 5 : 2);
+    });
+    const factors: FactorSeries[] = [{ id: 'f1', name: 'Rare', source: 'habit', byDay: factorByDay }];
+    const outcomes: OutcomeSeries[] = [{ key: 'mood', label: 'mood', higherIsBetter: true, byDay: outcomeByDay }];
+    expect(correlateFactorsToOutcomes(factors, outcomes, dayKeys)).toHaveLength(0);
+  });
+});
+
+describe('buildOutcomeSeries', () => {
+  it('averages multiple same-day entries per metric and ignores non-outcome keys', () => {
+    const dayKeys = lastNDayKeys(REF, 2);
+    const entries = [
+      we(dayKeys[0], 'mood', 4, 'morning'),
+      we(dayKeys[0], 'mood', 2, 'evening'),
+      we(dayKeys[0], 'weight', 180), // not an outcome metric
+    ];
+    const series = buildOutcomeSeries(entries, dayKeys);
+    const mood = series.find((s) => s.key === 'mood');
+    expect(mood).toBeDefined();
+    expect(mood!.byDay.get(dayKeys[0])).toBe(3); // (4 + 2) / 2
+    expect(series.find((s) => s.key === 'weight')).toBeUndefined();
+  });
+});
+
+describe('buildFactorSeries', () => {
+  it('builds taken-series for medications', () => {
+    const dayKeys = lastNDayKeys(REF, 5);
+    const sources = emptySources({
+      medications: [{
+        id: 'm1', userId: 'u1', householdId: 'h1', name: 'Lamotrigine', active: true,
+        createdAt: '', updatedAt: '',
+      } as InsightsSources['medications'][number]],
+      medicationLogs: dayKeys.map((dk, i) => ({
+        id: `l${i}`, userId: 'u1', householdId: 'h1', medicationId: 'm1', dayKey: dk,
+        taken: i % 2 === 0, timestampUtc: '', createdAt: '', updatedAt: '',
+      })),
+    });
+    const factors = buildFactorSeries(sources, 'America/New_York', dayKeys);
+    const med = factors.find((f) => f.source === 'medication');
+    expect(med).toBeDefined();
+    expect(med!.name).toBe('Lamotrigine');
+    expect(med!.byDay.get(dayKeys[0])).toBe(1);
+    expect(med!.byDay.get(dayKeys[1])).toBe(0);
+  });
+});
+
+describe('computeMetricPredictions', () => {
+  it('detects an improving trend for a higher-is-better metric', () => {
+    const dayKeys = lastNDayKeys(REF, 14);
+    const byDay = new Map<string, number>();
+    dayKeys.forEach((dk, i) => byDay.set(dk, 1 + i * 0.2)); // steadily rising
+    const outcomes: OutcomeSeries[] = [{ key: 'mood', label: 'mood', higherIsBetter: true, byDay }];
+    const [pred] = computeMetricPredictions(outcomes, dayKeys, 14);
+    expect(pred.direction).toBe('improving');
+    expect(pred.slopePerWeek).toBeGreaterThan(0);
+    expect(pred.predictedValue).toBeGreaterThan(pred.currentValue ?? 0);
+    expect(pred.confidence).toBe('high');
+  });
+
+  it('flags a rising bad metric as declining', () => {
+    const dayKeys = lastNDayKeys(REF, 14);
+    const byDay = new Map<string, number>();
+    dayKeys.forEach((dk, i) => byDay.set(dk, 1 + i * 0.2)); // anxiety rising = bad
+    const outcomes: OutcomeSeries[] = [{ key: 'anxiety', label: 'anxiety', higherIsBetter: false, byDay }];
+    const [pred] = computeMetricPredictions(outcomes, dayKeys, 14);
+    expect(pred.direction).toBe('declining');
+  });
+
+  it('returns low-confidence null predictions when data is sparse', () => {
+    const dayKeys = lastNDayKeys(REF, 10);
+    const byDay = new Map<string, number>();
+    byDay.set(dayKeys[0], 3);
+    byDay.set(dayKeys[1], 4); // only 2 points
+    const outcomes: OutcomeSeries[] = [{ key: 'mood', label: 'mood', higherIsBetter: true, byDay }];
+    const [pred] = computeMetricPredictions(outcomes, dayKeys, 14);
+    expect(pred.confidence).toBe('low');
+    expect(pred.predictedValue).toBeNull();
+  });
+});
+
+describe('computeDiscoveries', () => {
+  it('always returns at least one discovery (info fallback)', () => {
+    expect(computeDiscoveries([], [], 0)).toHaveLength(1);
+    expect(computeDiscoveries([], [], 0)[0].type).toBe('info');
+  });
+
+  it('emits a coverage milestone', () => {
+    const discoveries = computeDiscoveries([], [], 35);
+    expect(discoveries.some((d) => d.type === 'milestone' && d.id === 'milestone-30')).toBe(true);
+  });
+});
+
+describe('computeInsightsOverview', () => {
+  it('produces a coherent overview from a habit↔mood relationship', () => {
+    const dayKeys = lastNDayKeys(REF, 20);
+    const wellbeingEntries: WellbeingEntry[] = [];
+    dayKeys.forEach((dk, i) => {
+      wellbeingEntries.push(we(dk, 'mood', i % 2 === 0 ? 5 : 2));
+      wellbeingEntries.push(we(dk, 'caffeineMg', i % 2 === 0 ? 0 : 300));
+    });
+    const overview = computeInsightsOverview(emptySources({ wellbeingEntries }), REF, 20, 'America/New_York');
+    expect(overview.daysWithCheckins).toBe(20);
+    expect(overview.metricAverages.some((m) => m.metricKey === 'mood')).toBe(true);
+    expect(overview.discoveries.length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/services/insightsService.ts
+++ b/src/server/services/insightsService.ts
@@ -614,6 +614,41 @@ export function computeInsightsOverview(
   };
 }
 
+/**
+ * Correlations for a full source bundle, optionally restricted to certain factor
+ * sources (e.g. ['habit'] for the Habit tab, ['medication'] for Medications).
+ */
+export function computeCorrelationsForSources(
+  sources: InsightsSources,
+  referenceDayKey: string,
+  days: number,
+  timeZone: string,
+  factorSources?: string[]
+): CorrelationResult[] {
+  const startKey = startDayKeyForRange(referenceDayKey, days);
+  const dayKeys = generateDayKeyRange(startKey, referenceDayKey);
+  const outcomes = buildOutcomeSeries(sources.wellbeingEntries, dayKeys);
+  let factors = buildFactorSeries(sources, timeZone, dayKeys);
+  if (factorSources && factorSources.length > 0) {
+    const allowed = new Set(factorSources);
+    factors = factors.filter((f) => allowed.has(f.source));
+  }
+  return computeInsightsCorrelations(factors, outcomes, dayKeys);
+}
+
+/** Linear-trend predictions for a full source bundle. */
+export function computePredictionsForSources(
+  sources: InsightsSources,
+  referenceDayKey: string,
+  days: number,
+  horizonDays = DEFAULT_PREDICTION_HORIZON_DAYS
+): MetricPrediction[] {
+  const startKey = startDayKeyForRange(referenceDayKey, days);
+  const dayKeys = generateDayKeyRange(startKey, referenceDayKey);
+  const outcomes = buildOutcomeSeries(sources.wellbeingEntries, dayKeys);
+  return computeMetricPredictions(outcomes, dayKeys, horizonDays);
+}
+
 export function computeMedicationInsights(
   sources: InsightsSources,
   referenceDayKey: string,

--- a/src/server/services/insightsService.ts
+++ b/src/server/services/insightsService.ts
@@ -1,0 +1,670 @@
+/**
+ * Insights Service
+ *
+ * Cross-domain analytics computed entirely from canonical truth at read time —
+ * nothing is stored. Powers the Insights page tabs:
+ *   • Overview      — headline averages, discoveries, milestones
+ *   • Correlations  — factor↔outcome relationships (Cohen's d, via correlationEngine)
+ *   • Predictions   — simple linear-trend projections per wellbeing metric
+ *   • Medications   — per-medication adherence + correlations to wellbeing
+ *
+ * Statistical approach mirrors the Sleep Analytics service: a factor↔outcome
+ * relationship is a present/absent group split + Cohen's d effect size, always
+ * surfaced as correlation (never causation). Predictions are ordinary
+ * least-squares trend lines — intentionally simple and clearly caveated.
+ *
+ * All exported `compute*` functions are PURE (inputs → output, no I/O) so they
+ * are deterministically unit-testable and can back a future AI prompt layer.
+ */
+
+import { parseISO, subDays, format } from 'date-fns';
+import type {
+  Habit,
+  HabitEntry,
+  WellbeingEntry,
+  Medication,
+  MedicationLog,
+  Supplement,
+  SupplementLog,
+  Symptom,
+  SymptomLog,
+} from '../../models/persistenceTypes';
+import { buildDayStatesByHabit } from './analyticsService';
+import { isTrackableHabit } from './scheduleEngine';
+import {
+  correlateFactorsToOutcomes,
+  type FactorSeries,
+  type OutcomeSeries,
+  type CorrelationResult,
+} from './correlationEngine';
+
+// ─── Tunables ───────────────────────────────────────────────────────────────────
+
+const MIN_PER_GROUP = 5;
+const MIN_EFFECT_SIZE = 0.2;
+const MAX_CORRELATIONS = 12;
+const MIN_DAYS_FOR_PREDICTION = 5;
+const DEFAULT_PREDICTION_HORIZON_DAYS = 14;
+/** Slope (per week, on a 1-5 scale) below which a trend is "stable". */
+const STABLE_SLOPE_EPSILON = 0.05;
+
+// ─── Outcome metric registry ─────────────────────────────────────────────────────
+
+/**
+ * Subjective wellbeing metrics treated as OUTCOMES (and prediction targets).
+ * `higherIsBetter` drives improves/worsens + improving/declining wording.
+ */
+export const OUTCOME_METRICS: Array<{ key: string; label: string; higherIsBetter: boolean }> = [
+  { key: 'mood', label: 'mood', higherIsBetter: true },
+  { key: 'energy', label: 'energy', higherIsBetter: true },
+  { key: 'calm', label: 'calm', higherIsBetter: true },
+  { key: 'motivation', label: 'motivation', higherIsBetter: true },
+  { key: 'confidence', label: 'confidence', higherIsBetter: true },
+  { key: 'socialBattery', label: 'social battery', higherIsBetter: true },
+  { key: 'focus', label: 'focus', higherIsBetter: true },
+  { key: 'productivity', label: 'productivity', higherIsBetter: true },
+  { key: 'enjoyment', label: 'enjoyment', higherIsBetter: true },
+  { key: 'socialConnection', label: 'social connection', higherIsBetter: true },
+  { key: 'gratitude', label: 'gratitude', higherIsBetter: true },
+  { key: 'fulfillment', label: 'fulfillment', higherIsBetter: true },
+  { key: 'satisfaction', label: 'satisfaction', higherIsBetter: true },
+  { key: 'anxiety', label: 'anxiety', higherIsBetter: false },
+  { key: 'stress', label: 'stress', higherIsBetter: false },
+  { key: 'lowMood', label: 'low mood', higherIsBetter: false },
+  { key: 'depression', label: 'depression', higherIsBetter: false },
+  { key: 'brainFog', label: 'brain fog', higherIsBetter: false },
+  { key: 'irritability', label: 'irritability', higherIsBetter: false },
+];
+
+const OUTCOME_BY_KEY = new Map(OUTCOME_METRICS.map((m) => [m.key, m]));
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MetricPredictionPoint {
+  dayKey: string;
+  value: number;
+}
+
+export interface MetricPrediction {
+  metricKey: string;
+  label: string;
+  higherIsBetter: boolean;
+  sampleSize: number;
+  /** Recent average (last up-to-7 logged days). */
+  currentValue: number | null;
+  /** Signed change per week implied by the trend line. */
+  slopePerWeek: number | null;
+  /** Projected value `horizonDays` after the last logged day. */
+  predictedValue: number | null;
+  horizonDays: number;
+  direction: 'improving' | 'declining' | 'stable' | null;
+  confidence: 'low' | 'medium' | 'high';
+  /** R² of the fit (0-1), for transparency. */
+  fitQuality: number | null;
+  /** Observed daily averages used for the fit, for charting. */
+  trend: MetricPredictionPoint[];
+}
+
+export interface Discovery {
+  id: string;
+  type: 'positive' | 'negative' | 'milestone' | 'info';
+  title: string;
+  message: string;
+}
+
+export interface MetricAverage {
+  metricKey: string;
+  label: string;
+  average: number;
+  sampleSize: number;
+  higherIsBetter: boolean;
+}
+
+export interface InsightsOverview {
+  rangeDays: number;
+  daysWithCheckins: number;
+  metricAverages: MetricAverage[];
+  topCorrelations: CorrelationResult[];
+  discoveries: Discovery[];
+}
+
+export interface MedicationAdherence {
+  medicationId: string;
+  name: string;
+  dosage: string | null;
+  takenDays: number;
+  loggedDays: number;
+  adherencePercent: number | null;
+  currentTakenStreak: number;
+}
+
+export interface MedicationInsights {
+  rangeDays: number;
+  adherence: MedicationAdherence[];
+  correlations: CorrelationResult[];
+}
+
+export interface AllInsightsData {
+  factors: FactorSeries[];
+  outcomes: OutcomeSeries[];
+  dayKeys: string[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function toNum(value: number | string | null | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) return Number(value);
+  return null;
+}
+
+export function generateDayKeyRange(startDayKey: string, endDayKey: string): string[] {
+  const days: string[] = [];
+  const start = parseISO(startDayKey);
+  const end = parseISO(endDayKey);
+  for (let d = start; d <= end; d = new Date(d.getTime() + 86400000)) {
+    days.push(format(d, 'yyyy-MM-dd'));
+  }
+  return days;
+}
+
+export function startDayKeyForRange(referenceDayKey: string, days: number): string {
+  return format(subDays(parseISO(referenceDayKey), days - 1), 'yyyy-MM-dd');
+}
+
+// ─── Outcome series (subjective wellbeing metrics, averaged per day) ───────────────
+
+export function buildOutcomeSeries(wellbeingEntries: WellbeingEntry[], dayKeys: string[]): OutcomeSeries[] {
+  const dayKeySet = new Set(dayKeys);
+  // metricKey -> dayKey -> values[]
+  const acc = new Map<string, Map<string, number[]>>();
+  for (const e of wellbeingEntries) {
+    if (!OUTCOME_BY_KEY.has(e.metricKey)) continue;
+    if (!dayKeySet.has(e.dayKey)) continue;
+    const num = toNum(e.value);
+    if (num === null) continue;
+    let byDay = acc.get(e.metricKey);
+    if (!byDay) {
+      byDay = new Map();
+      acc.set(e.metricKey, byDay);
+    }
+    const arr = byDay.get(e.dayKey) ?? [];
+    arr.push(num);
+    byDay.set(e.dayKey, arr);
+  }
+
+  const series: OutcomeSeries[] = [];
+  for (const metric of OUTCOME_METRICS) {
+    const byDayValues = acc.get(metric.key);
+    if (!byDayValues || byDayValues.size === 0) continue;
+    const byDay = new Map<string, number>();
+    for (const [dk, vals] of byDayValues) {
+      const m = mean(vals);
+      if (m !== null) byDay.set(dk, m);
+    }
+    series.push({ key: metric.key, label: metric.label, higherIsBetter: metric.higherIsBetter, byDay });
+  }
+  return series;
+}
+
+// ─── Factor series (habits, meds, supplements, symptoms, behavioral factors) ──────
+
+/** Behavioral factors recorded directly as wellbeing metric keys. */
+const WELLBEING_FACTOR_KEYS: Array<{ key: string; name: string }> = [
+  { key: 'factorPhoneInBed', name: 'Phone in bed' },
+  { key: 'factorWindDown', name: 'Wind-down routine' },
+  { key: 'factorLateNightEating', name: 'Late-night eating' },
+  { key: 'factorCaffeineAfter12', name: 'Caffeine after noon' },
+  { key: 'factorBlueLightMinutes', name: 'Blue light after target' },
+  { key: 'sleepAidUsed', name: 'Sleep aid used' },
+  { key: 'caffeineMg', name: 'Caffeine intake' },
+];
+
+export interface InsightsSources {
+  wellbeingEntries: WellbeingEntry[];
+  habits: Habit[];
+  habitEntries: HabitEntry[];
+  medications: Medication[];
+  medicationLogs: MedicationLog[];
+  supplements: Supplement[];
+  supplementLogs: SupplementLog[];
+  symptoms: Symptom[];
+  symptomLogs: SymptomLog[];
+}
+
+function pivotWellbeing(wellbeingEntries: WellbeingEntry[]): Map<string, Record<string, number>> {
+  const byDay = new Map<string, Record<string, number>>();
+  for (const e of wellbeingEntries) {
+    const num = toNum(e.value);
+    if (num === null) continue;
+    const rec = byDay.get(e.dayKey) ?? {};
+    rec[e.metricKey] = num;
+    byDay.set(e.dayKey, rec);
+  }
+  return byDay;
+}
+
+export function buildFactorSeries(
+  sources: InsightsSources,
+  timeZone: string,
+  dayKeys: string[]
+): FactorSeries[] {
+  const dayKeySet = new Set(dayKeys);
+  const series: FactorSeries[] = [];
+
+  // (a) behavioral wellbeing factors
+  const wellbeingByDay = pivotWellbeing(sources.wellbeingEntries);
+  for (const f of WELLBEING_FACTOR_KEYS) {
+    const byDay = new Map<string, number>();
+    for (const dk of dayKeys) {
+      const rec = wellbeingByDay.get(dk);
+      if (rec && f.key in rec) byDay.set(dk, rec[f.key]);
+    }
+    if (byDay.size > 0) series.push({ id: f.key, name: f.name, source: 'wellbeingFactor', byDay });
+  }
+
+  // (b) tracked habits
+  const dayStates = buildDayStatesByHabit(sources.habitEntries, timeZone);
+  for (const habit of sources.habits.filter(isTrackableHabit)) {
+    const states = dayStates.get(habit.id);
+    if (!states) continue;
+    const byDay = new Map<string, number>();
+    for (const dk of dayKeys) {
+      const st = states.get(dk);
+      if (!st) continue;
+      byDay.set(dk, habit.goal?.type === 'boolean' ? (st.completed ? 1 : 0) : st.value);
+    }
+    if (byDay.size > 0) series.push({ id: habit.id, name: habit.name, source: 'habit', byDay });
+  }
+
+  // (c) medications (taken = 1)
+  const medNames = new Map(sources.medications.map((m) => [m.id, m.name]));
+  series.push(...buildTakenSeries(sources.medicationLogs, dayKeySet, medNames, 'medication', (l) => l.medicationId));
+
+  // (d) supplements (taken = 1)
+  const supNames = new Map(sources.supplements.map((s) => [s.id, s.name]));
+  series.push(...buildTakenSeries(sources.supplementLogs, dayKeySet, supNames, 'supplement', (l) => l.supplementId));
+
+  // (e) symptoms (severity 1-5)
+  const symNames = new Map(sources.symptoms.map((s) => [s.id, s.name]));
+  const symByEntity = new Map<string, Map<string, number>>();
+  for (const log of sources.symptomLogs) {
+    if (!dayKeySet.has(log.dayKey)) continue;
+    let byDay = symByEntity.get(log.symptomId);
+    if (!byDay) {
+      byDay = new Map();
+      symByEntity.set(log.symptomId, byDay);
+    }
+    byDay.set(log.dayKey, log.severity);
+  }
+  for (const [symptomId, byDay] of symByEntity) {
+    if (byDay.size > 0) {
+      series.push({ id: symptomId, name: symNames.get(symptomId) ?? 'Symptom', source: 'symptom', byDay });
+    }
+  }
+
+  return series;
+}
+
+function buildTakenSeries<T extends { dayKey: string; taken: boolean }>(
+  logs: T[],
+  dayKeySet: Set<string>,
+  names: Map<string, string>,
+  source: string,
+  entityId: (log: T) => string
+): FactorSeries[] {
+  const byEntity = new Map<string, Map<string, number>>();
+  for (const log of logs) {
+    if (!dayKeySet.has(log.dayKey)) continue;
+    const id = entityId(log);
+    let byDay = byEntity.get(id);
+    if (!byDay) {
+      byDay = new Map();
+      byEntity.set(id, byDay);
+    }
+    byDay.set(log.dayKey, log.taken ? 1 : 0);
+  }
+  const out: FactorSeries[] = [];
+  for (const [id, byDay] of byEntity) {
+    if (byDay.size > 0) out.push({ id, name: names.get(id) ?? source, source, byDay });
+  }
+  return out;
+}
+
+// ─── Correlations ────────────────────────────────────────────────────────────
+
+export function computeInsightsCorrelations(
+  factors: FactorSeries[],
+  outcomes: OutcomeSeries[],
+  dayKeys: string[],
+  maxResults = MAX_CORRELATIONS
+): CorrelationResult[] {
+  return correlateFactorsToOutcomes(factors, outcomes, dayKeys, {
+    minPerGroup: MIN_PER_GROUP,
+    minEffectSize: MIN_EFFECT_SIZE,
+    maxResults,
+  });
+}
+
+// ─── Predictions (ordinary least squares) ────────────────────────────────────
+
+function linearFit(points: Array<{ x: number; y: number }>): { slope: number; intercept: number; r2: number } | null {
+  const n = points.length;
+  if (n < 2) return null;
+  let sx = 0;
+  let sy = 0;
+  let sxx = 0;
+  let sxy = 0;
+  for (const p of points) {
+    sx += p.x;
+    sy += p.y;
+    sxx += p.x * p.x;
+    sxy += p.x * p.y;
+  }
+  const denom = n * sxx - sx * sx;
+  if (denom === 0) return null;
+  const slope = (n * sxy - sx * sy) / denom;
+  const intercept = (sy - slope * sx) / n;
+  const meanY = sy / n;
+  let ssTot = 0;
+  let ssRes = 0;
+  for (const p of points) {
+    ssTot += (p.y - meanY) ** 2;
+    ssRes += (p.y - (slope * p.x + intercept)) ** 2;
+  }
+  const r2 = ssTot === 0 ? 0 : Math.max(0, 1 - ssRes / ssTot);
+  return { slope, intercept, r2 };
+}
+
+export function computeMetricPredictions(
+  outcomes: OutcomeSeries[],
+  dayKeys: string[],
+  horizonDays = DEFAULT_PREDICTION_HORIZON_DAYS
+): MetricPrediction[] {
+  const indexByDay = new Map(dayKeys.map((dk, i) => [dk, i]));
+  const predictions: MetricPrediction[] = [];
+
+  for (const outcome of outcomes) {
+    const trend: MetricPredictionPoint[] = [];
+    const points: Array<{ x: number; y: number }> = [];
+    for (const dk of dayKeys) {
+      const v = outcome.byDay.get(dk);
+      if (typeof v === 'number' && Number.isFinite(v)) {
+        const x = indexByDay.get(dk)!;
+        points.push({ x, y: v });
+        trend.push({ dayKey: dk, value: round1(v) });
+      }
+    }
+
+    const sampleSize = points.length;
+    const recent = trend.slice(-7).map((p) => p.value);
+    const currentValue = recent.length ? round1(recent.reduce((a, b) => a + b, 0) / recent.length) : null;
+
+    if (sampleSize < MIN_DAYS_FOR_PREDICTION) {
+      predictions.push({
+        metricKey: outcome.key,
+        label: outcome.label,
+        higherIsBetter: outcome.higherIsBetter,
+        sampleSize,
+        currentValue,
+        slopePerWeek: null,
+        predictedValue: null,
+        horizonDays,
+        direction: null,
+        confidence: 'low',
+        fitQuality: null,
+        trend,
+      });
+      continue;
+    }
+
+    const fit = linearFit(points);
+    if (!fit) {
+      predictions.push({
+        metricKey: outcome.key,
+        label: outcome.label,
+        higherIsBetter: outcome.higherIsBetter,
+        sampleSize,
+        currentValue,
+        slopePerWeek: 0,
+        predictedValue: currentValue,
+        horizonDays,
+        direction: 'stable',
+        confidence: 'low',
+        fitQuality: null,
+        trend,
+      });
+      continue;
+    }
+
+    const slopePerWeek = round1(fit.slope * 7);
+    const lastX = points[points.length - 1].x;
+    const predictedValue = round1(fit.slope * (lastX + horizonDays) + fit.intercept);
+
+    let direction: MetricPrediction['direction'];
+    if (Math.abs(slopePerWeek) < STABLE_SLOPE_EPSILON) {
+      direction = 'stable';
+    } else {
+      const valueRising = fit.slope > 0;
+      const improving = valueRising === outcome.higherIsBetter;
+      direction = improving ? 'improving' : 'declining';
+    }
+
+    let confidence: MetricPrediction['confidence'] = 'medium';
+    if (sampleSize < 7) confidence = 'low';
+    else if (sampleSize >= 14 && fit.r2 >= 0.3) confidence = 'high';
+
+    predictions.push({
+      metricKey: outcome.key,
+      label: outcome.label,
+      higherIsBetter: outcome.higherIsBetter,
+      sampleSize,
+      currentValue,
+      slopePerWeek,
+      predictedValue,
+      horizonDays,
+      direction,
+      confidence,
+      fitQuality: round1(fit.r2),
+      trend,
+    });
+  }
+
+  // Most data first — strongest signals at the top.
+  return predictions.sort((a, b) => b.sampleSize - a.sampleSize);
+}
+
+// ─── Discoveries / milestones ─────────────────────────────────────────────────
+
+export function computeDiscoveries(
+  correlations: CorrelationResult[],
+  predictions: MetricPrediction[],
+  daysWithCheckins: number
+): Discovery[] {
+  const discoveries: Discovery[] = [];
+
+  const topPositive = correlations.find((c) => c.direction === 'improves');
+  if (topPositive) {
+    discoveries.push({
+      id: `corr-pos-${topPositive.factorId}-${topPositive.outcomeKey}`,
+      type: 'positive',
+      title: `${topPositive.factorName} is linked to better ${topPositive.outcomeLabel}`,
+      message: topPositive.message,
+    });
+  }
+
+  const topNegative = correlations.find((c) => c.direction === 'worsens');
+  if (topNegative) {
+    discoveries.push({
+      id: `corr-neg-${topNegative.factorId}-${topNegative.outcomeKey}`,
+      type: 'negative',
+      title: `${topNegative.factorName} is linked to worse ${topNegative.outcomeLabel}`,
+      message: topNegative.message,
+    });
+  }
+
+  const improving = predictions
+    .filter((p) => p.direction === 'improving' && p.confidence !== 'low')
+    .sort((a, b) => Math.abs(b.slopePerWeek ?? 0) - Math.abs(a.slopePerWeek ?? 0))[0];
+  if (improving) {
+    discoveries.push({
+      id: `trend-up-${improving.metricKey}`,
+      type: 'positive',
+      title: `Your ${improving.label} is trending up`,
+      message: `${improving.label} has been improving by about ${Math.abs(improving.slopePerWeek ?? 0)}/week over this window.`,
+    });
+  }
+
+  const declining = predictions
+    .filter((p) => p.direction === 'declining' && p.confidence !== 'low')
+    .sort((a, b) => Math.abs(b.slopePerWeek ?? 0) - Math.abs(a.slopePerWeek ?? 0))[0];
+  if (declining) {
+    discoveries.push({
+      id: `trend-down-${declining.metricKey}`,
+      type: 'negative',
+      title: `Your ${declining.label} is trending down`,
+      message: `${declining.label} has been declining by about ${Math.abs(declining.slopePerWeek ?? 0)}/week over this window. Worth a closer look.`,
+    });
+  }
+
+  // Coverage milestone — largest threshold reached.
+  const milestone = [100, 60, 30, 14, 7].find((t) => daysWithCheckins >= t);
+  if (milestone) {
+    discoveries.push({
+      id: `milestone-${milestone}`,
+      type: 'milestone',
+      title: `${milestone}+ days of check-ins`,
+      message: `You've logged wellbeing check-ins on ${daysWithCheckins} days. More data means sharper insights.`,
+    });
+  }
+
+  if (discoveries.length === 0) {
+    discoveries.push({
+      id: 'no-data',
+      type: 'info',
+      title: 'Keep checking in',
+      message: 'Log a few more morning and evening check-ins to start surfacing patterns and predictions.',
+    });
+  }
+
+  return discoveries;
+}
+
+// ─── Top-level assemblies ──────────────────────────────────────────────────────
+
+function countDaysWithCheckins(wellbeingEntries: WellbeingEntry[], dayKeys: string[]): number {
+  const dayKeySet = new Set(dayKeys);
+  const days = new Set<string>();
+  for (const e of wellbeingEntries) {
+    if (dayKeySet.has(e.dayKey) && OUTCOME_BY_KEY.has(e.metricKey) && toNum(e.value) !== null) {
+      days.add(e.dayKey);
+    }
+  }
+  return days.size;
+}
+
+export function computeMetricAverages(outcomes: OutcomeSeries[]): MetricAverage[] {
+  const averages: MetricAverage[] = [];
+  for (const o of outcomes) {
+    const vals = Array.from(o.byDay.values());
+    const m = mean(vals);
+    if (m === null) continue;
+    averages.push({
+      metricKey: o.key,
+      label: o.label,
+      average: round1(m),
+      sampleSize: vals.length,
+      higherIsBetter: o.higherIsBetter,
+    });
+  }
+  return averages.sort((a, b) => b.sampleSize - a.sampleSize);
+}
+
+export function computeInsightsOverview(
+  sources: InsightsSources,
+  referenceDayKey: string,
+  days: number,
+  timeZone: string
+): InsightsOverview {
+  const startKey = startDayKeyForRange(referenceDayKey, days);
+  const dayKeys = generateDayKeyRange(startKey, referenceDayKey);
+
+  const outcomes = buildOutcomeSeries(sources.wellbeingEntries, dayKeys);
+  const factors = buildFactorSeries(sources, timeZone, dayKeys);
+  const correlations = computeInsightsCorrelations(factors, outcomes, dayKeys);
+  const predictions = computeMetricPredictions(outcomes, dayKeys);
+  const daysWithCheckins = countDaysWithCheckins(sources.wellbeingEntries, dayKeys);
+  const discoveries = computeDiscoveries(correlations, predictions, daysWithCheckins);
+
+  return {
+    rangeDays: days,
+    daysWithCheckins,
+    metricAverages: computeMetricAverages(outcomes),
+    topCorrelations: correlations.slice(0, 5),
+    discoveries,
+  };
+}
+
+export function computeMedicationInsights(
+  sources: InsightsSources,
+  referenceDayKey: string,
+  days: number,
+  timeZone: string
+): MedicationInsights {
+  const startKey = startDayKeyForRange(referenceDayKey, days);
+  const dayKeys = generateDayKeyRange(startKey, referenceDayKey);
+  const dayKeySet = new Set(dayKeys);
+
+  // Per-medication adherence.
+  const logsByMed = new Map<string, MedicationLog[]>();
+  for (const log of sources.medicationLogs) {
+    if (!dayKeySet.has(log.dayKey)) continue;
+    const arr = logsByMed.get(log.medicationId) ?? [];
+    arr.push(log);
+    logsByMed.set(log.medicationId, arr);
+  }
+
+  const adherence: MedicationAdherence[] = sources.medications
+    .filter((m) => m.active)
+    .map((m) => {
+      const logs = (logsByMed.get(m.id) ?? []).slice().sort((a, b) => a.dayKey.localeCompare(b.dayKey));
+      const loggedDays = logs.length;
+      const takenDays = logs.filter((l) => l.taken).length;
+      // current streak: trailing run of taken days
+      let currentTakenStreak = 0;
+      for (let i = logs.length - 1; i >= 0; i--) {
+        if (logs[i].taken) currentTakenStreak += 1;
+        else break;
+      }
+      return {
+        medicationId: m.id,
+        name: m.name,
+        dosage: m.dosage ?? null,
+        takenDays,
+        loggedDays,
+        adherencePercent: loggedDays > 0 ? Math.round((takenDays / loggedDays) * 100) : null,
+        currentTakenStreak,
+      };
+    });
+
+  // Correlations limited to medication factors against wellbeing outcomes.
+  const outcomes = buildOutcomeSeries(sources.wellbeingEntries, dayKeys);
+  const allFactors = buildFactorSeries(sources, timeZone, dayKeys);
+  const medFactors = allFactors.filter((f) => f.source === 'medication');
+  const correlations = correlateFactorsToOutcomes(medFactors, outcomes, dayKeys, {
+    minPerGroup: MIN_PER_GROUP,
+    minEffectSize: MIN_EFFECT_SIZE,
+    maxResults: MAX_CORRELATIONS,
+  });
+
+  return { rangeDays: days, adherence, correlations };
+}

--- a/src/server/services/sleepAnalyticsService.ts
+++ b/src/server/services/sleepAnalyticsService.ts
@@ -36,6 +36,7 @@ import { parseISO, subDays, format, getISOWeek, getISOWeekYear } from 'date-fns'
 import type { Habit, HabitEntry, Category, WellbeingEntry } from '../../models/persistenceTypes';
 import { buildDayStatesByHabit } from './analyticsService';
 import { isTrackableHabit } from './scheduleEngine';
+import { cohensD, splitByFactor } from './correlationEngine';
 
 // ─── Tunable constants ─────────────────────────────────────────────────────────
 
@@ -537,42 +538,6 @@ const OUTCOMES: Array<{ key: 'appleSleepScore' | 'sleepQuality' | 'latencyMinute
   { key: 'sleepQuality', field: 'sleepQuality0to4', higherIsBetter: true, unitLabel: 'pts (0-4)' },
   { key: 'latencyMinutes', field: 'latencyMinutes', higherIsBetter: false, unitLabel: 'min' },
 ];
-
-function cohensD(a: number[], b: number[]): number {
-  if (a.length < 2 || b.length < 2) return 0;
-  const ma = a.reduce((x, y) => x + y, 0) / a.length;
-  const mb = b.reduce((x, y) => x + y, 0) / b.length;
-  const va = a.reduce((acc, v) => acc + (v - ma) ** 2, 0) / (a.length - 1);
-  const vb = b.reduce((acc, v) => acc + (v - mb) ** 2, 0) / (b.length - 1);
-  const pooled = Math.sqrt(((a.length - 1) * va + (b.length - 1) * vb) / (a.length + b.length - 2));
-  if (pooled === 0) {
-    // No within-group spread: identical means → no effect; differing means → maximal.
-    if (ma === mb) return 0;
-    return ma > mb ? 4 : -4;
-  }
-  return (ma - mb) / pooled;
-}
-
-/** Collapse a factor series into present/absent night sets via median split. */
-function splitByFactor(series: FactorSeries, dayKeys: string[]): { present: Set<string>; absent: Set<string> } {
-  const present = new Set<string>();
-  const absent = new Set<string>();
-  // boolean-like if all values are 0/1
-  const values = dayKeys.map((dk) => series.byDay.get(dk) ?? 0);
-  const isBinary = values.every((v) => v === 0 || v === 1);
-  if (isBinary) {
-    for (const dk of dayKeys) {
-      ((series.byDay.get(dk) ?? 0) >= 1 ? present : absent).add(dk);
-    }
-    return { present, absent };
-  }
-  const nonZero = values.filter((v) => v > 0).sort((a, b) => a - b);
-  const median = nonZero.length ? nonZero[Math.floor(nonZero.length / 2)] : 0;
-  for (const dk of dayKeys) {
-    ((series.byDay.get(dk) ?? 0) >= median && median > 0 ? present : absent).add(dk);
-  }
-  return { present, absent };
-}
 
 function buildFactorSeries(
   wellbeingByDay: Map<string, Record<string, number>>,

--- a/src/shared/insightsAiReview.ts
+++ b/src/shared/insightsAiReview.ts
@@ -1,0 +1,62 @@
+/**
+ * Insights AI Review — shared contract
+ *
+ * A grounded, forward-looking AI narrative built ONLY from the cross-domain
+ * insights the app already computes (correlations, linear-trend predictions,
+ * medication adherence, metric averages, discoveries). It explains what the
+ * numbers mean in plain language and suggests small, realistic next steps —
+ * always framed as correlation, never causation.
+ *
+ * Used by the server route that generates it (Gemini BYOK) and the AI Review tab.
+ */
+
+import type { ReviewConfidence } from './weeklyAiReview';
+
+export interface InsightsReviewPattern {
+  /** Short headline, e.g. "Exercise days track with higher mood". */
+  title: string;
+  /** The specific computed evidence supporting it. */
+  evidence: string;
+  /** How strongly the data supports it. */
+  confidence: ReviewConfidence;
+}
+
+export interface InsightsReviewRecommendation {
+  /** Short, concrete action headline. */
+  title: string;
+  /** Why this is suggested, tied to the computed insights. */
+  reason: string;
+  /** A small, behaviorally realistic next step. */
+  suggestedAction: string;
+}
+
+export interface InsightsAIReview {
+  /** Window analyzed (days). */
+  rangeDays: number;
+  /** Window bounds (YYYY-MM-DD, inclusive). */
+  rangeStart: string;
+  rangeEnd: string;
+  /** Plain-language narrative of what the insights show (1–3 short paragraphs). */
+  summary: string;
+  /** Objective findings drawn straight from the computed correlations/trends. */
+  keyFindings: string[];
+  /** Inferred relationships, each with a confidence level. */
+  patterns: InsightsReviewPattern[];
+  /** Forward-looking, caveated read of the trend predictions. */
+  outlook: string[];
+  /** A small number (max 5) of grounded, actionable suggestions. */
+  recommendations: InsightsReviewRecommendation[];
+  /** Honest notes about where data was too thin to draw conclusions. */
+  dataLimitations: string[];
+}
+
+export interface InsightsAIReviewResponse {
+  review: InsightsAIReview;
+  meta: {
+    rangeDays: number;
+    rangeStart: string;
+    rangeEnd: string;
+    daysWithCheckins: number;
+    correlationsFound: number;
+  };
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -47,9 +47,30 @@ metric keys; user-defined lists get medication-style definition+log collections.
 Verification: `npm run build` GREEN; `npm run lint:beta` 0 errors (pre-existing `any`
 warnings only).
 
-## Deferred (follow-up PRs)
-- Phase 5 Insights tabs: Overview/Correlations/Habit/Medication/Predictions/AI Review.
-- Analytics service (/api/insights/*), correlations, predictions, milestone alerts,
-  personal discoveries. Direction (confirmed with user): simple stats (Pearson-style
-  correlations reusing the sleep correlation approach + simple linear-trend predictions)
-  plus an AI Review tab using the existing Gemini infra.
+## Phase 5 — Insights tabs + analytics engine (DONE)
+
+Direction (confirmed with user): all six tabs in one PR; keep the page beta-gated;
+reuse the Sleep Analytics Cohen's d correlation approach (not literal Pearson); fold
+the existing heatmap/weekly/multiples wellbeing views into the new Overview tab.
+
+- [x] 1. Backend: shared `correlationEngine.ts` (Cohen's d + present/absent split,
+       extracted from sleepAnalyticsService) + `insightsService.ts` (factor↔outcome
+       correlations across habits/medications/supplements/symptoms/behavioral factors,
+       linear-trend predictions, discoveries/milestones, medication adherence). Unit tests.
+- [x] 2. Backend: `routes/insights.ts` — GET /api/insights/{overview,correlations,habits,
+       medications,predictions}, cached via analyticsCache; registered in app.ts.
+- [x] 3. Backend: `routes/aiInsightsReview.ts` — POST /api/ai/insights-review (Gemini BYOK,
+       grounded on computed insights); registered in app.ts.
+- [x] 4. Frontend: `lib/insightsClient.ts` — typed fetch methods for all endpoints + AI review.
+- [x] 5. Frontend: tabbed Insights shell (restructured WellbeingHistoryPage, beta gate kept)
+       + Overview tab folding in the existing heatmap/weekly/multiples views.
+- [x] 6. Frontend: Correlations + Predictions tabs.
+- [x] 7. Frontend: Habits + Medications tabs (Habits reuses habit analytics summary).
+- [x] 8. Frontend: AI Review tab (BYOK flow mirroring WeeklyAIReviewCard).
+- [x] 9. Docs: FEATURES.md, HABITFLOW_UI_ARCHITECTURE.md, InfoModal (AI tab).
+
+Verification: `npm run build` (tsc -b + vite) GREEN; new unit tests pass; sleep tests
+unchanged. AI Review is generate-on-demand (not archived) for this phase.
+
+Note: "milestone alerts / personal discoveries" are surfaced as the Overview tab's
+Discoveries section (correlation/trend/coverage-milestone derived).


### PR DESCRIPTION
Extract the Sleep Analytics correlation primitives (Cohen's d effect
size, present/absent median split) into a reusable correlationEngine
module so the Insights surfaces speak the same statistical language, and
refactor sleepAnalyticsService to consume them (behavior unchanged).

Add insightsService: pure, read-time computation of factor↔outcome
correlations (habits, medications, supplements, symptoms, behavioral
factors vs subjective wellbeing metrics), simple least-squares
linear-trend predictions per metric, and derived discoveries/milestones.
Includes per-medication adherence + medication↔wellbeing correlations.

24 unit tests pass (13 new insights/correlation + 11 sleep, unchanged).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PYNHkWFzN7xmDCi3MSQsQ