### PR TITLE
Trim "How HabitFlow Works" AI tab, drop Health tab, and move the modal into Settings

### DIFF
--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -36,7 +36,7 @@ HabitFlow App
 │   ├── AI Hub (✨ modal: Wellbeing Summary + Weekly Review + Journal Insights cards; each with explanation, last-generated date, wand=generate, clock=history. Without a key each card surfaces the latest archived report inline — readable with no key, so the read-only demo shows real AI output)
 │   │   └── AI Report History modal (per kind: browse / open / delete saved reports; full-height page-style view)
 │   ├── Settings (modal)
-│   ├── Info / Tutorial (modal)
+│   │   └── Info / Tutorial "How HabitFlow works" (modal, opened from Settings)
 │   └── User Menu (dropdown: sign out, hide streaks)
 │
 ├── Bottom Tab Bar (4 tabs)
@@ -166,7 +166,7 @@ HabitFlow App
 | Completed Habits | Modal | Routine runner completion | Summary of habits logged during routine | Habits, Entries |
 | AI Hub | Modal | Header ✨ AI icon | Stacks the three AI artifacts as inline generators (Wellbeing Summary, Weekly Review, Journal Insights); each shows an explanation, last-generated date, and a history icon. When no Gemini key is configured, each card renders the latest archived report inline (readable without a key), so the read-only demo shows real AI output instead of an empty prompt | AI Reports |
 | Settings | Modal | Header settings icon | Preferences, API keys, data management | User config |
-| Info / Tutorial | Modal | Header info icon | App tutorial and feature explanations | — |
+| Info / Tutorial ("How HabitFlow works") | Modal | Settings → "How HabitFlow works" (below "Reopen setup guide") | App tutorial and feature explanations across Basics, Advanced, and AI tabs | — |
 | Habit Creation Inline | Modal | Quick-add in certain contexts | Lightweight inline habit creation | Habits |
 
 ### Apple Health Integration (Feature-Gated)
@@ -262,13 +262,14 @@ graph TB
     subgraph "Global (Header)"
         AIHUB["AI Hub Modal"]
         SETTINGS["Settings Modal"]
-        INFO["Info Modal"]
+        INFO["Info Modal (How HabitFlow works)"]
     end
 
     TAB_DASH --> DASH
     TAB_HABITS --> TRACKER
     TAB_ROUTINES --> ROUTINE_LIST
     TAB_GOALS --> GOALS_LIST
