### PR TITLE
Show the Wellbeing AI Review in the demo and lead the Insights tabs with it

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -142,7 +142,12 @@ Every feature area below is **Shipped** unless an item notes otherwise.
   driven by a cross-domain insights engine (`/api/insights/*`), computed from canonical
   truth at read time. All correlations use the same statistical approach as Sleep
   Analytics (present/absent day-group split + Cohen's d effect size) and are always
-  framed as correlation, never causation. Six tabs:
+  framed as correlation, never causation. Six tabs (AI Review is first and the default):
+  - **AI Review** (default tab) — Gemini BYOK narrative grounded only on the computed insights
+    (correlations, predictions, adherence); structured into summary, key findings,
+    confidence-tagged patterns, outlook, recommendations, and data limitations. The tab loads
+    the latest archived review on open, so a previously generated review (and the demo's seeded
+    review) is readable without a Gemini key; generating/regenerating still requires BYOK
   - **Overview** — Discoveries & milestones, a top-correlations preview, metric averages,
     plus the original wellbeing visualizations (Heatmap, Weekly Summary, Small Multiples)
   - **Correlations** — Factor↔outcome relationships across habits, medications, supplements,
@@ -154,9 +159,6 @@ Every feature area below is **Shipped** unless an item notes otherwise.
     medication↔wellbeing correlations
   - **Predictions** — Simple least-squares linear-trend projections per wellbeing metric
     (current → projected, change/week, confidence) with inline sparklines
-  - **AI Review** — Gemini BYOK narrative grounded only on the computed insights
-    (correlations, predictions, adherence); structured into summary, key findings,
-    confidence-tagged patterns, outlook, recommendations, and data limitations
 - **Time Window Selection** — View 30, 90, or 180 day periods (applies to all Insights tabs)
 
 ## Analytics

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -95,12 +95,12 @@ HabitFlow App
 │   └── Inbox column
 │
 ├── Insights (via Wellbeing card → 📈 Insights; beta-gated)
+│   ├── AI Review tab (default; Gemini BYOK narrative — shows the latest archived review, no key needed to read)
 │   ├── Overview tab (discoveries, top correlations, metric averages, heatmap/weekly/multiples)
 │   ├── Correlations tab (what's helping / what's holding you back)
 │   ├── Habits tab (habit stats + habit↔wellbeing correlations)
 │   ├── Medications tab (adherence + medication↔wellbeing correlations)
-│   ├── Predictions tab (linear-trend projections)
-│   └── AI Review tab (Gemini BYOK narrative)
+│   └── Predictions tab (linear-trend projections)
 │
 └── Debug Entries (dev only)
 ```
@@ -128,7 +128,7 @@ HabitFlow App
 | Create Goal (Step 2) | Modal | Next from Step 1 | Link habits to goal (filtered by category if selected) | Goals, Habits | Goals List (on submit) |
 | Journal | Page | Dashboard card / `?view=journal` (`&tab=` deep-links Free/Template/History/AI Review) | Free-write, templates, history, and AI Review tabs; auto-generated AI summary banner | Journal Entries | — |
 | Tasks | Page | Dashboard card / `?view=tasks` | Today + Inbox columns; click a task title or pencil icon to rename inline | Tasks | — |
-| Insights | Page | Wellbeing card → 📈 Insights (`?view=wellbeing-history`); beta-gated | Tabbed analytics: Overview, Correlations, Habits, Medications, Predictions, AI Review. Cross-domain correlations (Cohen's d), linear-trend predictions, and a Gemini AI narrative, all from canonical truth at read time | Wellbeing Entries, Habit Entries, Medication/Supplement/Symptom Logs | — |
+| Insights | Page | Wellbeing card → 📈 Insights (`?view=wellbeing-history`); beta-gated | Tabbed analytics: AI Review (default), Overview, Correlations, Habits, Medications, Predictions. Cross-domain correlations (Cohen's d), linear-trend predictions, and a Gemini AI narrative, all from canonical truth at read time. The AI Review tab loads the latest archived review (readable without a Gemini key; the demo ships a seeded one) | Wellbeing Entries, Habit Entries, Medication/Supplement/Symptom Logs | — |
 | Take a Tour | Page | "Take the tour" on Login (no account required) / `?view=tour` | Interactive 14-stop guided walkthrough with the four AI features as first-class stops (violet "AI" chips/badges): Weekly AI Review follows Habits, AI Journal Review follows Journal, the AI Routine Builder follows Routines, and Wellbeing Insights leads with its AI Review narration. Each stop pairs a narrative panel (problem, mechanics, honesty badge: Functional today / Beta / AI · BYOK / Roadmap) with a live preview — a persistent iframe running the real app read-only at `/?demo=1&embed=1`, navigated between stops via postMessage. Desktop/Mobile toggle resizes the preview to a real 390px viewport. Renders in `app` and pre-login `auth` modes | — | App mode: Dashboard, Roadmap. Auth mode: Invite Redeem, Login, Roadmap |
 | Roadmap | Page | Final tour stop → "View the Roadmap" / `?view=roadmap` (also pre-login via the auth gate) | Dedicated home for future functionality, mirrored from `ROADMAP.md` with status chips (In Development / Planned / Exploring). Honesty contract: nothing on the page exists yet; shipped features never appear on it | — | Back (Dashboard in app mode; Tour in auth mode) |
 | Debug Entries | Page (dev) | `?view=debug-entries` | Testing entry data | Entries | — |

--- a/src/pages/WellbeingHistoryPage.tsx
+++ b/src/pages/WellbeingHistoryPage.tsx
@@ -17,12 +17,12 @@ export type InsightsTab = 'overview' | 'correlations' | 'habits' | 'medications'
 export type InsightsWindow = 30 | 90 | 180;
 
 const TABS: Array<{ id: InsightsTab; label: string; icon: React.ComponentType<{ size?: number; className?: string }> }> = [
+  { id: 'ai-review', label: 'AI Review', icon: Sparkles },
   { id: 'overview', label: 'Overview', icon: LayoutDashboard },
   { id: 'correlations', label: 'Correlations', icon: GitCompareArrows },
   { id: 'habits', label: 'Habits', icon: Activity },
   { id: 'medications', label: 'Medications', icon: Pill },
   { id: 'predictions', label: 'Predictions', icon: TrendingUp },
-  { id: 'ai-review', label: 'AI Review', icon: Sparkles },
 ];
 
 export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
@@ -30,7 +30,7 @@ export const WellbeingHistoryPage: React.FC<Props> = ({ onBack }) => {
   const isAuthorized = isBetaViewer(user);
 
   const [windowDays, setWindowDays] = useState<InsightsWindow>(90);
-  const [tab, setTab] = useState<InsightsTab>('overview');
+  const [tab, setTab] = useState<InsightsTab>('ai-review');
 
   useEffect(() => {
     if (!isAuthorized) onBack();

--- a/src/pages/insights/AIReviewTab.tsx
+++ b/src/pages/insights/AIReviewTab.tsx
@@ -1,15 +1,41 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Sparkles, Loader2, RefreshCw } from 'lucide-react';
 import { hasGeminiApiKey } from '../../lib/geminiClient';
 import { fetchInsightsAIReview } from '../../lib/insightsClient';
+import { listAIReports, getAIReport } from '../../lib/aiReportsClient';
 import type { InsightsAIReview } from '../../shared/insightsAiReview';
+import type { InsightsReviewPayload } from '../../shared/aiReport';
 import { InsightsReviewBody } from '../../components/insights/InsightsReviewBody';
 
 export const AIReviewTab: React.FC<{ days: number }> = ({ days }) => {
   const [review, setReview] = useState<InsightsAIReview | null>(null);
   const [loading, setLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const hasKey = hasGeminiApiKey();
+
+  // Load the most recent archived Insights review on mount. Reading history
+  // needs no Gemini key, so this is what surfaces a review in the read-only
+  // demo (where generation is blocked) and lets returning users see their last
+  // review without spending another Gemini call.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const items = await listAIReports('insights_review', 1);
+        if (cancelled || items.length === 0) return;
+        const full = await getAIReport(items[0].id);
+        if (!cancelled) setReview((full.payload as InsightsReviewPayload).review);
+      } catch {
+        // Non-fatal: fall back to the generate/placeholder states below.
+      } finally {
+        if (!cancelled) setInitialLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const generate = async () => {
     setLoading(true);
@@ -24,6 +50,39 @@ export const AIReviewTab: React.FC<{ days: number }> = ({ days }) => {
     }
   };
 
+  if (initialLoading) {
+    return (
+      <div className="flex items-center gap-3 py-4">
+        <Loader2 size={18} className="text-indigo-400 animate-spin" />
+        <span className="text-sm text-neutral-400">Loading AI review…</span>
+      </div>
+    );
+  }
+
+  // A review is available (archived or freshly generated) — show it. Regenerate
+  // is only offered when a Gemini key is configured (never in the read-only demo).
+  if (review) {
+    return (
+      <div className="space-y-5">
+        <InsightsReviewBody review={review} />
+        {hasKey && (
+          <div className="pt-2 border-t border-white/5">
+            <button
+              onClick={generate}
+              disabled={loading}
+              className="flex items-center gap-1.5 text-xs text-indigo-400 hover:text-indigo-300 transition-colors disabled:opacity-50"
+            >
+              {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+              Regenerate
+            </button>
+          </div>
+        )}
+        {error && <p className="text-xs text-red-300">{error}</p>}
+      </div>
+    );
+  }
+
+  // No archived review and no key — nothing we can show without BYOK.
   if (!hasKey) {
     return (
       <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-6">
@@ -38,9 +97,24 @@ export const AIReviewTab: React.FC<{ days: number }> = ({ days }) => {
     );
   }
 
+  // Has a key but nothing archived yet — offer to generate the first review.
   return (
     <div className="space-y-5">
-      {!review && !loading && !error && (
+      {loading ? (
+        <div className="flex items-center gap-3 py-4">
+          <Loader2 size={18} className="text-indigo-400 animate-spin" />
+          <span className="text-sm text-neutral-400">Analyzing your insights…</span>
+        </div>
+      ) : error ? (
+        <div className="space-y-3">
+          <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-3">
+            <p className="text-sm text-red-300">{error}</p>
+          </div>
+          <button onClick={generate} className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
+            Try again
+          </button>
+        </div>
+      ) : (
         <div className="rounded-xl border border-white/5 bg-neutral-900/40 p-6">
           <p className="text-sm text-neutral-400 mb-4">
             Turn your computed correlations and trend predictions into a clear, forward-looking narrative — grounded in
@@ -54,39 +128,6 @@ export const AIReviewTab: React.FC<{ days: number }> = ({ days }) => {
             Generate AI Review
           </button>
         </div>
-      )}
-
-      {loading && (
-        <div className="flex items-center gap-3 py-4">
-          <Loader2 size={18} className="text-indigo-400 animate-spin" />
-          <span className="text-sm text-neutral-400">Analyzing your insights…</span>
-        </div>
-      )}
-
-      {error && (
-        <div className="space-y-3">
-          <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-3">
-            <p className="text-sm text-red-300">{error}</p>
-          </div>
-          <button onClick={generate} className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
-            Try again
-          </button>
-        </div>
-      )}
-
-      {review && (
-        <>
-          <InsightsReviewBody review={review} />
-          <div className="pt-2 border-t border-white/5">
-            <button
-              onClick={generate}
-              className="flex items-center gap-1.5 text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
-            >
-              <RefreshCw size={12} />
-              Regenerate
-            </button>
-          </div>
-        </>
       )}
     </div>
   );

--- a/src/server/demo/seedShowcase.ts
+++ b/src/server/demo/seedShowcase.ts
@@ -27,6 +27,7 @@ import { DEMO_USER_ID } from '../config/demo';
 import { PUBLIC_DEMO_HOUSEHOLD_ID } from '../../shared/demo';
 import { MONGO_COLLECTIONS, type GoalMilestone, type RoutineVariant } from '../../models/persistenceTypes';
 import type { WeeklyAIReview } from '../../shared/weeklyAiReview';
+import type { InsightsAIReview } from '../../shared/insightsAiReview';
 import { createCategory } from '../repositories/categoryRepository';
 import { createHabit } from '../repositories/habitRepository';
 import { upsertHabitEntry } from '../repositories/habitEntryRepository';
@@ -555,6 +556,20 @@ export async function seedDemoShowcase(options?: { force?: boolean }): Promise<S
   const wEntries: WEntry[] = [];
   let weight = 174.5;
 
+  // Full-window aggregates for the seeded Insights AI Review below. Every figure
+  // the review cites is accumulated here from the same numbers written to the DB,
+  // so the narrative stays true to the dataset (matches the weekly-review pattern).
+  const insWin = {
+    windDownNights: 0,
+    windDownSleepSum: 0,
+    otherNights: 0,
+    otherSleepSum: 0,
+    moodSum: 0,
+    energySum: 0,
+    sleepSum: 0,
+    days: 0,
+  };
+
   for (let daysAgo = WELLBEING_DAYS - 1; daysAgo >= 0; daysAgo--) {
     const dayKey = dayKeyDaysAgo(daysAgo);
     const inReportWeek = reportDaySet.has(dayKey);
@@ -606,6 +621,19 @@ export async function seedDemoShowcase(options?: { force?: boolean }): Promise<S
       week.sleepScoreSum += appleScore;
       week.sleepScoreCount++;
       if (windDown) week.windDownNights++;
+    }
+
+    // Full-window accumulation for the seeded Insights AI Review.
+    insWin.days++;
+    insWin.moodSum += mood;
+    insWin.energySum += energy;
+    insWin.sleepSum += appleScore;
+    if (windDown) {
+      insWin.windDownNights++;
+      insWin.windDownSleepSum += appleScore;
+    } else {
+      insWin.otherNights++;
+      insWin.otherSleepSum += appleScore;
     }
 
     const m = (metricKey: WEntry['metricKey'], value: number | string, timeOfDay: 'morning' | 'evening' | null, timestampUtc: string): WEntry =>
@@ -672,9 +700,13 @@ export async function seedDemoShowcase(options?: { force?: boolean }): Promise<S
   const headache = await createSymptom({ name: 'Headache', active: true }, HH, UID);
 
   const logRng = mulberry32(42);
+  let allergyTakenDays = 0;
   for (let daysAgo = WELLBEING_DAYS - 1; daysAgo >= 0; daysAgo--) {
     const dayKey = dayKeyDaysAgo(daysAgo);
-    if (logRng() < 0.92) await setMedicationLog({ medicationId: allergyMed.id, dayKey, taken: true }, HH, UID);
+    if (logRng() < 0.92) {
+      await setMedicationLog({ medicationId: allergyMed.id, dayKey, taken: true }, HH, UID);
+      allergyTakenDays++;
+    }
     if (logRng() < 0.85) await setSupplementLog({ supplementId: vitaminD.id, dayKey, taken: true }, HH, UID);
     if (logRng() < 0.7) await setSupplementLog({ supplementId: magnesium.id, dayKey, taken: true }, HH, UID);
     if (logRng() < 0.13) {
@@ -857,6 +889,91 @@ export async function seedDemoShowcase(options?: { force?: boolean }): Promise<S
         'You already know your best days start before 9am. Consider writing tomorrow’s one priority the night before, as part of the wind-down checklist.',
       journalEntriesCount: 10,
     },
+  });
+
+  // Insights AI Review — the cross-domain narrative shown on the Insights page's
+  // AI Review tab. Seeded (not live-generated) so the read-only demo can display
+  // a real review without a Gemini key. Every figure is computed from insWin,
+  // which was accumulated from the same wellbeing entries written above.
+  const wdMean = insWin.windDownNights ? round1(insWin.windDownSleepSum / insWin.windDownNights) : 0;
+  const otherMean = insWin.otherNights ? round1(insWin.otherSleepSum / insWin.otherNights) : 0;
+  const sleepGap = round1(wdMean - otherMean);
+  const avgMoodWin = insWin.days ? round1(insWin.moodSum / insWin.days) : 0;
+  const avgEnergyWin = insWin.days ? round1(insWin.energySum / insWin.days) : 0;
+  const avgSleepWin = insWin.days ? Math.round(insWin.sleepSum / insWin.days) : 0;
+  const allergyAdherence = Math.round((allergyTakenDays / WELLBEING_DAYS) * 100);
+  const insRangeStart = dayKeyDaysAgo(WELLBEING_DAYS - 1);
+  const insRangeEnd = dayKeyDaysAgo(0);
+
+  const insightsReview: InsightsAIReview = {
+    rangeDays: WELLBEING_DAYS,
+    rangeStart: insRangeStart,
+    rangeEnd: insRangeEnd,
+    summary:
+      `Across the last ${WELLBEING_DAYS} days the clearest signal is behavioral: the evenings you ran the wind-down ` +
+      `routine were followed by better sleep. On wind-down nights your sleep score averaged ${wdMean}, versus ` +
+      `${otherMean} on the nights you skipped it — a gap of about ${sleepGap} points (n=${insWin.windDownNights} vs ` +
+      `${insWin.otherNights}). Sleep, in turn, tracks with how the next morning feels: mood averaged ${avgMoodWin}/5 ` +
+      `and energy ${avgEnergyWin}/5 over the window, both leaning higher on mornings after a stronger sleep score.\n\n` +
+      `Adherence is a quiet strength — the allergy medication was taken on ${allergyAdherence}% of days. Everything ` +
+      `below is correlation, not causation: these are relationships measured in your own data, not proof that one ` +
+      `thing causes another.`,
+    keyFindings: [
+      `Wind-down nights averaged a ${wdMean} sleep score vs ${otherMean} on other nights (n=${insWin.windDownNights} vs ${insWin.otherNights}).`,
+      `Sleep score averaged ${avgSleepWin} across ${insWin.days} nights in the window.`,
+      `Morning mood averaged ${avgMoodWin}/5 and energy ${avgEnergyWin}/5.`,
+      `Allergy medication adherence was ${allergyAdherence}% (${allergyTakenDays}/${WELLBEING_DAYS} days).`,
+    ],
+    patterns: [
+      {
+        title: 'Wind-down routine precedes better sleep',
+        evidence: `The ~${sleepGap}-point sleep-score gap between wind-down and non-wind-down nights, over ${insWin.days} nights, is the strongest relationship in the window.`,
+        confidence: 'high',
+      },
+      {
+        title: 'Better sleep tracks with better mornings',
+        evidence: `Mornings after higher sleep scores tended to log higher mood and energy; the effect is consistent but smaller than the wind-down → sleep link.`,
+        confidence: 'medium',
+      },
+      {
+        title: 'Phone-in-bed and late caffeine drag on sleep',
+        evidence: `Nights with the phone in bed or afternoon caffeine skewed toward lower sleep scores, though they overlap with non-wind-down nights and can't be cleanly separated.`,
+        confidence: 'low',
+      },
+    ],
+    outlook: [
+      `If your recent wind-down consistency holds, the simple linear trend keeps sleep scores around ${avgSleepWin} — a projection from the current slope, not a guarantee.`,
+      `Morning energy has been drifting up over the window; keeping the morning walk + meditation pairing is the most likely lever to hold that trend.`,
+    ],
+    recommendations: [
+      {
+        title: 'Protect the wind-down on work nights',
+        reason: `It's the single behavior with the largest measured effect on your sleep (~${sleepGap}-point gap).`,
+        suggestedAction: 'Set a fixed screens-off time and keep the phone charging outside the bedroom.',
+      },
+      {
+        title: 'Move caffeine earlier',
+        reason: 'Afternoon-caffeine days lean toward lower sleep scores and longer time to fall asleep.',
+        suggestedAction: 'Make noon your last-coffee cutoff and switch to decaf after.',
+      },
+      {
+        title: 'Keep the morning stack intact',
+        reason: 'Days that start with the walk and meditation show up with higher morning energy.',
+        suggestedAction: 'Anchor the ten-minute sit to the end of the walk so it stays near-automatic.',
+      },
+    ],
+    dataLimitations: [
+      `${WELLBEING_DAYS} days is a modest window — relationships are directional, not conclusive.`,
+      `Behavioral factors overlap (wind-down nights also tend to be phone-free), so their individual effects can't be fully separated.`,
+      'Sleep scores are entered manually, so occasional gaps or estimation noise are expected.',
+    ],
+  };
+
+  await saveAIReport(HH, UID, {
+    kind: 'insights_review',
+    periodStart: insRangeStart,
+    periodEnd: insRangeEnd,
+    payload: { review: insightsReview },
   });
 
   return { seeded: true, reason: hadData ? 'reseeded' : 'seeded' };


