### PR TITLE
fix(day-view): numeric habits show green check on value entry instead of a percentage

### DIFF
--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -160,26 +160,24 @@ export const HabitGridCell = ({
         }
     };
 
-    // Render quantity progress ring on checkbox
+    // Render checkbox. Numeric habits turn green with a check once any value
+    // is entered (currentValue > 0) — no percentage ring. The entered value
+    // is surfaced elsewhere (grid/tracker view and the expanded metadata).
     const renderCheckbox = () => {
-        if (isQuantity && habitStatus && habitStatus.targetValue > 0) {
-            const pct = Math.min(100, habitStatus.progressPercent);
+        if (isQuantity && habitStatus) {
+            const hasValue = habitStatus.currentValue > 0;
             return (
                 <button
                     onClick={handleCheckboxClick}
                     className={cn(
-                        "flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all duration-300 relative",
-                        isCompleted
+                        "flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center transition-all duration-300",
+                        hasValue
                             ? "bg-emerald-500/10 border-emerald-500 text-emerald-500"
                             : "border-white/20 text-transparent hover:border-emerald-500/50"
                     )}
-                    title={`${habitStatus.currentValue}/${habitStatus.targetValue} ${habit.goal?.unit ?? ''}`}
+                    title={`${habitStatus.currentValue}${habit.goal?.unit ? ` ${habit.goal.unit}` : ''}`}
                 >
-                    {isCompleted ? (
-                        <Check size={12} strokeWidth={3} />
-                    ) : pct > 0 ? (
-                        <span className="text-[8px] font-bold text-neutral-400">{Math.round(pct)}%</span>
-                    ) : null}
+                    {hasValue && <Check size={12} strokeWidth={3} />}
                 </button>
             );
         }


### PR DESCRIPTION
## Summary

On the **Today** view, numeric ("quantity") habits displayed a target-based percentage ring on the completion checkbox (e.g. `100%`, `40%`) and only turned into a green check once the target was fully met. This surfaced target math the user doesn't want on this view.

Per the request: numeric habits should just turn **green with a check mark once any value is entered** — the value itself is already shown in the grid/tracker view (and in this cell's expanded metadata).

**Before:** `Run` with a value shows a `100%` (or `40%`) ring; no check until target met.
**After:** `Run` with any entered value shows a green ring + emerald check; empty circle when nothing is logged yet.

## Changes

- `src/components/day-view/HabitGridCell.tsx` — `renderCheckbox()`: for numeric habits, drive the green + check state off `currentValue > 0` and remove the percentage text. The checkbox now matches the boolean-habit style. The `#` quick-entry badge (opens the numeric popover) is unchanged.

## Verification

- Rendered the numeric row states under headless Chromium: value entered → green ring + check; no value → empty circle; percentage removed.
- `npm run build` (`tsc -b && vite build`) passes clean.

No feature, screen, navigation, or flow changes (numeric logging still goes through the same popover), so `docs/FEATURES.md`, the UI architecture doc, and the InfoModal don't require updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjjDSEKWCtAzdgVd6tHkpw)_