### PR TITLE
Make the AI Routine Builder visible in the read-only demo

### DIFF
--- a/docs/DEMO_ARCHITECTURE.md
+++ b/docs/DEMO_ARCHITECTURE.md
@@ -16,6 +16,8 @@ How the public, no-login demo and the interactive product tour work. Related:
    server. A visitor can never mutate demo data or reach any other user's data.
 4. **Honest by construction.** Roadmap items are confined to the Roadmap page; sample AI
    reports are composed from the seeded dataset's actual numbers and labeled as samples.
+   Where the read-only demo can't call a BYOK model live (e.g. the Routine Builder), it
+   shows pre-authored sample drafts in the real UI, and the tour callout says so.
 
 ## The three pieces
 
@@ -33,7 +35,10 @@ Browser ──X-Demo-Mode: true──▶ publicDemoIdentity ──▶ identityMi
   arbitrary user, and a real session cookie always wins.
 - `publicDemoReadOnlyGuard` rejects every non-GET/HEAD/OPTIONS request for that identity
   with `403 { demoReadOnly: true }`. This also blocks the AI generation endpoints (POST),
-  which is correct: live generation requires a user's own Gemini key.
+  which is correct: live generation requires a user's own Gemini key. Where an AI feature
+  would otherwise be invisible without a key, the client shows pre-authored sample output
+  instead of calling the endpoint — e.g. the Routine Builder's "Suggest with AI" injects
+  demo variant drafts (`src/lib/demoRoutineSuggestions.ts`) rather than POSTing.
 - Distinct from the **dev-only** `DEMO_MODE_ENABLED` flag (header-based identity for local
   debugging, writable, never active in production). If both flags are set in dev, requests
   with the demo header get the read-only public path.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -56,7 +56,7 @@ Every feature area below is **Shipped** unless an item notes otherwise.
 - **Create/Edit Routines** — Build multi-step routines with title, category, and description
 - **Routine Variants** — Create multiple versions (e.g., Quick, Standard, Deep) with different steps and durations
 - **Variant Copy** — Duplicate an existing variant as a starting point
-- **AI Variant Suggestions** — Generate variant ideas via Gemini AI based on routine title and existing steps
+- **AI Variant Suggestions** — Generate variant ideas via Gemini AI based on routine title and existing steps. In the read-only demo (no key), "Suggest with AI" injects pre-authored sample Quick/Standard/Deep drafts so visitors can see the flow
 - **Steps** — Ordered steps with title, instruction text, and optional timer
 - **Step Timers** — Countdown timer or stopwatch mode per step
 - **Step Images** — Upload images for visual guidance (JPEG, PNG, WebP, max 5MB)

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -147,7 +147,7 @@ HabitFlow App
 | Bundle Picker | Modal | Habit context menu "Add to Bundle" | Select existing bundle for habit membership | Habits, Bundles |
 | Convert to Bundle Confirm | Modal | "Convert to Bundle" action | Confirmation before converting habit to bundle | Habits, Bundles |
 | Category Picker | Modal | "Move to Category" action | Change habit's category | Habits, Categories |
-| Routine Editor | Modal | "+ Routine" or edit routine | Create/edit routines with variants; step list navigates to dedicated Step Editor panel | Routines, Habits |
+| Routine Editor | Modal | "+ Routine" or edit routine | Create/edit routines with variants; step list navigates to dedicated Step Editor panel. "Suggest with AI" (Gemini BYOK) drafts Quick/Standard/Deep variants; shown when a key is present, and also in the read-only demo where it injects pre-authored sample drafts instead of calling the model | Routines, Habits |
 | Routine Runner | Modal | "Play" button on routine card | Step-by-step routine execution with timers | Routines, Habits, Entries |
 | Routine Preview | Modal | Preview button on routine card | Read-only routine view before starting | Routines |
 | Wellbeing Overview | Modal | Wellbeing card chevron | Today's status (Morning/Evening/Sleep), 7-day trend cards, quick actions | Wellbeing Entries |

--- a/src/components/RoutineEditorModal.tsx
+++ b/src/components/RoutineEditorModal.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Copy, Loader2, Image as ImageIcon, Sparkles } from 'lucide-react';
-import { uploadRoutineImage, deleteRoutineImage, suggestVariants } from '../lib/persistenceClient';
+import { uploadRoutineImage, deleteRoutineImage, suggestVariants, getActiveUserMode } from '../lib/persistenceClient';
 import { getGeminiApiKey, hasGeminiApiKey } from '../lib/geminiClient';