### PR DESCRIPTION
## Problem

On the tour's Wellbeing Insights stop, the **AI Review** was (1) the *last* Insights tab and (2) showed only the "Add your Gemini API key in Settings" placeholder — never any data.

Two independent root causes for the empty state:
- The `AIReviewTab` gated purely on a local Gemini key and only ever populated from the **Generate** button. It never loaded archived reviews, so with no key (always the case in the demo iframe) it fell straight to the placeholder.
- Unlike `weekly_review` and `journal_summary`, the demo seed **never archived an `insights_review`**, and live generation is a Gemini BYOK `POST` that the read-only demo guard rejects anyway. So there was nothing to show *and* no way to show it.

## Changes

**Data (make the AI Review actually display):**
- **Seed a grounded `insights_review`** in `seedShowcase.ts`, composed from full-window aggregates accumulated off the same wellbeing entries already written — wind-down vs. other-night sleep-score means, morning mood/energy averages, and allergy-medication adherence. Every cited figure is true of the dataset (matches the existing sample-report pattern). Adds no new PRNG draws, so the generated dataset is byte-identical to before.
- **`AIReviewTab` loads the latest archived review on mount** via the keyless GET history endpoint and renders it. Generate/regenerate still requires a Gemini key; the placeholder now shows only when there is neither a key nor an archived review. This also benefits returning real users — they see their last review without spending another Gemini call.

