### PR TITLE
Add guided tour page for new users

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -235,3 +235,4 @@ Every feature area below is **Shipped** unless an item notes otherwise.
 - **Soft Deletes** — `deletedAt` timestamp pattern for truth records
 - **Optimistic UI** — Changes appear instantly with backend sync
 - **Responsive Design** — Mobile-first with bottom tab bar (Dashboard, Habits, Routines, Goals)
+- **Take a Tour** — Accessible full-page tour (`?view=tour`, opened from the Compass button in the header) that orients new users to the six tracking domains, showcases the shipped Gemini BYOK AI features, and lists the AI features on the roadmap with their status

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -129,7 +129,7 @@ HabitFlow App
 | Journal | Page | Dashboard card / `?view=journal` (`&tab=` deep-links Free/Template/History/AI Review) | Free-write, templates, history, and AI Review tabs; auto-generated AI summary banner | Journal Entries | — |
 | Tasks | Page | Dashboard card / `?view=tasks` | Today + Inbox columns; click a task title or pencil icon to rename inline | Tasks | — |
 | Insights | Page | Wellbeing card → 📈 Insights (`?view=wellbeing-history`); beta-gated | Tabbed analytics: Overview, Correlations, Habits, Medications, Predictions, AI Review. Cross-domain correlations (Cohen's d), linear-trend predictions, and a Gemini AI narrative, all from canonical truth at read time | Wellbeing Entries, Habit Entries, Medication/Supplement/Symptom Logs | — |
-| Take a Tour | Page | Compass button in header / `?view=tour` | Orientation page: what HabitFlow tracks, shipped AI features (Gemini BYOK), and AI roadmap items with status badges | — | Dashboard, Tracker, Journal, Settings (via open-settings event) |
+| Take a Tour | Page | Compass button in header / "Take a tour" link in new-user Setup Guide / `?view=tour` | Orientation page: what HabitFlow tracks, shipped AI features (Gemini BYOK), and AI roadmap items with status badges | — | Dashboard, Tracker, Journal, Settings (via open-settings event) |
 | Debug Entries | Page (dev) | `?view=debug-entries` | Testing entry data | Entries | — |
 | Login | Page | Default for unauthenticated users | Email + password sign in. Includes "Forgot password?" link and switch to invite redeem | — | Invite Redeem, Forgot Password |
 | Invite Redeem | Page | "Have an invite code?" link on Login | Create an account with an invite code | Users | Login |

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -129,6 +129,7 @@ HabitFlow App
 | Journal | Page | Dashboard card / `?view=journal` (`&tab=` deep-links Free/Template/History/AI Review) | Free-write, templates, history, and AI Review tabs; auto-generated AI summary banner | Journal Entries | — |
 | Tasks | Page | Dashboard card / `?view=tasks` | Today + Inbox columns; click a task title or pencil icon to rename inline | Tasks | — |
 | Insights | Page | Wellbeing card → 📈 Insights (`?view=wellbeing-history`); beta-gated | Tabbed analytics: Overview, Correlations, Habits, Medications, Predictions, AI Review. Cross-domain correlations (Cohen's d), linear-trend predictions, and a Gemini AI narrative, all from canonical truth at read time | Wellbeing Entries, Habit Entries, Medication/Supplement/Symptom Logs | — |
+| Take a Tour | Page | Compass button in header / `?view=tour` | Orientation page: what HabitFlow tracks, shipped AI features (Gemini BYOK), and AI roadmap items with status badges | — | Dashboard, Tracker, Journal, Settings (via open-settings event) |
 | Debug Entries | Page (dev) | `?view=debug-entries` | Testing entry data | Entries | — |
 | Login | Page | Default for unauthenticated users | Email + password sign in. Includes "Forgot password?" link and switch to invite redeem | — | Invite Redeem, Forgot Password |
 | Invite Redeem | Page | "Have an invite code?" link on Login | Create an account with an invite code | Users | Login |
@@ -556,5 +557,5 @@ This document **must be updated** whenever:
 
 ## 10. Last Updated
 
-- **Date:** 2026-04-01
-- **Branch:** `claude/plan-apple-health-integration-qcQEr`
+- **Date:** 2026-07-01
+- **Branch:** `claude/habitflow-demo-tour-page-qcsnzl`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,9 +66,10 @@ const DebugEntriesPage = lazyRetry(() => import('./pages/DebugEntriesPage').then
 const WellbeingHistoryPage = lazyRetry(() => import('./pages/WellbeingHistoryPage').then(m => ({ default: m.WellbeingHistoryPage })));
 const AnalyticsPage = lazyRetry(() => import('./pages/AnalyticsPage').then(m => ({ default: m.AnalyticsPage })));
 const AppleHealthPage = lazyRetry(() => import('./pages/AppleHealthPage').then(m => ({ default: m.AppleHealthPage })));
+const TourPage = lazyRetry(() => import('./pages/TourPage').then(m => ({ default: m.TourPage })));
 
 // Simple router state
-type AppRoute = 'tracker' | 'dashboard' | 'routines' | 'goals' | 'wins' | 'journal' | 'tasks' | 'day' | 'debug-entries' | 'wellbeing-history' | 'analytics' | 'health';
+type AppRoute = 'tracker' | 'dashboard' | 'routines' | 'goals' | 'wins' | 'journal' | 'tasks' | 'day' | 'debug-entries' | 'wellbeing-history' | 'analytics' | 'health' | 'tour';
 
 
 // Helper functions for URL syncing
@@ -106,6 +107,8 @@ function parseRouteFromLocation(location: Location): AppRoute {
       return "analytics";
     case "health":
       return "health";
+    case "tour":
+      return "tour";
     default:
 
       return "dashboard"; // default view
@@ -637,6 +640,12 @@ const HabitTrackerContent: React.FC = () => {
           <AnalyticsPage onBack={() => handleNavigate('dashboard')} />
         ) : view === 'health' ? (
           <AppleHealthPage onBack={() => handleNavigate('dashboard')} />
+        ) : view === 'tour' ? (
+          <TourPage
+            onNavigate={(route) => handleNavigate(route)}
+            onOpenSettings={() => window.dispatchEvent(new Event('habitflow:open-settings'))}
+            onBack={() => handleNavigate('dashboard')}
+          />
         ) : goalsViewMode === 'schedule' ? (
           <GoalScheduleView
             onViewGoal={(goalId) => {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
-import { LayoutGrid, Settings, User, LogOut, Info, Eye, EyeOff, FlaskConical } from 'lucide-react';
+import { LayoutGrid, Settings, User, LogOut, Info, Eye, EyeOff, FlaskConical, Compass } from 'lucide-react';
 import { useHabitStore } from '../store/HabitContext';
 import { useAuth } from '../store/AuthContext';
 import { useDashboardPrefs } from '../store/DashboardPrefsContext';
@@ -118,6 +118,20 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                                     </button>
                                 </div>
                     )}
+                    <button
+                        onClick={() => {
+                            const searchParams = new URLSearchParams(window.location.search);
+                            searchParams.set('view', 'tour');
+                            const url = `${window.location.pathname}?${searchParams.toString()}`;
+                            window.history.pushState({ view: 'tour' }, '', url);
+                            window.dispatchEvent(new PopStateEvent('popstate'));
+                        }}
+                        className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-white/5 rounded-full transition-colors text-neutral-400 hover:text-white"
+                        title="Take a Tour"
+                        aria-label="Take a Tour"
+                    >
+                        <Compass size={20} />
+                    </button>
                     <button
                         onClick={() => setInfoOpen(true)}
                         className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-white/5 rounded-full transition-colors text-neutral-400 hover:text-white"

--- a/src/components/dashboard/SetupDashboard.tsx
+++ b/src/components/dashboard/SetupDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Sparkles, Calendar, CheckSquare, BookOpenText, Target, Check } from 'lucide-react';
+import { Sparkles, Calendar, CheckSquare, BookOpenText, Target, Check, Compass } from 'lucide-react';
 
 interface SetupStep {
   title: string;
@@ -85,6 +85,13 @@ export const SetupDashboard: React.FC<SetupDashboardProps> = ({
         <p className="text-neutral-400 text-sm">
           Let's get you set up in a few quick steps.
         </p>
+        <button
+          onClick={() => onNavigate('tour')}
+          className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-emerald-400 hover:text-emerald-300 transition-colors"
+        >
+          <Compass size={14} aria-hidden="true" />
+          New here? Take a tour
+        </button>
       </div>
 
       {/* Progress indicator */}

--- a/src/pages/TourPage.tsx
+++ b/src/pages/TourPage.tsx
@@ -1,0 +1,340 @@
+import React from 'react';
+import {
+  Sparkles,
+  Brain,
+  BookOpen,
+  Wand2,
+  Target,
+  Calendar,
+  Route as RouteIcon,
+  ClipboardList,
+  HeartPulse,
+  Compass,
+  ArrowRight,
+  ArrowLeft,
+  Rocket,
+  Mic,
+  Users,
+  KeyRound,
+  MessageSquareText,
+  LineChart,
+  ScrollText,
+  Clock,
+} from 'lucide-react';
+
+// Routes the tour can send the user to — a subset of the app's AppRoute union.
+type TourNavRoute = 'dashboard' | 'tracker' | 'routines' | 'goals' | 'journal';
+
+interface TourPageProps {
+  onNavigate: (route: TourNavRoute) => void;
+  onOpenSettings: () => void;
+  onBack: () => void;
+}
+
+interface Feature {
+  icon: React.FC<{ size?: number; className?: string }>;
+  title: string;
+  description: string;
+}
+
+interface RoadmapFeature extends Feature {
+  status: 'Planned' | 'Exploring';
+}
+
+// What HabitFlow lets you track — a quick orientation for new users.
+const CORE_FEATURES: Feature[] = [
+  {
+    icon: Calendar,
+    title: 'Habits',
+    description:
+      'Track daily behaviors — done/not-done or a numeric quantity — with flexible scheduling, categories, streaks, and bundles.',
+  },
+  {
+    icon: RouteIcon,
+    title: 'Routines',
+    description:
+      'Build multi-step routines with Quick, Standard, and Deep variants, step timers, and a guided runner that auto-logs linked habits.',
+  },
+  {
+    icon: Target,
+    title: 'Goals',
+    description:
+      'Set cumulative or one-time goals with milestones and trends. Link habits so completions count as progress toward the goal.',
+  },
+  {
+    icon: BookOpen,
+    title: 'Journal',
+    description:
+      'Free-write or use persona-driven templates. Entries feed AI summaries and reviews that surface themes over time.',
+  },
+  {
+    icon: HeartPulse,
+    title: 'Wellbeing',
+    description:
+      'Log morning and evening check-ins, sleep, mood, and medication. Insights correlate wellbeing with your habits.',
+  },
+  {
+    icon: ClipboardList,
+    title: 'Tasks',
+    description:
+      'Capture one-off to-dos in Today and Inbox lists — a clear finish line separate from recurring habits.',
+  },
+];
+
+// AI features that are shipped and usable today (Gemini BYOK).
+const AI_NOW: Feature[] = [
+  {
+    icon: Sparkles,
+    title: 'Weekly AI Review',
+    description:
+      'A comprehensive weekly report on the Habits page. It reads your real habit, sleep, mood, journal, and goal data and returns a Week at a Glance narrative, Facts, Patterns (with confidence levels), Journal Themes, Wins, Areas for Attention, and Recommendations — plus honest Data Limitations when a week is thin.',
+  },
+  {
+    icon: LineChart,
+    title: 'Insights AI Review',
+    description:
+      'On the Insights page, turn your computed correlations and trend predictions into a plain-language narrative: a Summary, Key Findings, Patterns, an Outlook, and Recommendations. Everything is framed as correlation, never cause and effect.',
+  },
+  {
+    icon: Brain,
+    title: 'AI Journal Review',
+    description:
+      'Pick a date range and generate a structured, grounded review of your entries: Overview, Emotional Themes, Recurring Stressors, Wins, Self-Talk Patterns, Reflection Questions, and Suggested Next Steps. Supportive and non-clinical — no diagnoses.',
+  },
+  {
+    icon: MessageSquareText,
+    title: 'Journal Summaries',
+    description:
+      'An auto-generated weekly summary of your journal entries — themes, highlights, and actionable feedback — shown as a dismissible banner and saved to your journal history.',
+  },
+  {
+    icon: Wand2,
+    title: 'AI Variant Suggestions',
+    description:
+      'While building a routine, let AI analyze your title and steps to suggest Quick, Standard, and Deep variants with full step lists.',
+  },
+  {
+    icon: ScrollText,
+    title: 'Persona-Driven Journaling',
+    description:
+      'Choose an AI persona (like "The Strategic Coach") to shape your journaling prompts with a specific tone and perspective.',
+  },
+  {
+    icon: Clock,
+    title: 'AI Report History',
+    description:
+      'Every Weekly AI Review and Journal Summary is saved to a browsable archive. Reopen or delete past reports by date — reading history never spends another API call.',
+  },
+];
+
+// AI features on the roadmap — see ROADMAP.md for the source of truth.
+const AI_ROADMAP: RoadmapFeature[] = [
+  {
+    icon: KeyRound,
+    title: 'Pluggable AI Providers',
+    status: 'Planned',
+    description:
+      'Bring your own Anthropic (Claude) or OpenAI key alongside the current Gemini integration, so you can pick the model that fits you.',
+  },
+  {
+    icon: ScrollText,
+    title: 'Journal Questionnaire Templates',
+    status: 'Planned',
+    description:
+      'Guided check-ins built from reusable prompt sets — structured reflection that goes beyond today’s persona templates.',
+  },
+  {
+    icon: Mic,
+    title: 'Dictation Journal Mode',
+    status: 'Planned',
+    description:
+      'A voice-first journaling workflow so you can capture reflections by speaking instead of typing.',
+  },
+  {
+    icon: Users,
+    title: 'Persona Switching UX',
+    status: 'Exploring',
+    description:
+      'A smoother way to switch between coaching personas across the app, tuning the voice of your AI guidance.',
+  },
+  {
+    icon: Compass,
+    title: 'Identity Prompts & Coaching',
+    status: 'Exploring',
+    description:
+      'Deeper, identity-based coaching that connects your habits to who you want to become, grounded in psychological-safety principles.',
+  },
+];
+
+const statusStyles: Record<RoadmapFeature['status'], string> = {
+  Planned: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30',
+  Exploring: 'bg-amber-500/10 text-amber-300 border-amber-500/30',
+};
+
+export const TourPage: React.FC<TourPageProps> = ({ onNavigate, onOpenSettings, onBack }) => {
+  return (
+    <div className="max-w-4xl mx-auto flex flex-col gap-10 pb-4">
+      {/* Back link */}
+      <button
+        onClick={onBack}
+        className="self-start inline-flex items-center gap-1.5 text-sm text-neutral-400 hover:text-white transition-colors -mb-2"
+      >
+        <ArrowLeft size={16} aria-hidden="true" />
+        Back to Dashboard
+      </button>
+
+      {/* Hero */}
+      <header className="text-center flex flex-col items-center gap-4">
+        <div className="w-14 h-14 bg-gradient-to-br from-emerald-400 to-cyan-500 rounded-2xl flex items-center justify-center shadow-lg shadow-emerald-500/20">
+          <Compass size={28} className="text-white" aria-hidden="true" />
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white to-neutral-400">
+          Take a Tour of HabitFlow
+        </h1>
+        <p className="text-neutral-300 max-w-2xl text-base leading-relaxed">
+          HabitFlow helps you build better routines by tracking habits, goals, journaling, and
+          wellbeing in one place — then turns your own data into grounded, AI-powered insight. Here's a
+          quick tour of what you can do today and what's coming next.
+        </p>
+      </header>
+
+      {/* What you can track */}
+      <section aria-labelledby="tour-core-heading" className="flex flex-col gap-4">
+        <div>
+          <h2 id="tour-core-heading" className="text-xl font-semibold text-white">
+            What you can track
+          </h2>
+          <p className="text-sm text-neutral-400 mt-1">
+            Six connected domains — everything is derived from a single source of truth, so your views
+            always stay in sync.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {CORE_FEATURES.map(({ icon: Icon, title, description }) => (
+            <article
+              key={title}
+              className="bg-neutral-900/40 border border-white/5 rounded-xl p-4 flex flex-col gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <Icon size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
+                <h3 className="font-semibold text-white">{title}</h3>
+              </div>
+              <p className="text-sm text-neutral-400 leading-relaxed">{description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* AI features — available now */}
+      <section aria-labelledby="tour-ai-now-heading" className="flex flex-col gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Sparkles size={20} className="text-emerald-400 shrink-0" aria-hidden="true" />
+            <h2 id="tour-ai-now-heading" className="text-xl font-semibold text-white">
+              AI features — available now
+            </h2>
+          </div>
+          <p className="text-sm text-neutral-400 mt-1">
+            Every AI feature reads only your real data and keeps facts, patterns, and suggestions
+            separate — if the data is thin, it says so instead of inventing patterns. They run on your
+            own Gemini API key (BYOK), which stays in your browser and is never stored on our servers.
+          </p>
+        </div>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4 list-none p-0 m-0">
+          {AI_NOW.map(({ icon: Icon, title, description }) => (
+            <li
+              key={title}
+              className="bg-neutral-900/40 border border-emerald-500/15 rounded-xl p-4 flex flex-col gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <Icon size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
+                <h3 className="font-semibold text-white">{title}</h3>
+              </div>
+              <p className="text-sm text-neutral-400 leading-relaxed">{description}</p>
+            </li>
+          ))}
+        </ul>
+        <div className="bg-emerald-500/5 border border-emerald-500/20 rounded-lg px-4 py-3 flex items-start gap-2">
+          <KeyRound size={16} className="text-emerald-400 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-sm text-neutral-300">
+            To enable AI features, add a free Gemini API key in{' '}
+            <button
+              onClick={onOpenSettings}
+              className="text-emerald-300 underline underline-offset-2 hover:text-emerald-200 transition-colors"
+            >
+              Settings
+            </button>
+            . Your key is stored only in your browser.
+          </p>
+        </div>
+      </section>
+
+      {/* AI features — on the roadmap */}
+      <section aria-labelledby="tour-ai-roadmap-heading" className="flex flex-col gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Rocket size={20} className="text-amber-400 shrink-0" aria-hidden="true" />
+            <h2 id="tour-ai-roadmap-heading" className="text-xl font-semibold text-white">
+              AI features — on the roadmap
+            </h2>
+          </div>
+          <p className="text-sm text-neutral-400 mt-1">
+            What we're building next. Planned items are committed; exploring items are directions we're
+            still investigating.
+          </p>
+        </div>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4 list-none p-0 m-0">
+          {AI_ROADMAP.map(({ icon: Icon, title, description, status }) => (
+            <li
+              key={title}
+              className="bg-neutral-900/40 border border-white/5 rounded-xl p-4 flex flex-col gap-2"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Icon size={18} className="text-neutral-300 shrink-0" aria-hidden="true" />
+                  <h3 className="font-semibold text-white truncate">{title}</h3>
+                </div>
+                <span
+                  className={`shrink-0 text-[10px] uppercase tracking-wide font-semibold px-2 py-0.5 rounded-full border ${statusStyles[status]}`}
+                >
+                  {status}
+                </span>
+              </div>
+              <p className="text-sm text-neutral-400 leading-relaxed">{description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Call to action */}
+      <section aria-labelledby="tour-cta-heading" className="flex flex-col gap-4">
+        <h2 id="tour-cta-heading" className="text-xl font-semibold text-white text-center">
+          Ready to dive in?
+        </h2>
+        <div className="flex flex-wrap justify-center gap-3">
+          <button
+            onClick={() => onNavigate('dashboard')}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-emerald-500 to-cyan-500 text-white font-semibold hover:from-emerald-400 hover:to-cyan-400 transition-colors shadow-lg shadow-emerald-500/20"
+          >
+            Go to Dashboard
+            <ArrowRight size={16} aria-hidden="true" />
+          </button>
+          <button
+            onClick={() => onNavigate('tracker')}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-neutral-800 border border-white/10 text-neutral-200 font-semibold hover:bg-neutral-700 hover:text-white transition-colors"
+          >
+            <Calendar size={16} aria-hidden="true" />
+            Track Habits
+          </button>
+          <button
+            onClick={() => onNavigate('journal')}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-neutral-800 border border-white/10 text-neutral-200 font-semibold hover:bg-neutral-700 hover:text-white transition-colors"
+          >
+            <BookOpen size={16} aria-hidden="true" />
+            Open Journal
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a comprehensive onboarding tour page that introduces new users to HabitFlow's core features, current AI capabilities, and roadmap. The tour is accessible via a new Compass icon in the header and from the setup dashboard.

## Changes

- **New `TourPage` component** (`src/pages/TourPage.tsx`): A full-page tour featuring:
  - Hero section with app overview
  - Six core tracking domains (Habits, Routines, Goals, Journal, Wellbeing, Tasks)
  - Seven shipped AI features with detailed descriptions
  - Five roadmap AI features with status badges (Planned/Exploring)
  - Call-to-action buttons linking to key app sections
  - Settings link for Gemini API key setup

- **Header navigation**: Added Compass icon button in `Layout.tsx` to launch the tour via URL state (`?view=tour`)

- **Router integration** (`App.tsx`): 
  - Added `'tour'` to `AppRoute` union type
  - Lazy-loaded `TourPage` component
  - Added route parsing for `?view=tour`

- **Setup dashboard link** (`SetupDashboard.tsx`): Added "New here? Take a tour" button for first-time users

- **Documentation updates**: Updated `HABITFLOW_UI_ARCHITECTURE.md` and `FEATURES.md` to reflect the new tour page

## Implementation Details

- Tour uses the same icon library and styling patterns as the rest of the app (Lucide icons, Tailwind gradients)
- Feature data is organized into three constants (`CORE_FEATURES`, `AI_NOW`, `AI_ROADMAP`) for easy maintenance
- Responsive grid layout (1 column mobile, 2 columns tablet, 3 columns desktop for core features)
- Status badges for roadmap items use color-coded styling (emerald for Planned, amber for Exploring)
- Navigation callbacks allow the tour to direct users to specific app sections
- Accessible markup with proper ARIA labels and semantic HTML

https://claude.ai/code/session_01MwLey2ojXUf7PYperob4yr