+import { getDemoSuggestedVariants } from '../lib/demoRoutineSuggestions';
 import { useRoutineStore } from '../store/RoutineContext';
 import { useHabitStore } from '../store/HabitContext';
 import { computeVariantLinkedHabits } from '../lib/routineVariantUtils';
@@ -183,7 +184,10 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
 
     // AI Suggest Variants
     const handleSuggestVariants = async () => {
-        if (!hasGeminiApiKey()) {
+        // The read-only demo is BYOK and can't call Gemini, so it shows
+        // pre-authored sample drafts instead — see demoRoutineSuggestions.
+        const isDemo = getActiveUserMode() === 'demo';
+        if (!isDemo && !hasGeminiApiKey()) {
             setAiError('No Gemini API key configured. Add your key in Settings.');
             return;
         }
@@ -196,16 +200,18 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
         setAiError(null);
         try {
             const activeVariant = variants[activeVariantIndex];
-            const result = await suggestVariants({
-                routineTitle: title.trim(),
-                categoryId,
-                existingSteps: (activeVariant?.steps || []).map(s => ({
-                    title: s.title,
-                    instruction: s.instruction,
-                    timerSeconds: s.timerSeconds,
-                })),
-                geminiApiKey: getGeminiApiKey(),
-            });
+            const result = isDemo
+                ? await getDemoSuggestedVariants(title.trim())
+                : await suggestVariants({
+                    routineTitle: title.trim(),
+                    categoryId,
+                    existingSteps: (activeVariant?.steps || []).map(s => ({
+                        title: s.title,
+                        instruction: s.instruction,
+                        timerSeconds: s.timerSeconds,
+                    })),
+                    geminiApiKey: getGeminiApiKey(),
+                });
 
             if (result.suggestedVariants && result.suggestedVariants.length > 0) {
                 const newVariants = result.suggestedVariants.map((sv, idx) => ({
@@ -437,7 +443,7 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                         <div className="space-y-4">
                             {!isEditingStep && <><div className="flex items-center justify-between">
                                 <label className="text-sm font-medium text-neutral-400">Variants</label>
-                                {hasGeminiApiKey() && (
+                                {(hasGeminiApiKey() || getActiveUserMode() === 'demo') && (
                                     <button
                                         type="button"
                                         onClick={handleSuggestVariants}

--- a/src/lib/demoRoutineSuggestions.ts
+++ b/src/lib/demoRoutineSuggestions.ts
@@ -1,0 +1,151 @@
+/**
+ * Demo-mode sample data for the AI Routine Builder ("Suggest with AI").
+ *
+ * The public demo is read-only and BYOK (see docs/DEMO_ARCHITECTURE.md), so it
+ * can't call Gemini. To let visitors see exactly what "Suggest with AI"
+ * produces, demo mode injects these pre-authored sample variants instead of
+ * hitting the /ai/suggest-variants endpoint (which the read-only guard would
+ * reject anyway). The output flows through the identical downstream code path
+ * in RoutineEditorModal.handleSuggestVariants, so the drafts appear as the same
+ * editable, sparkle-tabbed variants the real model returns.
+ *
+ * To change what the demo drafts look like, edit the entries below. Keys are
+ * lower-cased routine titles; any title without a specific entry falls back to
+ * `genericDrafts`.
+ */
+
+import type { RoutineVariant } from '../models/persistenceTypes';
+
+/**
+ * Author-facing shape: only the fields that matter for a draft. The editor
+ * reassigns id, sortOrder, isAiGenerated, step ids, linkedHabitIds, and
+ * timestamps downstream, so those are filled in by `toVariants` below.
+ */
+interface DemoSuggestedStep {
+  title: string;
+  instruction?: string;
+  timerSeconds?: number;
+}
+
+interface DemoSuggestedVariant {
+  name: string;
+  description?: string;
+  estimatedDurationMinutes: number;
+  steps: DemoSuggestedStep[];
+}
+
+/**
+ * Sample drafts keyed by lower-cased routine title. "Morning Kickstart" is the
+ * routine the product tour features, so it gets a tailored Quick/Standard/Deep
+ * set — including the Deep variant the seeded routine doesn't ship with, which
+ * is exactly the kind of addition the AI makes.
+ */
+const DEMO_SUGGESTIONS: Record<string, DemoSuggestedVariant[]> = {
+  'morning kickstart': [
+    {
+      name: 'Quick',
+      description: 'Bare minimum for a rough morning — momentum over completeness.',
+      estimatedDurationMinutes: 5,
+      steps: [
+        { title: 'Glass of water', instruction: 'Rehydrate before coffee.' },
+        { title: 'Three deep breaths', instruction: 'In for four, out for six.', timerSeconds: 60 },
+        { title: "Name today's one priority", instruction: 'Say it out loud, then start it.' },
+      ],
+    },
+    {
+      name: 'Standard',
+      description: 'A balanced start when you have a normal amount of time.',
+      estimatedDurationMinutes: 20,
+      steps: [
+        { title: 'Glass of water', instruction: 'Rehydrate before coffee.' },
+        { title: '10-minute walk', instruction: 'Outside if possible — daylight resets your clock.', timerSeconds: 600 },
+        { title: '5-minute journal', instruction: 'Three lines: focus, worry, one thing you are grateful for.', timerSeconds: 300 },
+        { title: 'Plan the first deep-work block', instruction: 'Define what "done" looks like today.' },
+      ],
+    },
+    {
+      name: 'Deep',
+      description: 'A full runway for a protected morning — body, mind, and plan.',
+      estimatedDurationMinutes: 40,
+      steps: [
+        { title: 'Glass of water', instruction: 'Rehydrate before coffee.' },
+        { title: '15-minute walk', instruction: 'No podcast — let your mind wander.', timerSeconds: 900 },
+        { title: 'Meditate', instruction: 'Follow the breath; return gently when it drifts.', timerSeconds: 900 },
+        { title: 'Mobility flow', instruction: 'Hips, shoulders, spine.', timerSeconds: 300 },
+        { title: 'Journal + plan', instruction: "Review yesterday, set today's three priorities.", timerSeconds: 300 },
+      ],
+    },
+  ],
+};
+
+/**
+ * Fallback for any routine without a tailored entry: three time-scaled drafts
+ * that reference the routine by name so the shape still reads as a real result.
+ */
+function genericDrafts(routineTitle: string): DemoSuggestedVariant[] {
+  const title = routineTitle.trim() || 'this routine';
+  return [
+    {
+      name: 'Quick',
+      description: `The shortest version of ${title} for low-energy days.`,
+      estimatedDurationMinutes: 5,
+      steps: [
+        { title: 'Set up', instruction: `Get ready to start ${title}.` },
+        { title: 'Core step', instruction: 'The one thing that matters most.', timerSeconds: 180 },
+      ],
+    },
+    {
+      name: 'Standard',
+      description: `A balanced version of ${title}.`,
+      estimatedDurationMinutes: 15,
+      steps: [
+        { title: 'Set up', instruction: `Get ready to start ${title}.` },
+        { title: 'Core step', instruction: 'The one thing that matters most.', timerSeconds: 300 },
+        { title: 'Follow-through', instruction: 'Round it out and reset for next time.', timerSeconds: 300 },
+      ],
+    },
+    {
+      name: 'Deep',
+      description: `The full version of ${title} when you have time to spare.`,
+      estimatedDurationMinutes: 30,
+      steps: [
+        { title: 'Set up', instruction: `Get ready to start ${title}.` },
+        { title: 'Warm up', instruction: 'Ease in.', timerSeconds: 300 },
+        { title: 'Core step', instruction: 'The one thing that matters most.', timerSeconds: 600 },
+        { title: 'Follow-through', instruction: 'Round it out and reset for next time.', timerSeconds: 300 },
+        { title: 'Reflect', instruction: 'Note what worked so tomorrow is easier.' },
+      ],
+    },
+  ];
+}
+
+/**
+ * Return demo AI-suggested variants for a routine title, mirroring the shape of
+ * the real `suggestVariants` response. Includes a short simulated delay so the
+ * editor's loading spinner reads like a genuine model call.
+ */
+export async function getDemoSuggestedVariants(
+  routineTitle: string,
+): Promise<{ suggestedVariants: RoutineVariant[] }> {
+  // Brief simulated latency so the "generating" spinner is visible.
+  await new Promise((resolve) => setTimeout(resolve, 900));
+
+  const drafts =
+    DEMO_SUGGESTIONS[routineTitle.trim().toLowerCase()] ?? genericDrafts(routineTitle);
+  const now = new Date().toISOString();
+
+  const suggestedVariants: RoutineVariant[] = drafts.map((draft, index) => ({
+    id: crypto.randomUUID(),
+    name: draft.name,
+    description: draft.description,
+    estimatedDurationMinutes: draft.estimatedDurationMinutes,
+    sortOrder: index,
+    steps: draft.steps.map((step) => ({ id: crypto.randomUUID(), ...step })),
+    linkedHabitIds: [],
+    isAiGenerated: true,
+    createdAt: now,
+    updatedAt: now,
+  }));
+
+  return { suggestedVariants };
+}

--- a/src/pages/TourPage.tsx
+++ b/src/pages/TourPage.tsx
@@ -244,8 +244,8 @@ const STEPS: TourStep[] = [
       'The suggestions arrive as editable drafts — rename, retime, reorder, or delete steps before anything is saved; nothing is applied silently. And because variant steps keep their habit links, an AI-drafted routine plugs straight into the tracking system: run it and the entries log themselves.',
     ],
     callout:
-      'BYOK like all AI here: suggestions run on your own free Gemini key, so the read-only demo can’t generate drafts live. The demo’s Morning Kickstart shows the end state — a routine with the kind of Quick/Standard variants the AI drafts for you.',
-    tryIt: 'Preview “Morning Kickstart” and flip between its variants — the exact shape “Suggest with AI” produces.',
+      'BYOK like all AI here: live suggestions run on your own free Gemini key. So you can see the flow without one, the read-only demo fills in representative sample drafts instead of calling Gemini — the same editable Quick/Standard/Deep shape the model produces.',
+    tryIt: 'Open “Morning Kickstart”, hit Edit, then click ✨ Suggest with AI — the Quick/Standard/Deep drafts appear as editable variant tabs.',
     preview: { route: 'routines' },
   },
   {


### PR DESCRIPTION
## Problem

The product tour's **AI Routine Builder** stop describes "Suggest with AI," but the feature was completely invisible in the Live Demo — even though it's present in the real app.

**Root cause:** the "Suggest with AI" button in `RoutineEditorModal` was gated on `hasGeminiApiKey()` (`src/components/RoutineEditorModal.tsx`). A demo visitor has never entered a Gemini key (AI is BYOK, key lives only in `localStorage`), so `hasGeminiApiKey()` returned `false` and the button was never rendered. In the real app you added your key, so it shows — hence the discrepancy.

## Fix

Show and wire up the button in demo mode so visitors see exactly what it looks like "as if they had a key," using pre-authored sample data (the read-only demo can't call Gemini, and the read-only guard would `403` the POST anyway):

- **New fixture** `src/lib/demoRoutineSuggestions.ts` — pre-authored Quick/Standard/Deep sample drafts keyed by routine title (tailored "Morning Kickstart" set, plus a generic fallback), shaped to mirror the `/ai/suggest-variants` response.
- **`RoutineEditorModal`** — render the button when `hasGeminiApiKey() || getActiveUserMode() === 'demo'`, and in demo mode route the click to `getDemoSuggestedVariants(...)` instead of the API. The result flows through the **exact same downstream draft code** (`isAiGenerated`, sparkle-tabbed editable variants, rename/retime/reorder before save), so it's the real flow, not a mockup. `getActiveUserMode()` already resolves `demo` correctly inside the tour iframe via its in-memory override.
- **Tour stop copy** (`TourPage.tsx`) — the `ai-routines` callout previously claimed the demo "can't generate drafts live." Reworded to describe representative sample drafts honestly, and the "Try it" now directs visitors to open the editor and click Suggest with AI.

## Behavior

- **Real app (key present):** unchanged.
- **Demo:** click "Suggest with AI" on Morning Kickstart → after a brief simulated delay, three AI-drafted variants (Quick 5m / Standard 20m / Deep 40m) appear as editable, italic, sparkle-marked tabs. Nothing is written; attempting to Save still hits the normal read-only toast.

## Docs

Updated `docs/DEMO_ARCHITECTURE.md`, `docs/product/HABITFLOW_UI_ARCHITECTURE.md` (Routine Editor modal row), and `docs/FEATURES.md` (AI Variant Suggestions) to note the demo shows pre-authored sample drafts.

## Verification

- `npm run build` (tsc -b + vite build) passes.
- Added a throwaway test exercising `getDemoSuggestedVariants` (tailored Morning Kickstart set, case-insensitivity, generic fallback) — all passed; removed after verifying.
- The 3 failing `TrackerGrid.clearEntry` tests are pre-existing on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPqEBycnDLsaf8DqXk1Y1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPqEBycnDLsaf8DqXk1Y1i)_