**Ordering:**
- **AI Review is now the first and default Insights tab** (was last, opened on Overview), matching the documented "leads with its AI Review narration" intent. The tour's "statistics before narrative" copy stays accurate — it describes the data pipeline (stats computed first, then narrated), not the tab order.

**Docs:** Updated `docs/FEATURES.md` and `docs/product/HABITFLOW_UI_ARCHITECTURE.md` for the new tab order and the keyless archived-read behavior.

## Concrete effect

- **Before:** demo AI Review tab → "Add your Gemini API key in Settings." Nothing else.
- **After:** demo opens on AI Review showing a real narrative, e.g. *"On wind-down nights your sleep score averaged ~81 vs ~70 on nights you skipped it — a gap of ~11 points (n≈32 vs 13)"*, with confidence-tagged patterns, outlook, and recommendations — the exact wind-down↔sleep pattern the tour points to.

## Verification

- `npm run build` (tsc -b + vite build) — green
- `npm run lint:beta` — 0 errors
- Non-Mongo test suites pass; the Mongo-backed suites couldn't run in this environment (the sandbox network policy blocks the `mongodb-memory-server` binary download — unrelated to these changes; CI runs them normally).
- Standalone simulation of the seed's wellbeing-loop math confirms the review is non-degenerate: both night groups populated (no division by zero), a clear positive wind-down→sleep gap, and sensible averages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GWMKUg3RkuMY5q9KRjitH)_