### PR TITLE
Fix demo tour showing generate UI instead of seeded AI reports

### DIFF
--- a/src/components/dashboard/InsightsAIReviewCard.tsx
+++ b/src/components/dashboard/InsightsAIReviewCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Sparkles, Loader2, RefreshCw, Wand2, History } from 'lucide-react';
 import { hasGeminiApiKey } from '../../lib/geminiClient';
 import { fetchInsightsAIReview } from '../../lib/insightsClient';
+import { getActiveUserMode } from '../../lib/persistenceClient';
 import type { InsightsAIReview } from '../../shared/insightsAiReview';
 import type { InsightsReviewPayload } from '../../shared/aiReport';
 import { InsightsReviewBody } from '../insights/InsightsReviewBody';
@@ -23,7 +24,12 @@ export const InsightsAIReviewCard: React.FC = () => {
   const [showHistory, setShowHistory] = useState(false);
   const [genCount, setGenCount] = useState(0);
 
-  const hasKey = hasGeminiApiKey();
+  // The read-only demo always shows the saved (seeded) summary — never the
+  // generate UI. The tour iframe shares localStorage with the parent origin,
+  // so a visitor (or the owner) with a Gemini key stored would otherwise see
+  // an empty generator instead of the summary content.
+  const isDemo = getActiveUserMode() === 'demo';
+  const hasKey = hasGeminiApiKey() && !isDemo;
   const lastGenerated = useLastGenerated('insights_review', genCount);
   const archived = useLatestReport('insights_review', genCount);
 

--- a/src/components/dashboard/WeeklyAIReviewCard.tsx
+++ b/src/components/dashboard/WeeklyAIReviewCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Sparkles, Loader2, RefreshCw, Wand2, History } from 'lucide-react';
 import { hasGeminiApiKey, fetchWeeklyAIReview } from '../../lib/geminiClient';
+import { getActiveUserMode } from '../../lib/persistenceClient';
 import type { WeeklyAIReview } from '../../shared/weeklyAiReview';
 import type { WeeklyReviewPayload } from '../../shared/aiReport';
 import { WeeklyReviewBody } from './WeeklyReviewBody';
@@ -30,7 +31,12 @@ export const WeeklyAIReviewCard: React.FC = () => {
   const [showHistory, setShowHistory] = useState(false);
   const [genCount, setGenCount] = useState(0);
 
-  const hasKey = hasGeminiApiKey();
+  // The read-only demo always shows the saved (seeded) review — never the
+  // generate UI. The tour iframe shares localStorage with the parent origin,
+  // so a visitor (or the owner) with a Gemini key stored would otherwise see
+  // an empty generator instead of the review content.
+  const isDemo = getActiveUserMode() === 'demo';
+  const hasKey = hasGeminiApiKey() && !isDemo;
   const lastGenerated = useLastGenerated('weekly_review', genCount);
   const archived = useLatestReport('weekly_review', genCount);
 


### PR DESCRIPTION
## Problem

In the "Take a Tour" demo, the **Weekly AI Review** and **Wellbeing Summary** cards showed a live "Generate" button instead of the seeded report. Clicking it POSTs to the AI endpoints, which the read-only demo guard rejects — producing the `Failed to generate weekly review (403)` error visible in the tour. The **AI Journal Review** worked correctly because it already handled this case.

## Root cause

All three AI cards live in the AI hub modal. `WeeklyAIReviewCard` and `InsightsAIReviewCard` gated purely on whether a Gemini key exists in `localStorage`:

```js
const hasKey = hasGeminiApiKey();
```

The tour iframe shares `localStorage` with the parent origin, so a visitor (or the owner) with a key stored made `hasKey` true — rendering the live generator instead of the seeded archived report. The seeded `weekly_review` and `insights_review` reports already exist in the demo dataset; the cards just weren't reading them.

`JournalReviewPanel` already avoided this by forcing the archived path in demo mode.

## Fix

Mirror `JournalReviewPanel`'s guard in both cards:

```js
const isDemo = getActiveUserMode() === 'demo';
const hasKey = hasGeminiApiKey() && !isDemo;
```

This forces both cards into their existing archived-report branch in demo mode, so they display the seeded `weekly_review` / `insights_review` data — no live API call, no 403.

## Testing

- `npm run build` passes (tsc + vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01329XoKtQEkzZUhj96LTuYN)_