### PR TITLE
Enable the public demo in the Render blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,3 +16,8 @@ services:
         sync: false
       - key: BOOTSTRAP_ADMIN_KEY
         sync: false
+      # Public read-only demo: seeds/refreshes the demo dataset at startup and
+      # maps X-Demo-Mode requests to the fixed demo identity (writes rejected).
+      # See docs/DEMO_ARCHITECTURE.md.
+      - key: PUBLIC_DEMO_ENABLED
+        value: "true"


### PR DESCRIPTION
Follow-up to #497. Declares `PUBLIC_DEMO_ENABLED=true` on the `habitflowai-api` service in `render.yaml`.

`PUBLIC_DEMO_ENABLED` is a **backend** flag (read by the Express server in `src/server/config/demo.ts`), so it belongs on Render, not Vercel — Vercel only serves the static frontend and rewrites `/api/*` to the Render service. With this set, blueprint-synced deploys automatically:

- seed/refresh the demo dataset at server startup (skips when fresh),
- map `X-Demo-Mode: true` requests to the fixed read-only demo identity,
- reject all mutating requests for that identity with `403 { demoReadOnly: true }`.

If the Render service was created manually rather than from the blueprint, set the same variable in the Render dashboard (**habitflowai-api → Environment**) instead.

**Verify after deploy:** `GET /api/health` reports `"publicDemo": true`, Render logs show `[DemoShowcase] Demo dataset seeded`, and the login screen's "Explore the live demo" drops into the seeded read-only app. See `docs/DEMO_ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNmmSQWDFWsgahzJiSx7Js

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNmmSQWDFWsgahzJiSx7Js)_