### PR TITLE
fix(goals): cap heatmap graphic width so cells aren't oversized on desktop

### DIFF
--- a/src/components/goals/GoalGridCard.tsx
+++ b/src/components/goals/GoalGridCard.tsx
@@ -174,8 +174,9 @@ const CumulativeGoalCard: React.FC<GoalGridCardProps> = ({
                 </button>
             </div>
 
-            {/* Progress visualization */}
-            <div className="px-3 pb-3">
+            {/* Progress visualization — capped width so heatmap cells stay
+                a comfortable size on desktop instead of scaling up with the card */}
+            <div className="px-3 pb-3 max-w-[360px]">
                 {isLowTarget ? (
                     <div className="w-full py-1">
                         <div className="relative h-2.5 w-full bg-neutral-800 rounded-full overflow-hidden">


### PR DESCRIPTION
## Summary

Goal heatmaps (e.g. "Apply to jobs", "Deep work sessions" on the Goals page) looked correctly sized on mobile but far too large on desktop.

**Root cause:** `MiniHeatmap` renders cells as `w-full aspect-square` in a `grid-cols-7`, so each cell's size scales with the goal card's width. Cumulative goal cards render full-width in the `max-w-2xl` (672px) Goals container, which produced ~**81px** cells on desktop versus ~**44px** on mobile.

**Fix:** Cap the cumulative goal card's progress-visualization block at `max-w-[360px]`. This keeps heatmap cells at ~44px on desktop — matching the mobile size — while leaving the card header/title full-width. The cap is inert on mobile (the visualization is already narrower than 360px), so mobile rendering is unchanged.

## Changes

- `src/components/goals/GoalGridCard.tsx` — add `max-w-[360px]` to the progress-visualization container in `CumulativeGoalCard`.

## Verification

Rendered the exact card DOM/box-model under headless Chromium at desktop and mobile viewports:

- **Desktop (1280px):** cells `80.6px` → `44.6px` (visualization capped to 336px content width).
- **Mobile (390px):** cells remain ~`44px` — cap is inert, no change.
- `npm run build` (`tsc -b && vite build`) passes clean.

Pure visual sizing tweak — no feature, screen, navigation, or flow changes, so `docs/FEATURES.md`, the UI architecture doc, and the InfoModal do not require updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjjDSEKWCtAzdgVd6tHkpw)_