+    SETTINGS --> INFO
 ```
 
 ---

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -90,7 +90,7 @@ function renderExamples(examples: Example[]) {
 }
 
 export function InfoModal({ isOpen, onClose }: InfoModalProps) {
-  const [activeTab, setActiveTab] = useState<'basics' | 'advanced' | 'ai' | 'health'>('basics');
+  const [activeTab, setActiveTab] = useState<'basics' | 'advanced' | 'ai'>('basics');
 
   if (!isOpen) return null;
 
@@ -155,17 +155,6 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
             >
               <Brain size={14} className={activeTab === 'ai' ? 'text-emerald-400' : ''} />
               AI
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab('health')}
-              className={`flex items-center gap-1.5 pb-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${activeTab === 'health'
-                ? 'border-emerald-400 text-emerald-400'
-                : 'border-transparent text-neutral-500 hover:text-neutral-300'}`}
-            >
-              <Activity size={14} className={activeTab === 'health' ? 'text-emerald-400' : ''} />
-              Health
-              <span className="text-[9px] uppercase tracking-wide bg-amber-500/20 text-amber-400 px-1 py-0.5 rounded font-semibold">Beta</span>
             </button>
           </div>
 
@@ -473,63 +462,8 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                     <p className="mt-0.5">AI analyzes your routine and suggests Quick/Standard/Deep variants with full step lists.</p>
                   </li>
                   <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Journal Summaries</span>
-                    <p className="mt-0.5">Auto-generated weekly summary of your journal entries with themes, highlights, actionable feedback, and follow-up reminders. Appears as a dismissible banner on the Journal page and is saved to your journal history. Use the wand icon to generate and the clock icon to browse your saved summary history.</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
                     <span className="font-semibold text-neutral-300">Journal Insights</span>
                     <p className="mt-0.5">In the header AI hub (also on the Journal page's "AI Review" tab), pick a date range (last 7/30 days or custom) and generate a structured, grounded review of your entries: an Overview, Emotional Themes, Recurring Stressors, Wins, Self-Talk Patterns, Reflection Questions, Suggested Next Steps, and honest Data Limitations. It reads only your own writing, separates evidence from interpretation from suggestions, and stays supportive and non-clinical (no diagnoses). Empty ranges and sparse data are flagged, each generation is saved to history, and you can regenerate anytime.</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Persona-Driven Insights</span>
-                    <p className="mt-0.5">Choose an AI persona (like "The Strategic Coach") to guide your journaling prompts.</p>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          )}
-
-          {/* Health tab */}
-          {activeTab === 'health' && (
-            <div className="p-4 space-y-5">
-              <div className="bg-amber-500/5 border border-amber-500/20 rounded-lg px-3 py-2.5">
-                <p className="text-xs text-amber-400 uppercase tracking-wide font-semibold">Beta Feature</p>
-                <p className="text-xs text-neutral-400 mt-1">Apple Health integration is currently available to select users.</p>
-              </div>
-
-              <div className="pl-3 border-l-2 border-emerald-500/40">
-                <p className="text-sm text-neutral-200">
-                  <span className="font-bold text-emerald-400">Apple Health Integration</span>
-                </p>
-                <p className="text-sm text-neutral-300 mt-1">Sync health data from Apple Health to automatically track habits based on real-world activity.</p>
-
-                <ul className="mt-2 space-y-2">
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Getting Started</span>
-                    <p className="mt-0.5">Go to Settings &rarr; Apple Health to connect metrics and create health-tracked habits from a dedicated page.</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Supported Metrics</span>
-                    <p className="mt-0.5">Steps, active calories, sleep hours, workout minutes, and weight.</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Health Rules</span>
-                    <p className="mt-0.5">Define rules that auto-log habits when health data meets a threshold (e.g., auto-log "Walk" when steps exceed 8,000).</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Suggestions</span>
-                    <p className="mt-0.5">Receive suggestions to log habits based on your health data. Accept or dismiss each suggestion.</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Backfill</span>
-                    <p className="mt-0.5">When creating a health-tracked habit, pick a backfill window of 7, 30, or 90 days (or none). Backfill reads Apple Health data already synced into HabitFlow and creates entries for qualifying days in the window. It never overwrites existing entries and is capped at 365 days.</p>
-                  </li>
-                  <li className="text-xs text-neutral-400 pl-2">
-                    <span className="font-semibold text-neutral-300">Auto-Logged Entries</span>
-                    <div className="flex items-center gap-1.5 mt-0.5">
-                      <Activity size={11} className="text-emerald-500/70 shrink-0" />
-                      <span>Entries from Apple Health are marked with this icon in the tracker.</span>
-                    </div>
                   </li>
                 </ul>
               </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
-import { LayoutGrid, Settings, User, LogOut, Info, Eye, EyeOff, FlaskConical, Sparkles } from 'lucide-react';
+import { LayoutGrid, Settings, User, LogOut, Eye, EyeOff, FlaskConical, Sparkles } from 'lucide-react';
 import { useHabitStore } from '../store/HabitContext';
 import { useAuth } from '../store/AuthContext';
 import { useDashboardPrefs } from '../store/DashboardPrefsContext';
@@ -8,7 +8,6 @@ import { isBetaViewer } from '../lib/betaAccess';
 import { DEMO_WRITE_BLOCKED_EVENT, DEMO_READ_ONLY_MESSAGE, exitDemoMode, isEmbedMode } from '../lib/demoMode';
 import { useToast } from './Toast';
 import { SettingsModal } from './SettingsModal';
-import { InfoModal } from './InfoModal';
 import { AIStudioModal } from './dashboard/AIStudioModal';
 
 interface LayoutProps {
@@ -27,7 +26,6 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     const [devNotice, setDevNotice] = useState<string | null>(null);
     const [userMenuOpen, setUserMenuOpen] = useState(false);
     const [settingsOpen, setSettingsOpen] = useState(false);
-    const [infoOpen, setInfoOpen] = useState(false);
     const [aiOpen, setAiOpen] = useState(false);
     const userMenuRef = useRef<HTMLDivElement>(null);
 
@@ -150,13 +148,6 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                         <Sparkles size={20} />
                     </button>
                     <button
-                        onClick={() => setInfoOpen(true)}
-                        className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-white/5 rounded-full transition-colors text-neutral-400 hover:text-white"
-                        title="How HabitFlow Works"
-                    >
-                        <Info size={20} />
-                    </button>
-                    <button
                         onClick={() => setSettingsOpen(true)}
                         className="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-white/5 rounded-full transition-colors text-neutral-400 hover:text-white"
                         title="Settings"
@@ -252,10 +243,6 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                     window.history.pushState({ view: route }, '', url);
                     window.dispatchEvent(new PopStateEvent('popstate'));
                 }}
-            />
-            <InfoModal
-                isOpen={infoOpen}
-                onClose={() => setInfoOpen(false)}
             />
             {aiOpen && <AIStudioModal onClose={() => setAiOpen(false)} />}
         </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,8 +3,9 @@ import { useAuth } from '../store/AuthContext';
 import { useHabitStore } from '../store/HabitContext';
 import { getGeminiApiKey, setGeminiApiKey } from '../lib/geminiClient';
 import { deleteAllUserData, isHealthFeatureEnabled } from '../lib/persistenceClient';
-import { Eye, EyeOff, Sparkles, Activity, ChevronRight, Archive } from 'lucide-react';
+import { Eye, EyeOff, Sparkles, Activity, ChevronRight, Archive, Info } from 'lucide-react';
 import { ArchivedHabitsModal } from './ArchivedHabitsModal';
+import { InfoModal } from './InfoModal';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -21,6 +22,7 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
   const [showGeminiKey, setShowGeminiKey] = useState(false);
   const [geminiKeySaved, setGeminiKeySaved] = useState(false);
   const [showArchivedHabits, setShowArchivedHabits] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
   const archivedCount = habits.filter(h => h.archived === true && !h.deletedAt).length;
   const handleReopenGuide = useCallback(() => {
     try { localStorage.removeItem('hf_setup_guide_dismissed'); } catch { /* noop */ }
@@ -88,6 +90,14 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
               >
                 <Sparkles size={16} className="text-emerald-400 flex-shrink-0" />
                 Reopen setup guide
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowInfo(true)}
+                className="w-full mt-3 px-4 py-2.5 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 hover:bg-neutral-700 text-sm text-left flex items-center gap-2"
+              >
+                <Info size={16} className="text-emerald-400 flex-shrink-0" />
+                How HabitFlow works
               </button>
             </section>
 
@@ -263,6 +273,10 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
       <ArchivedHabitsModal
         isOpen={showArchivedHabits}
         onClose={() => setShowArchivedHabits(false)}
+      />
+      <InfoModal
+        isOpen={showInfo}
+        onClose={() => setShowInfo(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Updates the "How HabitFlow Works" info modal so it only reflects real functionality, and relocates it out of the global header into Settings.

### AI tab now lists only the AI features that exist
The AI tab called out features that aren't real. It now lists only the four shipping AI features:
- **Wellbeing Summary**
- **Weekly Review** (weekly summary)
- **Journal Insights**
- **Variant Suggestions** (routine variation generator)

Removed the **Journal Summaries** and **Persona-Driven Insights** entries.

### Removed the "Health (Beta)" tab
The Apple Health tab and its content were dropped from the modal — it's not useful there now. (The Apple Health integration itself is unchanged; only the modal tab was removed.)

### Moved "How HabitFlow works" from the top bar into Settings
- Removed the `Info` icon from the global header.
- Added a **"How HabitFlow works"** button in Settings, directly below **"Reopen setup guide"**.
- The `InfoModal` now renders from within `SettingsModal`.

## Changes
- `src/components/InfoModal.tsx` — trim AI tab, remove Health tab (and its `activeTab` union member).
- `src/components/Layout.tsx` — remove header Info button, modal render, state, and unused import.
- `src/components/SettingsModal.tsx` — add "How HabitFlow works" button + render `InfoModal`.
- `docs/product/HABITFLOW_UI_ARCHITECTURE.md` — reflect the modal moving from the header into Settings (IA tree, modal inventory, access-map diagram).

## Verification
- `npm run build` (tsc -b + vite build) passes.
- ESLint clean on the changed component files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXJ7GiLkR3rdynoB9rC6CS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXJ7GiLkR3rdynoB9rC6CS)_