### PR TITLE
Web Push habit reminders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,19 @@ MONGODB_DB_NAME=habitflow
 #RESEND_API_KEY=
 #EMAIL_FROM=
 
+# --- Web Push reminders ---
+
+# Master switch for the push-reminder scheduler and subscription endpoints.
+#PUSH_REMINDERS_ENABLED=true
+
+# VAPID keys for Web Push. Generate once with: npx web-push generate-vapid-keys
+# WARNING: rotating these keys invalidates every existing device subscription —
+# users would have to re-enable notifications. Do not rotate casually.
+#VAPID_PUBLIC_KEY=
+#VAPID_PRIVATE_KEY=
+# Contact URI required by push services, e.g. mailto:you@example.com
+#VAPID_SUBJECT=
+
 # --- Testing ---
 
 # Set to true AND use a MONGODB_DB_NAME containing "_test" to run tests

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,6 +38,15 @@ reset-password, bootstrap-admin) are rate-limited via `authRateLimiter`.
 - `PATCH /habits/:id`
 - `DELETE /habits/:id`
 
+Habit create/PATCH accept `reminderTime` (24h `"HH:mm"`; `null` clears) and `reminderEnabled` (boolean; absent = enabled when a time is set) for Web Push reminders.
+
+## Push Notifications (Web Push Reminders)
+
+- `GET /push/public-key` — `{ enabled, publicKey }`; `enabled: false` when `PUSH_REMINDERS_ENABLED`/VAPID keys are not configured (clients hide push UI)
+- `POST /push/subscriptions` — body `{ subscription: { endpoint, keys: { p256dh, auth } }, timeZone, userAgent? }`; idempotent per-device upsert (refreshes keys/timezone/lastSeenAt, revives disabled endpoints); `501 PUSH_DISABLED` when unconfigured
+- `DELETE /push/subscriptions` — body `{ endpoint }` → `{ deleted }`
+- `POST /push/test` — sends a test notification to the caller's active devices → `{ sent, gone, errors }`; endpoints reported gone (404/410) are disabled
+
 ## Habit Entries (Canonical Behavioral Truth)
 
 - `GET /entries`

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -30,6 +30,8 @@ Defined in `src/models/persistenceTypes.ts` (`MONGO_COLLECTIONS`). **Current** c
 - `habitHealthRules` (habit ↔ health data rule mappings)
 - `healthSuggestions` (pending suggestions from health rule evaluation)
 - `aiReports` (archived AI-generated insights — Weekly Review, Journal Summary — for history; generated artifacts, not derived truth; soft-deleted)
+- `pushSubscriptions` (Web Push device registrations — operational device data, NOT truth; one doc per user+device endpoint with per-device IANA `timeZone`; unique index on `householdId+userId+endpoint`; gone endpoints soft-disabled via `disabledAt`, revived on re-subscribe; hard-deleted on user unsubscribe)
+- `pushSendLog` (reminder send-dedup ledger — operational, NOT truth; unique index on `habitId+dayKey+endpoint` makes scheduler sends at-most-once; rows expire via 48h TTL on `sentAt`)
 
 **Removed / no longer used:** `dayLogs`, `goalManualLogs`. Do not reference these in new code or docs.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -50,6 +50,7 @@ Every feature area below is **Shipped** unless an item notes otherwise.
 - **Archiving** — Archive a habit to hide it from active tracking while preserving the habit definition and all entries. The trash icon archives by default (click twice to confirm). Restored from **Settings → View archived habits** with one click; restoration brings the habit back to its original category with full entry history intact
 - **Remove Habit Modal (goal-linked habits)** — Removing a habit linked to one or more goals opens a chooser listing affected goals and offering two paths: **Archive** (recommended, restorable) or **Delete permanently** (soft-delete, not restorable from UI). Historical goal progress is preserved either way — past entries keep contributing to the goal — but only Archive lets you bring the habit itself back without re-creating it
 - **Reordering** — Drag-and-drop to reorder habits within categories
+- **Push Reminders** — Set a reminder time per habit (create/edit modal, Schedule section); a Web Push notification fires at that local time on the habit's assigned days and is skipped when the habit is already completed that day. Notifications are enabled per device from **Settings → Notifications** (test-send included); on iPhone/iPad the app must be added to the Home Screen first (iOS 16.4+). Server-side the feature is gated by `PUSH_REMINDERS_ENABLED` + VAPID keys, and the in-process scheduler requires an always-on backend instance
 
 ## Routines
 

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -292,6 +292,8 @@ graph TB
 | **Archive** | Tracker → trash icon (click twice). Goal-linked habits open the Remove Habit modal first |
 | **Restore** | Settings → View archived habits → Restore |
 | **Delete permanently** | Goal-linked: Remove Habit modal → "Delete permanently". Archived habit: Settings → View archived habits → trash icon → confirm |
+| **Set Reminder** | Add Habit Modal (create/edit) → Schedule & Streak section → Reminder time input + "Send push reminder" toggle (hidden for bundles) |
+| **Enable Notifications (per device)** | Settings → Notifications → "Enable habit reminders" (permission prompt; test-send + turn-off once enabled). Hidden in demo mode or when the server has push disabled. iPhone/iPad: requires Add to Home Screen first (iOS 16.4+) — the section shows install guidance until then |
 
 ### Routine
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "tailwind-merge": "^3.4.0",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -45,6 +46,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/supertest": "^6.0.3",
         "@types/uuid": "^10.0.0",
+        "@types/web-push": "^3.6.4",
         "@vitejs/plugin-react": "^5.1.1",
         "autoprefixer": "^10.4.22",
         "concurrently": "^9.2.1",
@@ -2184,6 +2186,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -2639,7 +2651,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2755,6 +2766,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2982,6 +3005,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
@@ -3081,6 +3110,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3851,6 +3886,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -4852,6 +4896,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4890,7 +4943,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5242,6 +5294,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5498,6 +5571,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -8324,6 +8403,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "tailwind-merge": "^3.4.0",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
@@ -62,6 +63,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.22",
     "concurrently": "^9.2.1",

--- a/public/sw.js
+++ b/public/sw.js
@@ -45,3 +45,68 @@ self.addEventListener('fetch', event => {
   );
 });
 
+// --- Web Push habit reminders ---
+
+self.addEventListener('push', event => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    // Payload missing or not JSON — fall back to a generic notification
+  }
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'HabitFlow', {
+      body: data.body || '',
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
+      tag: data.tag,
+      data: { url: (data.data && data.data.url) || '/' },
+    })
+  );
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || '/';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
+      const existing = clients.find(client => new URL(client.url).origin === self.location.origin);
+      if (existing) {
+        return existing
+          .focus()
+          .then(client => (client && 'navigate' in client ? client.navigate(url) : undefined))
+          .catch(() => undefined);
+      }
+      return self.clients.openWindow(url);
+    })
+  );
+});
+
+// Push services occasionally rotate subscriptions. Best-effort re-subscribe
+// and re-register with the API — this only works when the API is same-origin
+// (the session cookie authenticates); the reliable backstop is the
+// page-load re-sync in the app itself.
+self.addEventListener('pushsubscriptionchange', event => {
+  const applicationServerKey =
+    event.oldSubscription && event.oldSubscription.options
+      ? event.oldSubscription.options.applicationServerKey
+      : undefined;
+  if (!applicationServerKey) return;
+  event.waitUntil(
+    self.registration.pushManager
+      .subscribe({ userVisibleOnly: true, applicationServerKey })
+      .then(subscription =>
+        fetch('/api/push/subscriptions', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            subscription: subscription.toJSON(),
+            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+          }),
+        })
+      )
+      .catch(() => undefined)
+  );
+});
+

--- a/render.yaml
+++ b/render.yaml
@@ -21,3 +21,15 @@ services:
       # See docs/DEMO_ARCHITECTURE.md.
       - key: PUBLIC_DEMO_ENABLED
         value: "true"
+      # Web Push habit reminders. The scheduler is an in-process 60s timer, so
+      # it only fires reliably on an always-on instance (no idle sleep). Keys
+      # via: npx web-push generate-vapid-keys — rotating them invalidates all
+      # existing device subscriptions.
+      - key: PUSH_REMINDERS_ENABLED
+        value: "false"
+      - key: VAPID_PUBLIC_KEY
+        sync: false
+      - key: VAPID_PRIVATE_KEY
+        sync: false
+      - key: VAPID_SUBJECT
+        sync: false

--- a/src/components/AddHabitModal.tsx
+++ b/src/components/AddHabitModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { X, Shield, CheckCircle2, Calculator, Layers, CheckSquare, ChevronDown, ChevronRight, ChevronUp, Search, Trophy, Calendar } from 'lucide-react';
+import { X, Shield, CheckCircle2, Calculator, Layers, CheckSquare, ChevronDown, ChevronRight, ChevronUp, Search, Trophy, Calendar, Bell } from 'lucide-react';
 import { DayChipSelector } from './DayChipSelector';
 import { NumberChipSelector } from './NumberChipSelector';
 import { useHabitStore } from '../store/HabitContext';
@@ -68,6 +68,8 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
     const [durationMinutes, setDurationMinutes] = useState('30');
     const [scheduledDays, setScheduledDays] = useState<number[]>([0, 1, 2, 3, 4, 5, 6]);
     const [requiredDaysPerWeek, setRequiredDaysPerWeek] = useState<number>(7);
+    const [reminderTime, setReminderTime] = useState('');
+    const [reminderEnabled, setReminderEnabled] = useState(true);
 
     // Metadata
     const [description, setDescription] = useState('');
@@ -114,6 +116,8 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                 setTarget(initialData.goal.target ? String(initialData.goal.target) : '');
                 setUnit(initialData.goal.unit || '');
                 setScheduledTime(initialData.scheduledTime || '');
+                setReminderTime(initialData.reminderTime || '');
+                setReminderEnabled(initialData.reminderEnabled !== false);
                 setLinkedGoalId(initialData.linkedGoalId || null);
                 setLinkedRoutineIds(initialData.linkedRoutineIds || []);
                 setDurationMinutes(initialData.durationMinutes?.toString() || '30');
@@ -145,6 +149,8 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                 setTarget('');
                 setUnit('');
                 setScheduledTime('');
+                setReminderTime('');
+                setReminderEnabled(true);
                 setLinkedGoalId(null);
                 setIsCreateGoalOpen(false);
                 setLinkedRoutineIds([]);
@@ -243,6 +249,10 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                 goal: goalConfig,
                 assignedDays: scheduledDays,
                 scheduledTime: scheduledTime || undefined,
+                // Bundles are containers (never trackable) — no reminders.
+                // null clears a previously set time on edit.
+                reminderTime: habitType === 'bundle' || !reminderTime ? null : reminderTime,
+                reminderEnabled,
                 durationMinutes: durationMinutes ? Number(durationMinutes) : undefined,
                 linkedGoalId: linkedGoalId || undefined,
                 linkedRoutineIds: linkedRoutineIds.length > 0 ? linkedRoutineIds : undefined,
@@ -1156,6 +1166,49 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({ isOpen, onClose, c
                                 </p>
                             )}
                         </div>
+
+                        {/* Reminder — bundles are containers, never trackable, so no reminders */}
+                        {habitType !== 'bundle' && (
+                            <div className="space-y-2">
+                                <label htmlFor="reminder-time" className="text-xs font-medium text-neutral-400 uppercase flex items-center gap-1">
+                                    <Bell size={12} /> Reminder
+                                </label>
+                                <div className="flex items-center gap-2">
+                                    <input
+                                        id="reminder-time"
+                                        type="time"
+                                        value={reminderTime}
+                                        onChange={(e) => setReminderTime(e.target.value)}
+                                        className="px-3 py-2 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 text-base focus:outline-none focus:ring-1 focus:ring-emerald-500/50 [color-scheme:dark]"
+                                    />
+                                    {reminderTime && (
+                                        <button
+                                            type="button"
+                                            onClick={() => setReminderTime('')}
+                                            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-500 hover:text-neutral-300 rounded-lg hover:bg-white/5"
+                                            aria-label="Clear reminder time"
+                                        >
+                                            <X size={16} />
+                                        </button>
+                                    )}
+                                </div>
+                                {reminderTime && (
+                                    <label className="flex items-center gap-2 text-sm text-neutral-300 cursor-pointer">
+                                        <input
+                                            type="checkbox"
+                                            checked={reminderEnabled}
+                                            onChange={(e) => setReminderEnabled(e.target.checked)}
+                                            className="w-4 h-4 rounded border-white/20 bg-neutral-800 accent-emerald-500"
+                                        />
+                                        Send push reminder
+                                    </label>
+                                )}
+                                <p className="text-[11px] text-neutral-500">
+                                    Reminders go to devices where you've enabled notifications
+                                    (Settings → Notifications). Skipped on days the habit is already done.
+                                </p>
+                            </div>
+                        )}
                     </div>
 
                     {/* Add to Bundle action — for regular habits not already in a bundle */}

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -225,6 +225,23 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                 </div>
               ))}
 
+              {/* Reminders */}
+              <div className="pl-3 border-l-2 border-emerald-500/40">
+                <p className="text-sm text-neutral-200">
+                  <span className="font-bold text-emerald-400">Reminders</span>
+                </p>
+                <p className="text-sm text-neutral-300 mt-1">
+                  Give any habit a reminder time (when creating or editing it) and HabitFlow
+                  sends a push notification at that time on the habit's scheduled days —
+                  skipped automatically once the habit is done for the day. Turn notifications
+                  on per device in <span className="text-neutral-200">Settings → Notifications</span>.
+                </p>
+                <p className="text-xs text-neutral-500 mt-1.5">
+                  iPhone/iPad: add HabitFlow to your Home Screen first (Share → Add to Home
+                  Screen), then enable reminders from the installed app. Requires iOS 16.4+.
+                </p>
+              </div>
+
               {/* Link to advanced tab */}
               <div className="pt-2 border-t border-white/5">
                 <button

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,11 +1,149 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../store/AuthContext';
 import { useHabitStore } from '../store/HabitContext';
 import { getGeminiApiKey, setGeminiApiKey } from '../lib/geminiClient';
-import { deleteAllUserData, isHealthFeatureEnabled } from '../lib/persistenceClient';
-import { Eye, EyeOff, Sparkles, Activity, ChevronRight, Archive, Info } from 'lucide-react';
+import { deleteAllUserData, isHealthFeatureEnabled, getPushPublicKey, sendTestPush, getActiveUserMode } from '../lib/persistenceClient';
+import { getPushStatus, enablePush, disablePush, type PushStatus } from '../lib/pushClient';
+import { Eye, EyeOff, Sparkles, Activity, ChevronRight, Archive, Info, Bell, BellOff } from 'lucide-react';
 import { ArchivedHabitsModal } from './ArchivedHabitsModal';
 import { InfoModal } from './InfoModal';
+
+/**
+ * Per-device push reminder controls. Mounted only while the modal is open;
+ * hidden entirely when the server has push disabled or in demo mode.
+ */
+function NotificationsSection() {
+  const [serverEnabled, setServerEnabled] = useState<boolean | null>(null);
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [status, setStatus] = useState<PushStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const key = await getPushPublicKey();
+        if (cancelled) return;
+        setServerEnabled(key.enabled);
+        setPublicKey(key.publicKey);
+        if (key.enabled) {
+          const current = await getPushStatus();
+          if (!cancelled) setStatus(current);
+        }
+      } catch {
+        if (!cancelled) setServerEnabled(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (getActiveUserMode() === 'demo' || serverEnabled === false || serverEnabled === null) {
+    return null;
+  }
+
+  const rowClass = 'w-full px-4 py-2.5 rounded-lg bg-neutral-800 text-neutral-200 border border-white/10 hover:bg-neutral-700 text-sm text-left flex items-center gap-2';
+
+  const handleEnable = async () => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      // Direct call in the click stack — iOS requires the permission prompt
+      // inside a user gesture (publicKey prefetched above).
+      await enablePush(publicKey ?? undefined);
+      setStatus('enabled');
+      setNotice('Reminders enabled on this device.');
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : 'Could not enable notifications.');
+      setStatus(await getPushStatus());
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDisable = async () => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      await disablePush();
+      setStatus('disabled');
+      setNotice('Reminders turned off on this device.');
+    } catch {
+      setNotice('Could not turn off notifications.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      const result = await sendTestPush();
+      setNotice(result.sent > 0 ? 'Test notification sent.' : 'No active devices received the test.');
+    } catch {
+      setNotice('Could not send the test notification.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section>
+      <h3 className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-2">
+        Notifications
+      </h3>
+      {status === 'needs-install' && (
+        <p className="text-[11px] text-neutral-500 px-1">
+          On iPhone and iPad, first add HabitFlow to your Home Screen
+          (Share <span aria-hidden="true">→</span> Add to Home Screen), then enable
+          reminders from the installed app. Requires iOS 16.4 or later.
+        </p>
+      )}
+      {status === 'unsupported' && (
+        <p className="text-[11px] text-neutral-500 px-1">
+          This browser does not support push notifications.
+        </p>
+      )}
+      {status === 'denied' && (
+        <p className="text-[11px] text-neutral-500 px-1">
+          Notifications are blocked for HabitFlow. Re-enable them in your device
+          or browser settings, then come back here.
+        </p>
+      )}
+      {status === 'disabled' && (
+        <button type="button" onClick={handleEnable} disabled={busy} className={rowClass}>
+          <Bell size={16} className="text-emerald-400 flex-shrink-0" />
+          <span className="flex-1">{busy ? 'Enabling…' : 'Enable habit reminders'}</span>
+        </button>
+      )}
+      {status === 'enabled' && (
+        <div className="space-y-2">
+          <div className="px-4 py-2.5 rounded-lg bg-neutral-800/60 border border-white/10 text-sm text-neutral-300 flex items-center gap-2">
+            <Bell size={16} className="text-emerald-400 flex-shrink-0" />
+            <span className="flex-1">Reminders on this device: On</span>
+          </div>
+          <div className="flex gap-2">
+            <button type="button" onClick={handleTest} disabled={busy} className={`${rowClass} flex-1`}>
+              Send test notification
+            </button>
+            <button type="button" onClick={handleDisable} disabled={busy} className={`${rowClass} flex-1 text-neutral-400`}>
+              <BellOff size={14} className="flex-shrink-0" />
+              Turn off
+            </button>
+          </div>
+        </div>
+      )}
+      {notice && <p className="text-[11px] text-neutral-400 mt-2 px-1">{notice}</p>}
+      {status === 'disabled' && (
+        <p className="text-[11px] text-neutral-500 mt-2 px-1">
+          Get a push notification when a habit with a reminder time is due.
+          Set times per habit when creating or editing it.
+        </p>
+      )}
+    </section>
+  );
+}
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -119,6 +257,9 @@ export function SettingsModal({ isOpen, onClose, onNavigate }: SettingsModalProp
                 <ChevronRight size={16} className="text-neutral-500" />
               </button>
             </section>
+
+            {/* Notifications (push reminders) */}
+            <NotificationsSection />
 
             {/* Apple Health Integration */}
             {isHealthFeatureEnabled(user?.email) && (

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -465,6 +465,52 @@ export async function setSymptomLog(params: {
 }
 
 /**
+ * Web Push Persistence Functions
+ */
+export type PushPublicKeyResponse = {
+  enabled: boolean;
+  publicKey: string | null;
+};
+
+export type SavedPushSubscription = {
+  id: string;
+  endpoint: string;
+  timeZone: string;
+  createdAt: string;
+  lastSeenAt: string;
+};
+
+export async function getPushPublicKey(): Promise<PushPublicKeyResponse> {
+  return apiRequest<PushPublicKeyResponse>('/push/public-key');
+}
+
+export async function savePushSubscription(input: {
+  subscription: { endpoint: string; keys: { p256dh: string; auth: string } };
+  timeZone: string;
+  userAgent?: string;
+}): Promise<SavedPushSubscription> {
+  const response = await apiRequest<{ subscription: SavedPushSubscription }>('/push/subscriptions', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+  return response.subscription;
+}
+
+export async function deletePushSubscription(endpoint: string): Promise<boolean> {
+  const response = await apiRequest<{ deleted: boolean }>('/push/subscriptions', {
+    method: 'DELETE',
+    body: JSON.stringify({ endpoint }),
+  });
+  return response.deleted;
+}
+
+export async function sendTestPush(): Promise<{ sent: number; gone: number; errors: number }> {
+  return apiRequest<{ sent: number; gone: number; errors: number }>('/push/test', {
+    method: 'POST',
+  });
+}
+
+/**
  * Supplement Persistence Functions (Health Hub)
  */
 export type SupplementInput = {

--- a/src/lib/pushClient.ts
+++ b/src/lib/pushClient.ts
@@ -1,0 +1,156 @@
+/**
+ * Browser Web Push client
+ *
+ * All permission/subscription logic for push reminders lives here. iOS
+ * constraints shape this module: Web Push requires iOS 16.4+, the app must be
+ * installed to the Home Screen (standalone), and Notification.requestPermission
+ * must run inside a user-gesture call stack — so enablePush() is designed to
+ * be called directly from an onClick handler.
+ */
+
+import {
+  getPushPublicKey,
+  savePushSubscription,
+  deletePushSubscription,
+  getLocalTimeZone,
+} from './persistenceClient';
+
+export type PushStatus =
+  | 'unsupported'   // browser lacks Push API (or iOS Safari outside a PWA install)
+  | 'needs-install' // iOS: must Add to Home Screen before push is available
+  | 'denied'        // permission hard-denied; only device settings can undo
+  | 'enabled'       // permission granted + active subscription on this device
+  | 'disabled';     // available but not turned on for this device
+
+export function isPushSupported(): boolean {
+  return 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window;
+}
+
+export function isIos(): boolean {
+  const ua = navigator.userAgent;
+  // iPadOS 13+ reports as Macintosh; the touch check distinguishes it
+  return /iPhone|iPad|iPod/.test(ua) || (ua.includes('Macintosh') && navigator.maxTouchPoints > 1);
+}
+
+export function isStandalone(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as { standalone?: boolean }).standalone === true
+  );
+}
+
+/** iOS only exposes Web Push to Home-Screen-installed apps. */
+export function needsInstallForPush(): boolean {
+  return isIos() && !isStandalone();
+}
+
+export async function getPushStatus(): Promise<PushStatus> {
+  if (needsInstallForPush()) return 'needs-install';
+  if (!isPushSupported()) return 'unsupported';
+  if (Notification.permission === 'denied') return 'denied';
+  if (Notification.permission !== 'granted') return 'disabled';
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription ? 'enabled' : 'disabled';
+  } catch {
+    return 'disabled';
+  }
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  // Explicit ArrayBuffer backing so the result satisfies BufferSource
+  const outputArray = new Uint8Array(new ArrayBuffer(rawData.length));
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+/**
+ * Request permission, subscribe this device, and register it with the API.
+ * MUST be called from a user-gesture handler (iOS requirement) — pass a
+ * prefetched VAPID key so Notification.requestPermission() is the first await
+ * and the gesture's transient activation is still valid.
+ * Throws with a user-presentable message on failure.
+ */
+export async function enablePush(prefetchedPublicKey?: string): Promise<void> {
+  if (needsInstallForPush()) {
+    throw new Error('Add HabitFlow to your Home Screen first, then enable reminders from the installed app.');
+  }
+  if (!isPushSupported()) {
+    throw new Error('This browser does not support push notifications.');
+  }
+
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') {
+    throw new Error('Notification permission was not granted.');
+  }
+
+  let publicKey = prefetchedPublicKey;
+  if (!publicKey) {
+    const response = await getPushPublicKey();
+    if (!response.enabled || !response.publicKey) {
+      throw new Error('Push notifications are not enabled on the server.');
+    }
+    publicKey = response.publicKey;
+  }
+
+  const registration = await navigator.serviceWorker.ready;
+  const subscription =
+    (await registration.pushManager.getSubscription()) ??
+    (await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    }));
+
+  await registerSubscription(subscription);
+}
+
+/** Unsubscribe this device and remove it from the API. */
+export async function disablePush(): Promise<void> {
+  if (!isPushSupported()) return;
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) return;
+
+  const endpoint = subscription.endpoint;
+  await subscription.unsubscribe();
+  await deletePushSubscription(endpoint);
+}
+
+/**
+ * Re-register the existing subscription on app open. Refreshes the device's
+ * timezone (heals drift when traveling) and lastSeenAt, and is the reliable
+ * backstop for push-service endpoint rotation. Never throws.
+ */
+export async function syncPushSubscription(): Promise<void> {
+  try {
+    if (!isPushSupported() || Notification.permission !== 'granted') return;
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    if (!subscription) return;
+    await registerSubscription(subscription);
+  } catch {
+    // Best-effort: sync failures must never affect app startup
+  }
+}
+
+async function registerSubscription(subscription: PushSubscription): Promise<void> {
+  const json = subscription.toJSON();
+  if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) {
+    throw new Error('Push subscription is missing endpoint or keys.');
+  }
+  await savePushSubscription({
+    subscription: {
+      endpoint: json.endpoint,
+      keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
+    },
+    timeZone: getLocalTimeZone(),
+    userAgent: navigator.userAgent,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { applyDemoBootParams } from './lib/demoMode'
+import { syncPushSubscription } from './lib/pushClient'
 
 // Apply ?demo=1 / ?demo=0 before anything reads the active user mode.
 applyDemoBootParams()
@@ -15,7 +16,10 @@ createRoot(document.getElementById('root')!).render(
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((error) => {
+    navigator.serviceWorker.register('/sw.js').then(() => {
+      // Refresh this device's push registration (timezone, rotated endpoints)
+      void syncPushSubscription();
+    }).catch((error) => {
       console.error('Service worker registration failed:', error);
     });
   });

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -1492,7 +1492,34 @@ export const MONGO_COLLECTIONS = {
     SYMPTOM_LOGS: 'symptomLogs',
     SUPPLEMENTS: 'supplements',
     SUPPLEMENT_LOGS: 'supplementLogs',
+    PUSH_SUBSCRIPTIONS: 'pushSubscriptions',
+    PUSH_SEND_LOG: 'pushSendLog',
 } as const;
+
+/**
+ * Web Push device subscription (operational data, NOT truth data).
+ *
+ * One document per device/browser a user has enabled notifications on.
+ * Stored scoped by householdId + userId (stripped on read like other repos).
+ * `timeZone` is per-device and refreshed on every subscribe call so reminders
+ * fire in the device's local time. `disabledAt` marks endpoints the push
+ * service reported gone (404/410); re-subscribing revives the document.
+ */
+export interface PushSubscriptionDoc {
+  id: string;
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+  /** IANA timezone captured at subscribe time, refreshed on each sync. */
+  timeZone: string;
+  userAgent?: string;
+  createdAt: string;
+  lastSeenAt: string;
+  /** Set when the push service reports the endpoint gone; cleared on re-subscribe. */
+  disabledAt?: string;
+}
 
 /**
  * Household user registry (lightweight; no passwords/auth).

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -170,6 +170,19 @@ export interface Habit {
     scheduledTime?: string;
 
     /**
+     * Optional: Push reminder time ("HH:mm"), interpreted in each subscribed
+     * device's local timezone. Reminders fire only on assignedDays (or every
+     * day when unset) and skip habits already completed that day.
+     */
+    reminderTime?: string;
+
+    /**
+     * Optional: Toggle push reminders without losing the configured time.
+     * Absent means enabled when reminderTime is set.
+     */
+    reminderEnabled?: boolean;
+
+    /**
      * Optional: Duration in minutes for the habit (default: 30).
      * Used for calendar visualization.
      */

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -173,8 +173,9 @@ export interface Habit {
      * Optional: Push reminder time ("HH:mm"), interpreted in each subscribed
      * device's local timezone. Reminders fire only on assignedDays (or every
      * day when unset) and skip habits already completed that day.
+     * null clears the reminder on PATCH (and may round-trip from storage).
      */
-    reminderTime?: string;
+    reminderTime?: string | null;
 
     /**
      * Optional: Toggle push reminders without losing the configured time.

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -26,6 +26,12 @@ import { getEntriesRoute, createEntryRoute, upsertEntryByKeyRoute, getEntryRoute
 import { getTasksRoute, createTaskRoute, updateTaskRoute, deleteTaskRoute } from './routes/tasks';
 import { getDashboardPrefsRoute, updateDashboardPrefsRoute } from './routes/dashboardPrefs';
 import {
+  getPushPublicKeyRoute,
+  savePushSubscriptionRoute,
+  deletePushSubscriptionRoute,
+  sendTestPushRoute,
+} from './routes/pushSubscriptions';
+import {
   getAuthMe,
   postInviteRedeem,
   postLogin,
@@ -169,6 +175,12 @@ export function createApp(): Express {
   app.post('/api/habits/:id/convert-to-bundle', convertToBundleRoute);
   app.post('/api/habits/:id/archive', archiveHabitRoute);
   app.post('/api/habits/:id/unarchive', unarchiveHabitRoute);
+
+  // Web Push reminders (subscription management; behind identity + demo guard)
+  app.get('/api/push/public-key', getPushPublicKeyRoute);
+  app.post('/api/push/subscriptions', savePushSubscriptionRoute);
+  app.delete('/api/push/subscriptions', deletePushSubscriptionRoute);
+  app.post('/api/push/test', sendTestPushRoute);
 
   // Apple Health integration (feature-gated)
   app.use('/api/health', requireHealthFeature, healthRoutes);

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -64,6 +64,21 @@ export function getMongoDbName(): string {
   return process.env.MONGODB_DB_NAME || '';
 }
 
+// Web Push (VAPID) configuration. Generate keys with: npx web-push generate-vapid-keys
+// The public key is safe to expose to clients; the private key is server-only.
+export function getVapidPublicKey(): string {
+  return process.env.VAPID_PUBLIC_KEY || '';
+}
+
+export function getVapidPrivateKey(): string {
+  return process.env.VAPID_PRIVATE_KEY || '';
+}
+
+export function getVapidSubject(): string {
+  // Contact URI sent to push services (mailto: or https:), required by VAPID.
+  return process.env.VAPID_SUBJECT || '';
+}
+
 // For backward compatibility, also export as constants (but they read from process.env)
 // Note: These will be evaluated at import time, so set env vars before importing
 export const MONGODB_URI = getMongoDbUri();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,11 +12,15 @@ import { createApp } from './app';
 import { closeConnection } from './lib/mongoClient';
 import { runStartupMigrations } from './migrations/startup';
 import { maybeSeedDemoShowcase } from './demo/seedShowcase';
+import { isPushConfigured } from './lib/webPush';
+import { startReminderScheduler, type ReminderSchedulerHandle } from './services/reminderScheduler';
 
 assertMongoEnabled();
 
 const app = createApp();
 const PORT = process.env.PORT || 3001;
+
+let schedulerHandle: ReminderSchedulerHandle | null = null;
 
 const server = app.listen(PORT, async () => {
   console.log(`🚀 Server running on http://localhost:${PORT}`);
@@ -34,10 +38,18 @@ const server = app.listen(PORT, async () => {
   if (isPublicDemoEnabled()) {
     await maybeSeedDemoShowcase();
   }
+
+  // Web Push reminder scheduler (in-process; requires an always-on instance)
+  if (isPushConfigured()) {
+    schedulerHandle = startReminderScheduler();
+  } else {
+    console.log('🔕 Push reminders disabled (PUSH_REMINDERS_ENABLED/VAPID keys not configured)');
+  }
 });
 
 process.on('SIGTERM', async () => {
   console.log('SIGTERM received, shutting down gracefully...');
+  schedulerHandle?.stop();
   server.close(async () => {
     await closeConnection();
     process.exit(0);
@@ -46,6 +58,7 @@ process.on('SIGTERM', async () => {
 
 process.on('SIGINT', async () => {
   console.log('SIGINT received, shutting down gracefully...');
+  schedulerHandle?.stop();
   server.close(async () => {
     await closeConnection();
     process.exit(0);

--- a/src/server/lib/webPush.ts
+++ b/src/server/lib/webPush.ts
@@ -1,0 +1,72 @@
+/**
+ * Web Push sender
+ *
+ * Thin wrapper around the web-push library: lazy VAPID initialization from
+ * env, and a sendPush() that maps push-service responses to a small result
+ * union. Isolated in one module so tests can vi.mock it.
+ */
+
+import webpush from 'web-push';
+import { getVapidPublicKey, getVapidPrivateKey, getVapidSubject } from '../config/env';
+import { getFeatureFlag } from '../config';
+
+let vapidInitialized = false;
+
+/**
+ * True when push is switched on AND VAPID keys are configured.
+ * Routes return PUSH_DISABLED and the scheduler stays off otherwise.
+ */
+export function isPushConfigured(): boolean {
+  return (
+    getFeatureFlag('PUSH_REMINDERS_ENABLED') &&
+    getVapidPublicKey().length > 0 &&
+    getVapidPrivateKey().length > 0
+  );
+}
+
+function ensureVapid(): void {
+  if (vapidInitialized) return;
+  const subject = getVapidSubject() || 'mailto:admin@habitflow.local';
+  webpush.setVapidDetails(subject, getVapidPublicKey(), getVapidPrivateKey());
+  vapidInitialized = true;
+}
+
+export interface PushTarget {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  /** Coalesces notifications with the same tag on the device. */
+  tag?: string;
+  data?: { url?: string };
+}
+
+export type PushSendResult = 'sent' | 'gone' | 'error';
+
+/**
+ * Send one push message. 'gone' means the push service reported the endpoint
+ * dead (404/410) and the subscription should be disabled; 'error' is
+ * transient (caller may retry).
+ */
+export async function sendPush(target: PushTarget, payload: PushPayload): Promise<PushSendResult> {
+  ensureVapid();
+  try {
+    await webpush.sendNotification(
+      { endpoint: target.endpoint, keys: target.keys },
+      JSON.stringify(payload),
+      { TTL: 600, urgency: 'high' }
+    );
+    return 'sent';
+  } catch (error) {
+    const statusCode = (error as { statusCode?: number })?.statusCode;
+    if (statusCode === 404 || statusCode === 410) {
+      return 'gone';
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[WebPush] send failed (status ${statusCode ?? 'n/a'}): ${message}`);
+    return 'error';
+  }
+}

--- a/src/server/repositories/__tests__/pushSubscriptionRepository.test.ts
+++ b/src/server/repositories/__tests__/pushSubscriptionRepository.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Push Subscription Repository Tests
+ *
+ * Integration tests for Web Push device subscription persistence and the
+ * pushSendLog dedup ledger. Uses mongodb-memory-server via shared test helper.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import {
+  upsertPushSubscription,
+  deletePushSubscriptionByEndpoint,
+  disablePushSubscriptionByEndpoint,
+  getActivePushSubscriptionsForUser,
+  getActivePushSubscriptions,
+} from '../pushSubscriptionRepository';
+import { tryClaimSend, markSendResult, releaseClaim } from '../pushSendLogRepository';
+
+const HH = 'test-household-push';
+const USER_A = 'test-user-push-a';
+const USER_B = 'test-user-push-b';
+
+const ENDPOINT_1 = 'https://push.example.com/send/device-1';
+const ENDPOINT_2 = 'https://push.example.com/send/device-2';
+
+function input(overrides: Partial<{ endpoint: string; timeZone: string }> = {}) {
+  return {
+    endpoint: overrides.endpoint ?? ENDPOINT_1,
+    keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+    timeZone: overrides.timeZone ?? 'America/New_York',
+    userAgent: 'test-agent',
+  };
+}
+
+describe('PushSubscriptionRepository', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await db.collection('pushSubscriptions').deleteMany({});
+    await db.collection('pushSendLog').deleteMany({});
+  });
+
+  it('creates a subscription with generated id and timestamps', async () => {
+    const sub = await upsertPushSubscription(HH, USER_A, input());
+    expect(sub.id).toBeTruthy();
+    expect(sub.endpoint).toBe(ENDPOINT_1);
+    expect(sub.timeZone).toBe('America/New_York');
+    expect(sub.createdAt).toBeTruthy();
+    expect(sub.lastSeenAt).toBeTruthy();
+    expect((sub as any).householdId).toBeUndefined(); // scope stripped on read
+    expect((sub as any).userId).toBeUndefined();
+  });
+
+  it('is idempotent: re-subscribe refreshes timeZone/lastSeenAt but keeps id and createdAt', async () => {
+    const first = await upsertPushSubscription(HH, USER_A, input());
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await upsertPushSubscription(HH, USER_A, input({ timeZone: 'Europe/London' }));
+
+    expect(second.id).toBe(first.id);
+    expect(second.createdAt).toBe(first.createdAt);
+    expect(second.timeZone).toBe('Europe/London');
+    expect(second.lastSeenAt >= first.lastSeenAt).toBe(true);
+
+    const db = await getTestDb();
+    expect(await db.collection('pushSubscriptions').countDocuments({})).toBe(1);
+  });
+
+  it('re-subscribe revives a disabled endpoint', async () => {
+    await upsertPushSubscription(HH, USER_A, input());
+    await disablePushSubscriptionByEndpoint(HH, USER_A, ENDPOINT_1);
+    expect(await getActivePushSubscriptionsForUser(HH, USER_A)).toHaveLength(0);
+
+    const revived = await upsertPushSubscription(HH, USER_A, input());
+    expect(revived.disabledAt).toBeUndefined();
+    expect(await getActivePushSubscriptionsForUser(HH, USER_A)).toHaveLength(1);
+  });
+
+  it('supports multiple devices per user', async () => {
+    await upsertPushSubscription(HH, USER_A, input({ endpoint: ENDPOINT_1 }));
+    await upsertPushSubscription(HH, USER_A, input({ endpoint: ENDPOINT_2 }));
+    const subs = await getActivePushSubscriptionsForUser(HH, USER_A);
+    expect(subs).toHaveLength(2);
+  });
+
+  it('delete removes only the targeted endpoint for the scoped user', async () => {
+    await upsertPushSubscription(HH, USER_A, input({ endpoint: ENDPOINT_1 }));
+    await upsertPushSubscription(HH, USER_B, input({ endpoint: ENDPOINT_2 }));
+
+    // User B cannot delete user A's endpoint
+    expect(await deletePushSubscriptionByEndpoint(HH, USER_B, ENDPOINT_1)).toBe(false);
+    // User A can
+    expect(await deletePushSubscriptionByEndpoint(HH, USER_A, ENDPOINT_1)).toBe(true);
+
+    expect(await getActivePushSubscriptionsForUser(HH, USER_A)).toHaveLength(0);
+    expect(await getActivePushSubscriptionsForUser(HH, USER_B)).toHaveLength(1);
+  });
+
+  it('scoped reads do not leak across users', async () => {
+    await upsertPushSubscription(HH, USER_A, input({ endpoint: ENDPOINT_1 }));
+    const subsB = await getActivePushSubscriptionsForUser(HH, USER_B);
+    expect(subsB).toHaveLength(0);
+  });
+
+  it('getActivePushSubscriptions returns all active subs with scope fields (scheduler)', async () => {
+    await upsertPushSubscription(HH, USER_A, input({ endpoint: ENDPOINT_1 }));
+    await upsertPushSubscription(HH, USER_B, input({ endpoint: ENDPOINT_2 }));
+    await disablePushSubscriptionByEndpoint(HH, USER_B, ENDPOINT_2);
+
+    const all = await getActivePushSubscriptions();
+    expect(all).toHaveLength(1);
+    expect(all[0].householdId).toBe(HH);
+    expect(all[0].userId).toBe(USER_A);
+  });
+});
+
+describe('PushSendLogRepository', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await db.collection('pushSendLog').deleteMany({});
+  });
+
+  it('claims once per (habit, dayKey, endpoint)', async () => {
+    expect(await tryClaimSend('h1', '2026-07-16', ENDPOINT_1, HH, USER_A)).toBe(true);
+    expect(await tryClaimSend('h1', '2026-07-16', ENDPOINT_1, HH, USER_A)).toBe(false);
+    // Different day / endpoint / habit are independent claims
+    expect(await tryClaimSend('h1', '2026-07-17', ENDPOINT_1, HH, USER_A)).toBe(true);
+    expect(await tryClaimSend('h1', '2026-07-16', ENDPOINT_2, HH, USER_A)).toBe(true);
+    expect(await tryClaimSend('h2', '2026-07-16', ENDPOINT_1, HH, USER_A)).toBe(true);
+  });
+
+  it('releaseClaim allows a retry after transient failure', async () => {
+    expect(await tryClaimSend('h1', '2026-07-16', ENDPOINT_1, HH, USER_A)).toBe(true);
+    await releaseClaim('h1', '2026-07-16', ENDPOINT_1);
+    expect(await tryClaimSend('h1', '2026-07-16', ENDPOINT_1, HH, USER_A)).toBe(true);
+  });
+
+  it('markSendResult records the outcome', async () => {
+    await tryClaimSend('h1', '2026-07-16', ENDPOINT_1, HH, USER_A);
+    await markSendResult('h1', '2026-07-16', ENDPOINT_1, 'sent');
+    const db = await getTestDb();
+    const row = await db.collection('pushSendLog').findOne({ habitId: 'h1' });
+    expect(row?.status).toBe('sent');
+  });
+});

--- a/src/server/repositories/habitRepository.ts
+++ b/src/server/repositories/habitRepository.ts
@@ -53,6 +53,40 @@ function normalizeHabit(habit: Habit): Habit {
   return habit;
 }
 
+/**
+ * SCHEDULER-ONLY: cross-scope query for habits with a reminder due at one of
+ * the given "HH:mm" times, restricted to the scopes that actually have active
+ * push subscriptions. Returns habits WITH their scope fields so the scheduler
+ * can match them to subscriptions — a deliberate exception to the per-request
+ * scoping rule; never call this from a request handler.
+ */
+export async function findReminderHabitsForScopes(
+  scopes: Array<{ householdId: string; userId: string }>,
+  times: string[]
+): Promise<Array<Habit & { householdId: string; userId: string }>> {
+  if (scopes.length === 0 || times.length === 0) return [];
+
+  const db = await getDb();
+  const collection = db.collection(COLLECTION_NAME);
+
+  const docs = await collection
+    .find({
+      $or: scopes.map((s) => ({ householdId: s.householdId, userId: s.userId })),
+      reminderTime: { $in: times },
+      reminderEnabled: { $ne: false },
+      deletedAt: { $exists: false },
+      archived: { $ne: true },
+      // Mirrors isTrackableHabit (scheduleEngine): bundles are containers, not trackable
+      type: { $ne: 'bundle' },
+    })
+    .toArray();
+
+  return docs.map((doc) => {
+    const { householdId, userId } = doc as any;
+    return { ...stripScope(doc), householdId, userId };
+  });
+}
+
 export async function createHabit(
   data: Omit<Habit, 'id' | 'createdAt' | 'archived'>,
   householdId: string,

--- a/src/server/repositories/pushSendLogRepository.ts
+++ b/src/server/repositories/pushSendLogRepository.ts
@@ -1,0 +1,93 @@
+/**
+ * Push Send Log Repository
+ *
+ * Dedup ledger for reminder sends: at most one push per
+ * (habitId, dayKey, endpoint), enforced by a unique index so the scheduler is
+ * idempotent across restarts, overlapping ticks, and multiple instances.
+ * Rows expire via TTL — dedup only needs to outlive the day it protects.
+ */
+
+import { getDb } from '../lib/mongoClient';
+import { MONGO_COLLECTIONS } from '../../models/persistenceTypes';
+import { requireScope } from '../lib/scoping';
+
+const COLLECTION = MONGO_COLLECTIONS.PUSH_SEND_LOG;
+
+// 48h: comfortably outlives the dayKey being deduped in every timezone.
+const TTL_SECONDS = 48 * 60 * 60;
+
+let indexesEnsured = false;
+
+async function ensureIndexes(): Promise<void> {
+  if (indexesEnsured) return;
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  await col.createIndex(
+    { habitId: 1, dayKey: 1, endpoint: 1 },
+    { name: 'dedup_send', unique: true }
+  );
+  await col.createIndex({ sentAt: 1 }, { name: 'ttl_sent_at', expireAfterSeconds: TTL_SECONDS });
+  indexesEnsured = true;
+}
+
+/**
+ * Claim the right to send this (habit, day, device) reminder by inserting the
+ * dedup row first. Returns false if another tick/instance already claimed it.
+ */
+export async function tryClaimSend(
+  habitId: string,
+  dayKey: string,
+  endpoint: string,
+  householdId: string,
+  userId: string
+): Promise<boolean> {
+  const scope = requireScope(householdId, userId);
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  try {
+    await col.insertOne({
+      habitId,
+      dayKey,
+      endpoint,
+      householdId: scope.householdId,
+      userId: scope.userId,
+      status: 'pending',
+      sentAt: new Date(),
+    });
+    return true;
+  } catch (error) {
+    if (error && typeof error === 'object' && (error as { code?: number }).code === 11000) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** Record the outcome of a claimed send. */
+export async function markSendResult(
+  habitId: string,
+  dayKey: string,
+  endpoint: string,
+  status: 'sent' | 'gone'
+): Promise<void> {
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  await col.updateOne({ habitId, dayKey, endpoint }, { $set: { status } });
+}
+
+/**
+ * Release a claim after a transient send failure so the next tick can retry
+ * (bounded by the scheduler's catch-up window).
+ */
+export async function releaseClaim(
+  habitId: string,
+  dayKey: string,
+  endpoint: string
+): Promise<void> {
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  await col.deleteOne({ habitId, dayKey, endpoint });
+}

--- a/src/server/repositories/pushSubscriptionRepository.ts
+++ b/src/server/repositories/pushSubscriptionRepository.ts
@@ -1,0 +1,145 @@
+/**
+ * Push Subscription Repository
+ *
+ * Stores Web Push device subscriptions (operational device data — NOT truth
+ * data; the "entries are truth" invariant is untouched). One document per
+ * (householdId, userId, endpoint). Hard deletes are intentional here: device
+ * tokens are not truth records, so the soft-delete rule does not apply.
+ */
+
+import crypto from 'crypto';
+import { getDb } from '../lib/mongoClient';
+import { MONGO_COLLECTIONS, type PushSubscriptionDoc } from '../../models/persistenceTypes';
+import { requireScope, scopeFilter } from '../lib/scoping';
+
+const COLLECTION = MONGO_COLLECTIONS.PUSH_SUBSCRIPTIONS;
+
+let indexesEnsured = false;
+
+async function ensureIndexes(): Promise<void> {
+  if (indexesEnsured) return;
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  await col.createIndex(
+    { householdId: 1, userId: 1, endpoint: 1 },
+    { name: 'by_scope_endpoint', unique: true }
+  );
+  indexesEnsured = true;
+}
+
+function stripScope(doc: Record<string, unknown>): PushSubscriptionDoc {
+  const { _id, householdId: _h, userId: _u, ...rest } = doc as any;
+  return rest as PushSubscriptionDoc;
+}
+
+export interface PushSubscriptionInput {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+  timeZone: string;
+  userAgent?: string;
+}
+
+/**
+ * Create or refresh the subscription for a device endpoint. Idempotent:
+ * repeated subscribes refresh keys/timeZone/lastSeenAt and revive a
+ * previously disabled endpoint.
+ */
+export async function upsertPushSubscription(
+  householdId: string,
+  userId: string,
+  input: PushSubscriptionInput
+): Promise<PushSubscriptionDoc> {
+  const scope = requireScope(householdId, userId);
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+
+  const now = new Date().toISOString();
+  const result = await col.findOneAndUpdate(
+    scopeFilter(scope.householdId, scope.userId, { endpoint: input.endpoint }),
+    {
+      $setOnInsert: {
+        id: crypto.randomUUID(),
+        createdAt: now,
+      },
+      $set: {
+        keys: { p256dh: input.keys.p256dh, auth: input.keys.auth },
+        timeZone: input.timeZone,
+        ...(input.userAgent ? { userAgent: input.userAgent } : {}),
+        lastSeenAt: now,
+      },
+      $unset: { disabledAt: '' },
+    },
+    { upsert: true, returnDocument: 'after' }
+  );
+
+  return stripScope(result as any);
+}
+
+/** Remove a device subscription entirely (user turned notifications off). */
+export async function deletePushSubscriptionByEndpoint(
+  householdId: string,
+  userId: string,
+  endpoint: string
+): Promise<boolean> {
+  const scope = requireScope(householdId, userId);
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  const result = await col.deleteOne(scopeFilter(scope.householdId, scope.userId, { endpoint }));
+  return result.deletedCount > 0;
+}
+
+/**
+ * Mark a subscription dead after the push service reported it gone (404/410).
+ * Kept (not deleted) so a later re-subscribe on the same endpoint revives it
+ * with its original createdAt.
+ */
+export async function disablePushSubscriptionByEndpoint(
+  householdId: string,
+  userId: string,
+  endpoint: string
+): Promise<void> {
+  const scope = requireScope(householdId, userId);
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  await col.updateOne(
+    scopeFilter(scope.householdId, scope.userId, { endpoint }),
+    { $set: { disabledAt: new Date().toISOString() } }
+  );
+}
+
+/** Active subscriptions for one user (e.g. the test-notification endpoint). */
+export async function getActivePushSubscriptionsForUser(
+  householdId: string,
+  userId: string
+): Promise<PushSubscriptionDoc[]> {
+  const scope = requireScope(householdId, userId);
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  const docs = await col
+    .find(scopeFilter(scope.householdId, scope.userId, { disabledAt: { $exists: false } }))
+    .toArray();
+  return docs.map(stripScope);
+}
+
+/**
+ * SCHEDULER-ONLY: cross-scope read of every active subscription, WITH the
+ * householdId/userId scope fields intact (the scheduler needs them to query
+ * each user's habits and entries). This is a deliberate exception to the
+ * per-request scoping rule — never call it from a request handler.
+ */
+export async function getActivePushSubscriptions(): Promise<
+  Array<PushSubscriptionDoc & { householdId: string; userId: string }>
+> {
+  await ensureIndexes();
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+  const docs = await col.find({ disabledAt: { $exists: false } }).toArray();
+  return docs.map((doc) => {
+    const { _id, ...rest } = doc as any;
+    return rest as PushSubscriptionDoc & { householdId: string; userId: string };
+  });
+}

--- a/src/server/routes/__tests__/habits.reminder.test.ts
+++ b/src/server/routes/__tests__/habits.reminder.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Habit Reminder Field Tests
+ *
+ * Validates that POST/PATCH /api/habits correctly handles the
+ * reminderTime ("HH:mm") and reminderEnabled fields, including
+ * format validation and the clear-with-null contract.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import { createHabitRoute, updateHabitRoute } from '../habits';
+import { createCategoryRoute } from '../categories';
+
+const TEST_HOUSEHOLD_ID = 'test-reminder-household';
+const TEST_USER_ID = 'test-reminder-user';
+
+describe('Habit Reminder Fields (reminderTime + reminderEnabled)', () => {
+  let app: Express;
+  let category: any;
+
+  beforeAll(async () => {
+    await setupTestMongo();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).householdId = TEST_HOUSEHOLD_ID;
+      (req as any).userId = TEST_USER_ID;
+      next();
+    });
+
+    app.post('/api/habits', createHabitRoute);
+    app.patch('/api/habits/:id', updateHabitRoute);
+    app.post('/api/categories', createCategoryRoute);
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const testDb = await getTestDb();
+    await testDb.collection('habits').deleteMany({});
+    await testDb.collection('categories').deleteMany({});
+
+    const res = await request(app)
+      .post('/api/categories')
+      .send({ name: 'Health', color: 'bg-green-500' });
+    category = res.body.category;
+  });
+
+  async function createHabit(extra: Record<string, unknown> = {}) {
+    return request(app)
+      .post('/api/habits')
+      .send({
+        name: 'Meditate',
+        categoryId: category.id,
+        goal: { type: 'boolean', frequency: 'daily' },
+        ...extra,
+      });
+  }
+
+  it('creates a habit with a valid reminderTime', async () => {
+    const res = await createHabit({ reminderTime: '09:00' });
+    expect(res.status).toBe(201);
+    expect(res.body.habit.reminderTime).toBe('09:00');
+  });
+
+  it('accepts boundary times 00:00 and 23:59', async () => {
+    const early = await createHabit({ reminderTime: '00:00' });
+    expect(early.status).toBe(201);
+    const late = await createHabit({ reminderTime: '23:59' });
+    expect(late.status).toBe(201);
+  });
+
+  it.each(['9:00', '25:00', '09:60', '0900', '09:00:00', 'evening'])(
+    'rejects malformed reminderTime %s on create',
+    async (bad) => {
+      const res = await createHabit({ reminderTime: bad });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    }
+  );
+
+  it('treats null reminderTime as unset on create', async () => {
+    const res = await createHabit({ reminderTime: null });
+    expect(res.status).toBe(201);
+    expect(res.body.habit.reminderTime ?? undefined).toBeUndefined();
+  });
+
+  it('sets reminderTime via PATCH', async () => {
+    const created = await createHabit();
+    const res = await request(app)
+      .patch(`/api/habits/${created.body.habit.id}`)
+      .send({ reminderTime: '07:30' });
+    expect(res.status).toBe(200);
+    expect(res.body.habit.reminderTime).toBe('07:30');
+  });
+
+  it('rejects malformed reminderTime via PATCH', async () => {
+    const created = await createHabit({ reminderTime: '07:30' });
+    const res = await request(app)
+      .patch(`/api/habits/${created.body.habit.id}`)
+      .send({ reminderTime: '7:30pm' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('toggles reminderEnabled without losing reminderTime', async () => {
+    const created = await createHabit({ reminderTime: '07:30' });
+    const id = created.body.habit.id;
+
+    const off = await request(app).patch(`/api/habits/${id}`).send({ reminderEnabled: false });
+    expect(off.status).toBe(200);
+    expect(off.body.habit.reminderEnabled).toBe(false);
+    expect(off.body.habit.reminderTime).toBe('07:30');
+
+    const on = await request(app).patch(`/api/habits/${id}`).send({ reminderEnabled: true });
+    expect(on.status).toBe(200);
+    expect(on.body.habit.reminderEnabled).toBe(true);
+    expect(on.body.habit.reminderTime).toBe('07:30');
+  });
+
+  it('clears reminderTime with null while keeping other fields', async () => {
+    const created = await createHabit({ reminderTime: '07:30', description: 'daily calm' });
+    const id = created.body.habit.id;
+
+    const res = await request(app).patch(`/api/habits/${id}`).send({ reminderTime: null });
+    expect(res.status).toBe(200);
+    expect(res.body.habit.reminderTime ?? undefined).toBeUndefined();
+    expect(res.body.habit.description).toBe('daily calm');
+  });
+});

--- a/src/server/routes/__tests__/push.subscriptions.test.ts
+++ b/src/server/routes/__tests__/push.subscriptions.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Push Subscription Route Tests
+ *
+ * Covers the /api/push endpoints: public-key availability, subscribe
+ * validation + idempotency, unsubscribe, and test-send (with the web-push
+ * sender mocked, including gone-endpoint cleanup).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+
+vi.mock('../../lib/webPush', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/webPush')>('../../lib/webPush');
+  return {
+    ...actual,
+    sendPush: vi.fn(async () => 'sent' as const),
+  };
+});
+
+import { sendPush } from '../../lib/webPush';
+import {
+  getPushPublicKeyRoute,
+  savePushSubscriptionRoute,
+  deletePushSubscriptionRoute,
+  sendTestPushRoute,
+} from '../pushSubscriptions';
+
+const TEST_HOUSEHOLD_ID = 'test-push-routes-household';
+const TEST_USER_ID = 'test-push-routes-user';
+const ENDPOINT = 'https://push.example.com/send/route-device';
+
+const VALID_BODY = {
+  subscription: {
+    endpoint: ENDPOINT,
+    keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+  },
+  timeZone: 'Europe/Berlin',
+  userAgent: 'vitest',
+};
+
+describe('Push subscription routes', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    await setupTestMongo();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).householdId = TEST_HOUSEHOLD_ID;
+      (req as any).userId = TEST_USER_ID;
+      next();
+    });
+
+    app.get('/api/push/public-key', getPushPublicKeyRoute);
+    app.post('/api/push/subscriptions', savePushSubscriptionRoute);
+    app.delete('/api/push/subscriptions', deletePushSubscriptionRoute);
+    app.post('/api/push/test', sendTestPushRoute);
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+    delete process.env.PUSH_REMINDERS_ENABLED;
+    delete process.env.VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await db.collection('pushSubscriptions').deleteMany({});
+    vi.mocked(sendPush).mockClear();
+    vi.mocked(sendPush).mockResolvedValue('sent');
+
+    // Configured by default; individual tests flip these off
+    process.env.PUSH_REMINDERS_ENABLED = 'true';
+    process.env.VAPID_PUBLIC_KEY = 'test-public-key';
+    process.env.VAPID_PRIVATE_KEY = 'test-private-key';
+  });
+
+  describe('GET /api/push/public-key', () => {
+    it('returns the public key when configured', async () => {
+      const res = await request(app).get('/api/push/public-key');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ enabled: true, publicKey: 'test-public-key' });
+    });
+
+    it('reports disabled when the flag is off', async () => {
+      process.env.PUSH_REMINDERS_ENABLED = 'false';
+      const res = await request(app).get('/api/push/public-key');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ enabled: false, publicKey: null });
+    });
+
+    it('reports disabled when VAPID keys are missing', async () => {
+      process.env.VAPID_PRIVATE_KEY = '';
+      const res = await request(app).get('/api/push/public-key');
+      expect(res.body.enabled).toBe(false);
+    });
+  });
+
+  describe('POST /api/push/subscriptions', () => {
+    it('creates a subscription', async () => {
+      const res = await request(app).post('/api/push/subscriptions').send(VALID_BODY);
+      expect(res.status).toBe(201);
+      expect(res.body.subscription.endpoint).toBe(ENDPOINT);
+      expect(res.body.subscription.timeZone).toBe('Europe/Berlin');
+      expect(res.body.subscription.id).toBeTruthy();
+    });
+
+    it('is idempotent on repeat subscribe', async () => {
+      const first = await request(app).post('/api/push/subscriptions').send(VALID_BODY);
+      const second = await request(app)
+        .post('/api/push/subscriptions')
+        .send({ ...VALID_BODY, timeZone: 'Asia/Tokyo' });
+
+      expect(second.status).toBe(201);
+      expect(second.body.subscription.id).toBe(first.body.subscription.id);
+      expect(second.body.subscription.timeZone).toBe('Asia/Tokyo');
+
+      const db = await getTestDb();
+      expect(await db.collection('pushSubscriptions').countDocuments({})).toBe(1);
+    });
+
+    it('rejects a missing endpoint or keys', async () => {
+      const noEndpoint = await request(app)
+        .post('/api/push/subscriptions')
+        .send({ subscription: { keys: VALID_BODY.subscription.keys }, timeZone: 'UTC' });
+      expect(noEndpoint.status).toBe(400);
+      expect(noEndpoint.body.error.code).toBe('VALIDATION_ERROR');
+
+      const noKeys = await request(app)
+        .post('/api/push/subscriptions')
+        .send({ subscription: { endpoint: ENDPOINT, keys: { p256dh: 'x' } }, timeZone: 'UTC' });
+      expect(noKeys.status).toBe(400);
+    });
+
+    it('falls back to the default timezone for invalid input', async () => {
+      const res = await request(app)
+        .post('/api/push/subscriptions')
+        .send({ ...VALID_BODY, timeZone: 'Not/AZone' });
+      expect(res.status).toBe(201);
+      expect(res.body.subscription.timeZone).toBe('America/New_York');
+    });
+
+    it('returns 501 PUSH_DISABLED when unconfigured', async () => {
+      process.env.PUSH_REMINDERS_ENABLED = 'false';
+      const res = await request(app).post('/api/push/subscriptions').send(VALID_BODY);
+      expect(res.status).toBe(501);
+      expect(res.body.error.code).toBe('PUSH_DISABLED');
+    });
+  });
+
+  describe('DELETE /api/push/subscriptions', () => {
+    it('removes an existing subscription', async () => {
+      await request(app).post('/api/push/subscriptions').send(VALID_BODY);
+      const res = await request(app).delete('/api/push/subscriptions').send({ endpoint: ENDPOINT });
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(true);
+
+      const again = await request(app).delete('/api/push/subscriptions').send({ endpoint: ENDPOINT });
+      expect(again.body.deleted).toBe(false);
+    });
+
+    it('rejects a missing endpoint', async () => {
+      const res = await request(app).delete('/api/push/subscriptions').send({});
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/push/test', () => {
+    it('sends to every active device of the caller', async () => {
+      await request(app).post('/api/push/subscriptions').send(VALID_BODY);
+      await request(app).post('/api/push/subscriptions').send({
+        ...VALID_BODY,
+        subscription: { ...VALID_BODY.subscription, endpoint: `${ENDPOINT}-2` },
+      });
+
+      const res = await request(app).post('/api/push/test');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ sent: 2, gone: 0, errors: 0 });
+      expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(2);
+    });
+
+    it('disables subscriptions the push service reports gone', async () => {
+      await request(app).post('/api/push/subscriptions').send(VALID_BODY);
+      vi.mocked(sendPush).mockResolvedValueOnce('gone');
+
+      const res = await request(app).post('/api/push/test');
+      expect(res.body).toEqual({ sent: 0, gone: 1, errors: 0 });
+
+      // Endpoint is now disabled — a second test-send reaches no devices
+      const again = await request(app).post('/api/push/test');
+      expect(again.body).toEqual({ sent: 0, gone: 0, errors: 0 });
+    });
+
+    it('returns 501 when unconfigured', async () => {
+      process.env.PUSH_REMINDERS_ENABLED = 'false';
+      const res = await request(app).post('/api/push/test');
+      expect(res.status).toBe(501);
+    });
+  });
+});

--- a/src/server/routes/habits.ts
+++ b/src/server/routes/habits.ts
@@ -34,6 +34,13 @@ import { invalidateUserCaches } from '../lib/cacheInstances';
 const recoveredUsers = new Set<string>();
 const selfHealedUsers = new Set<string>();
 
+// 24h "HH:mm" — the format stored for reminderTime.
+const REMINDER_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function isValidReminderTime(value: unknown): value is string {
+  return typeof value === 'string' && REMINDER_TIME_PATTERN.test(value);
+}
+
 /**
  * Get all habits for the current user.
  *
@@ -149,8 +156,20 @@ export async function createHabitRoute(req: Request, res: Response): Promise<voi
       bundleType, bundleOptions,
       pinned, timeEstimate,
       linkedGoalId, linkedRoutineIds,
-      requiredDaysPerWeek
+      requiredDaysPerWeek,
+      reminderTime, reminderEnabled
     } = req.body;
+
+    // null is treated as "no reminder" so create and PATCH share one contract
+    if (reminderTime !== undefined && reminderTime !== null && !isValidReminderTime(reminderTime)) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'reminderTime must be a 24h "HH:mm" string (e.g. "09:00")',
+        },
+      });
+      return;
+    }
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
       res.status(400).json({
@@ -207,6 +226,8 @@ export async function createHabitRoute(req: Request, res: Response): Promise<voi
         linkedGoalId,
         linkedRoutineIds,
         requiredDaysPerWeek,
+        reminderTime: reminderTime ?? undefined,
+        reminderEnabled: reminderEnabled === undefined ? undefined : !!reminderEnabled,
       },
       householdId,
       userId
@@ -299,7 +320,8 @@ export async function updateHabitRoute(req: Request, res: Response): Promise<voi
       bundleType, bundleOptions,
       pinned, timeEstimate,
       linkedGoalId, linkedRoutineIds,
-      requiredDaysPerWeek
+      requiredDaysPerWeek,
+      reminderTime, reminderEnabled
     } = req.body;
 
     if (!id) {
@@ -335,6 +357,20 @@ export async function updateHabitRoute(req: Request, res: Response): Promise<voi
     if (linkedGoalId !== undefined) patch.linkedGoalId = linkedGoalId;
     if (linkedRoutineIds !== undefined) patch.linkedRoutineIds = linkedRoutineIds;
     if (requiredDaysPerWeek !== undefined) patch.requiredDaysPerWeek = requiredDaysPerWeek;
+    // Clear with null, set with a valid "HH:mm" string (same contract as archivedAt).
+    if (reminderTime !== undefined) {
+      if (reminderTime !== null && !isValidReminderTime(reminderTime)) {
+        res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'reminderTime must be a 24h "HH:mm" string (e.g. "09:00")',
+          },
+        });
+        return;
+      }
+      patch.reminderTime = reminderTime === null ? undefined : reminderTime;
+    }
+    if (reminderEnabled !== undefined) patch.reminderEnabled = !!reminderEnabled;
 
     if (Object.keys(patch).length === 0) {
       res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'At least one field must be provided for update' } });

--- a/src/server/routes/pushSubscriptions.ts
+++ b/src/server/routes/pushSubscriptions.ts
@@ -1,0 +1,172 @@
+/**
+ * Push Subscription Routes
+ *
+ * REST endpoints for Web Push device subscriptions:
+ *   GET    /api/push/public-key     — VAPID public key + feature availability
+ *   POST   /api/push/subscriptions  — create/refresh this device's subscription
+ *   DELETE /api/push/subscriptions  — remove this device's subscription
+ *   POST   /api/push/test           — send a test notification to the caller's devices
+ */
+
+import type { Request, Response } from 'express';
+import { getRequestIdentity } from '../middleware/identity';
+import { getVapidPublicKey } from '../config/env';
+import { isPushConfigured, sendPush } from '../lib/webPush';
+import { resolveTimeZone } from '../utils/dayKey';
+import {
+  upsertPushSubscription,
+  deletePushSubscriptionByEndpoint,
+  disablePushSubscriptionByEndpoint,
+  getActivePushSubscriptionsForUser,
+} from '../repositories/pushSubscriptionRepository';
+
+function respondPushDisabled(res: Response): void {
+  res.status(501).json({
+    error: {
+      code: 'PUSH_DISABLED',
+      message: 'Push notifications are not enabled on this server',
+    },
+  });
+}
+
+function internalError(res: Response, action: string, error: unknown): void {
+  const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+  console.error(`Error ${action}:`, errorMessage);
+  res.status(500).json({
+    error: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `Failed to ${action}`,
+      details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+    },
+  });
+}
+
+/**
+ * GET /api/push/public-key
+ * Always 200: clients use `enabled` to decide whether to show push UI at all.
+ */
+export async function getPushPublicKeyRoute(_req: Request, res: Response): Promise<void> {
+  const enabled = isPushConfigured();
+  res.status(200).json({
+    enabled,
+    publicKey: enabled ? getVapidPublicKey() : null,
+  });
+}
+
+/**
+ * POST /api/push/subscriptions
+ * Body: { subscription: { endpoint, keys: { p256dh, auth } }, timeZone, userAgent? }
+ * Idempotent: re-subscribing refreshes keys/timeZone/lastSeenAt.
+ */
+export async function savePushSubscriptionRoute(req: Request, res: Response): Promise<void> {
+  try {
+    if (!isPushConfigured()) {
+      respondPushDisabled(res);
+      return;
+    }
+
+    const { subscription, timeZone, userAgent } = req.body ?? {};
+    const endpoint = subscription?.endpoint;
+    const p256dh = subscription?.keys?.p256dh;
+    const auth = subscription?.keys?.auth;
+
+    if (
+      typeof endpoint !== 'string' || endpoint.trim().length === 0 ||
+      typeof p256dh !== 'string' || p256dh.trim().length === 0 ||
+      typeof auth !== 'string' || auth.trim().length === 0
+    ) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'subscription with endpoint and keys (p256dh, auth) is required',
+        },
+      });
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+
+    const saved = await upsertPushSubscription(householdId, userId, {
+      endpoint: endpoint.trim(),
+      keys: { p256dh, auth },
+      // Invalid/missing timezone falls back to the server default rather than 400 —
+      // a reminder in the wrong timezone beats a device that can't subscribe.
+      timeZone: resolveTimeZone(typeof timeZone === 'string' ? timeZone : undefined),
+      userAgent: typeof userAgent === 'string' ? userAgent.slice(0, 512) : undefined,
+    });
+
+    res.status(201).json({
+      subscription: {
+        id: saved.id,
+        endpoint: saved.endpoint,
+        timeZone: saved.timeZone,
+        createdAt: saved.createdAt,
+        lastSeenAt: saved.lastSeenAt,
+      },
+    });
+  } catch (error) {
+    internalError(res, 'save push subscription', error);
+  }
+}
+
+/**
+ * DELETE /api/push/subscriptions
+ * Body: { endpoint } (endpoints are long URLs — body, not path param)
+ */
+export async function deletePushSubscriptionRoute(req: Request, res: Response): Promise<void> {
+  try {
+    const { endpoint } = req.body ?? {};
+    if (typeof endpoint !== 'string' || endpoint.trim().length === 0) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'endpoint is required' },
+      });
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+    const deleted = await deletePushSubscriptionByEndpoint(householdId, userId, endpoint.trim());
+    res.status(200).json({ deleted });
+  } catch (error) {
+    internalError(res, 'delete push subscription', error);
+  }
+}
+
+/**
+ * POST /api/push/test
+ * Sends a test notification to every active subscription of the caller.
+ */
+export async function sendTestPushRoute(req: Request, res: Response): Promise<void> {
+  try {
+    if (!isPushConfigured()) {
+      respondPushDisabled(res);
+      return;
+    }
+
+    const { householdId, userId } = getRequestIdentity(req);
+    const subscriptions = await getActivePushSubscriptionsForUser(householdId, userId);
+
+    let sent = 0;
+    let gone = 0;
+    let errors = 0;
+
+    for (const sub of subscriptions) {
+      const result = await sendPush(
+        { endpoint: sub.endpoint, keys: sub.keys },
+        {
+          title: 'HabitFlow',
+          body: 'Test notification — habit reminders are working on this device.',
+          data: { url: '/?view=tracker' },
+        }
+      );
+      if (result === 'sent') sent += 1;
+      else if (result === 'gone') {
+        gone += 1;
+        await disablePushSubscriptionByEndpoint(householdId, userId, sub.endpoint);
+      } else errors += 1;
+    }
+
+    res.status(200).json({ sent, gone, errors });
+  } catch (error) {
+    internalError(res, 'send test push', error);
+  }
+}

--- a/src/server/services/__tests__/reminderScheduler.test.ts
+++ b/src/server/services/__tests__/reminderScheduler.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Reminder Scheduler Tests
+ *
+ * Drives runReminderTick() with fixed Dates against memory Mongo, with the
+ * web-push sender mocked. Covers timezone matching, the catch-up window,
+ * schedule/completion/enablement exclusions, dedup, gone-endpoint cleanup,
+ * transient-error retry, local-midnight windows, and multi-device fan-out.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+
+vi.mock('../../lib/webPush', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/webPush')>('../../lib/webPush');
+  return {
+    ...actual,
+    sendPush: vi.fn(async () => 'sent' as const),
+  };
+});
+
+import { sendPush } from '../../lib/webPush';
+import { runReminderTick, formatLocalHHmm } from '../reminderScheduler';
+import { upsertPushSubscription, getActivePushSubscriptions } from '../../repositories/pushSubscriptionRepository';
+import { createHabit } from '../../repositories/habitRepository';
+
+const HH = 'sched-household';
+const USER = 'sched-user';
+const OTHER_USER = 'sched-other-user';
+const ENDPOINT = 'https://push.example.com/send/sched-1';
+const ENDPOINT_2 = 'https://push.example.com/send/sched-2';
+
+// 2026-07-16 is a Thursday. 12:00 UTC = 08:00 in New York (EDT, UTC-4).
+const NY = 'America/New_York';
+const TOKYO = 'Asia/Tokyo';
+
+function utc(iso: string): Date {
+  return new Date(iso);
+}
+
+async function subscribe(overrides: Partial<{ endpoint: string; timeZone: string; userId: string }> = {}) {
+  return upsertPushSubscription(HH, overrides.userId ?? USER, {
+    endpoint: overrides.endpoint ?? ENDPOINT,
+    keys: { p256dh: 'k', auth: 'a' },
+    timeZone: overrides.timeZone ?? NY,
+  });
+}
+
+async function makeHabit(overrides: Partial<Record<string, unknown>> = {}, userId = USER) {
+  return createHabit(
+    {
+      name: (overrides.name as string) ?? 'Meditate',
+      categoryId: 'cat-1',
+      goal: { type: 'boolean', frequency: 'daily' },
+      reminderTime: '08:00',
+      ...overrides,
+    } as any,
+    HH,
+    userId
+  );
+}
+
+describe('reminderScheduler', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+    await db.collection('pushSubscriptions').deleteMany({});
+    await db.collection('pushSendLog').deleteMany({});
+    await db.collection('habits').deleteMany({});
+    await db.collection('habitEntries').deleteMany({});
+    vi.mocked(sendPush).mockClear();
+    vi.mocked(sendPush).mockResolvedValue('sent');
+  });
+
+  describe('formatLocalHHmm', () => {
+    it('formats 24h local time in a timezone', () => {
+      expect(formatLocalHHmm(utc('2026-07-16T12:00:00Z'), NY)).toBe('08:00');
+      expect(formatLocalHHmm(utc('2026-07-16T12:00:00Z'), TOKYO)).toBe('21:00');
+      expect(formatLocalHHmm(utc('2026-07-16T00:05:00Z'), 'UTC')).toBe('00:05');
+    });
+  });
+
+  it('sends when the local minute matches reminderTime in the sub timezone', async () => {
+    await subscribe();
+    const habit = await makeHabit();
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z')); // 08:00 NY
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+    const [target, payload] = vi.mocked(sendPush).mock.calls[0];
+    expect(target.endpoint).toBe(ENDPOINT);
+    expect(payload.title).toBe('Meditate');
+    expect(payload.tag).toBe(`habit-${habit.id}-2026-07-16`);
+    expect(payload.data?.url).toBe('/?view=tracker');
+  });
+
+  it('does not send for non-matching minutes', async () => {
+    await subscribe();
+    await makeHabit({ reminderTime: '09:30' });
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z')); // 08:00 NY
+
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  it('catches up reminders a few minutes in the past (delayed tick)', async () => {
+    await subscribe();
+    await makeHabit({ reminderTime: '08:00' });
+
+    // Tick fires at 08:03 local — 08:00 is inside the 5-minute window
+    await runReminderTick(utc('2026-07-16T12:03:00Z'));
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not catch up beyond the window', async () => {
+    await subscribe();
+    await makeHabit({ reminderTime: '08:00' });
+
+    await runReminderTick(utc('2026-07-16T12:06:00Z')); // 08:06 local
+
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  it('dedups across consecutive ticks (at most one send per habit/day/device)', async () => {
+    await subscribe();
+    await makeHabit();
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+    await runReminderTick(utc('2026-07-16T12:01:10Z')); // 08:00 still in window
+    await runReminderTick(utc('2026-07-16T12:02:10Z'));
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects assignedDays (2026-07-16 is a Thursday=4)', async () => {
+    await subscribe();
+    await makeHabit({ name: 'WeekendOnly', assignedDays: [0, 6] });
+    await makeHabit({ name: 'ThursdayHabit', assignedDays: [4] });
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendPush).mock.calls[0][1].title).toBe('ThursdayHabit');
+  });
+
+  it('skips reminderEnabled=false, archived, and bundle habits', async () => {
+    await subscribe();
+    await makeHabit({ name: 'Disabled', reminderEnabled: false });
+    await makeHabit({ name: 'Bundle', type: 'bundle' });
+    const db = await getTestDb();
+    await makeHabit({ name: 'Archived' });
+    await db.collection('habits').updateOne({ name: 'Archived' }, { $set: { archived: true } });
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  it('skips habits already completed for the local day', async () => {
+    await subscribe();
+    const habit = await makeHabit();
+    const db = await getTestDb();
+    await db.collection('habitEntries').insertOne({
+      id: 'entry-1',
+      householdId: HH,
+      userId: USER,
+      habitId: habit.id,
+      dayKey: '2026-07-16',
+      createdAt: new Date().toISOString(),
+    });
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  it('disables the subscription when the push service reports it gone', async () => {
+    await subscribe();
+    await makeHabit();
+    vi.mocked(sendPush).mockResolvedValueOnce('gone');
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+    expect(await getActivePushSubscriptions()).toHaveLength(0);
+
+    // Next day: nothing to send to
+    vi.mocked(sendPush).mockClear();
+    await runReminderTick(utc('2026-07-17T12:00:10Z'));
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  it('retries after a transient error (claim released, still in window)', async () => {
+    await subscribe();
+    await makeHabit();
+    vi.mocked(sendPush).mockResolvedValueOnce('error');
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+    await runReminderTick(utc('2026-07-16T12:01:10Z'));
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(2);
+    // Second attempt succeeded; a third tick must not send again
+    await runReminderTick(utc('2026-07-16T12:02:10Z'));
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles the catch-up window across local midnight', async () => {
+    await subscribe({ timeZone: 'UTC' });
+    await makeHabit({ reminderTime: '23:59' });
+
+    // 00:02 UTC on the 17th: 23:59 belongs to the 16th's dayKey
+    await runReminderTick(utc('2026-07-17T00:02:00Z'));
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendPush).mock.calls[0][1].tag).toContain('2026-07-16');
+  });
+
+  it('fans out to multiple devices of the same user', async () => {
+    await subscribe({ endpoint: ENDPOINT });
+    await subscribe({ endpoint: ENDPOINT_2 });
+    await makeHabit();
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(2);
+    const endpoints = vi.mocked(sendPush).mock.calls.map(([t]) => t.endpoint).sort();
+    expect(endpoints).toEqual([ENDPOINT, ENDPOINT_2].sort());
+  });
+
+  it('only fires for the local minute of each subscription timezone', async () => {
+    await subscribe({ endpoint: ENDPOINT, timeZone: NY });
+    await subscribe({ endpoint: ENDPOINT_2, timeZone: TOKYO, userId: OTHER_USER });
+    await makeHabit({ name: 'NY habit', reminderTime: '08:00' }, USER);
+    await makeHabit({ name: 'Tokyo habit', reminderTime: '21:00' }, OTHER_USER);
+
+    // 12:00 UTC = 08:00 NY = 21:00 Tokyo → both fire, each exactly once
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+    expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(2);
+
+    // An hour later neither local minute matches
+    vi.mocked(sendPush).mockClear();
+    await runReminderTick(utc('2026-07-16T13:00:10Z'));
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  it('does not cross-fire habits between users', async () => {
+    await subscribe({ endpoint: ENDPOINT, userId: USER });
+    // OTHER_USER has the habit but no subscription
+    await makeHabit({ name: 'Other user habit' }, OTHER_USER);
+
+    await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+    expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/reminderScheduler.ts
+++ b/src/server/services/reminderScheduler.ts
@@ -1,0 +1,201 @@
+/**
+ * Reminder Scheduler
+ *
+ * In-process scheduler for Web Push habit reminders. Every TICK_MS it
+ * computes, per subscription timezone, the current local minute plus a small
+ * catch-up window of recent minutes (so a delayed/skipped tick after a deploy
+ * or restart still delivers), finds habits whose reminderTime matches, and
+ * pushes to each subscribed device — unless the habit is already completed
+ * for that local day.
+ *
+ * Idempotency: pushSendLog's unique (habitId, dayKey, endpoint) index with
+ * claim-by-insert makes sends at-most-once per habit per day per device, even
+ * across overlapping ticks, restarts, and multiple instances. The dayKey is
+ * computed per offset minute so the catch-up window behaves correctly across
+ * local midnight; dayKey-scoped dedup also makes the DST fall-back repeated
+ * hour single-send. (DST spring-forward: 02:xx local times never occur that
+ * day, so those reminders are skipped once a year — accepted limitation.)
+ *
+ * NOTE: this only runs while the process runs. On hosts that idle-sleep
+ * (e.g. Render free tier) reminders silently stop — deploy always-on, or
+ * adapt runReminderTick() behind a cron-triggered endpoint.
+ */
+
+import type { Habit } from '../../models/persistenceTypes';
+import {
+  getActivePushSubscriptions,
+  disablePushSubscriptionByEndpoint,
+} from '../repositories/pushSubscriptionRepository';
+import { tryClaimSend, markSendResult, releaseClaim } from '../repositories/pushSendLogRepository';
+import { findReminderHabitsForScopes } from '../repositories/habitRepository';
+import { getHabitEntriesForDay } from '../repositories/habitEntryRepository';
+import { isHabitScheduledOnDay } from './scheduleEngine';
+import { getDayKeyForDate } from '../utils/dayKey';
+import { sendPush, isPushConfigured } from '../lib/webPush';
+
+const TICK_MS = 60_000;
+/** How many recent minutes each tick re-checks; dedup makes overlap safe. */
+const CATCH_UP_MINUTES = 5;
+
+/** Format a Date as local "HH:mm" in an IANA timezone (24h). */
+export function formatLocalHHmm(date: Date, timeZone: string): string {
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    timeZone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  });
+  const parts = formatter.formatToParts(date);
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? '00';
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? '00';
+  return `${hour}:${minute}`;
+}
+
+interface MinuteCandidate {
+  hhmm: string;
+  dayKey: string;
+}
+
+/**
+ * One scheduler pass. Exported (with `now` injected) so tests can drive it
+ * deterministically without timers.
+ */
+export async function runReminderTick(now: Date): Promise<void> {
+  const subscriptions = await getActivePushSubscriptions();
+  if (subscriptions.length === 0) return;
+
+  // 1. Candidate (local minute, local dayKey) pairs per distinct timezone.
+  //    dayKey is computed per offset minute so a window that crosses local
+  //    midnight attributes each minute to its own calendar day.
+  const tzCandidates = new Map<string, MinuteCandidate[]>();
+  for (const sub of subscriptions) {
+    if (tzCandidates.has(sub.timeZone)) continue;
+    const candidates: MinuteCandidate[] = [];
+    const seen = new Set<string>();
+    for (let i = 0; i < CATCH_UP_MINUTES; i++) {
+      const t = new Date(now.getTime() - i * 60_000);
+      const hhmm = formatLocalHHmm(t, sub.timeZone);
+      const dayKey = getDayKeyForDate(t, sub.timeZone);
+      const key = `${hhmm}|${dayKey}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      candidates.push({ hhmm, dayKey });
+    }
+    tzCandidates.set(sub.timeZone, candidates);
+  }
+
+  // 2. One cross-scope habit query for all subscribed users and all
+  //    candidate times (over-fetches across timezones; filtered per sub below).
+  const scopeKeys = new Set<string>();
+  const scopes: Array<{ householdId: string; userId: string }> = [];
+  for (const sub of subscriptions) {
+    const key = `${sub.householdId}|${sub.userId}`;
+    if (scopeKeys.has(key)) continue;
+    scopeKeys.add(key);
+    scopes.push({ householdId: sub.householdId, userId: sub.userId });
+  }
+  const allTimes = [...new Set([...tzCandidates.values()].flat().map((c) => c.hhmm))];
+  const habits = await findReminderHabitsForScopes(scopes, allTimes);
+  if (habits.length === 0) return;
+
+  // Completion lookups are cached per (habit, dayKey) within the tick.
+  const completionCache = new Map<string, boolean>();
+  async function isCompleted(
+    habit: Habit & { householdId: string; userId: string },
+    dayKey: string
+  ): Promise<boolean> {
+    const cacheKey = `${habit.id}|${dayKey}`;
+    const cached = completionCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+    const entries = await getHabitEntriesForDay(habit.id, dayKey, habit.householdId, habit.userId);
+    const completed = entries.length > 0;
+    completionCache.set(cacheKey, completed);
+    return completed;
+  }
+
+  // 3. Match each subscription's local candidate minutes against its user's habits.
+  for (const sub of subscriptions) {
+    const candidates = tzCandidates.get(sub.timeZone) ?? [];
+    for (const habit of habits) {
+      if (habit.householdId !== sub.householdId || habit.userId !== sub.userId) continue;
+      const candidate = candidates.find((c) => c.hhmm === habit.reminderTime);
+      if (!candidate) continue;
+      if (!isHabitScheduledOnDay(habit, candidate.dayKey)) continue;
+      if (await isCompleted(habit, candidate.dayKey)) continue;
+
+      // 4. Claim-then-send: the unique dedup index makes this at-most-once.
+      const claimed = await tryClaimSend(
+        habit.id,
+        candidate.dayKey,
+        sub.endpoint,
+        sub.householdId,
+        sub.userId
+      );
+      if (!claimed) continue;
+
+      const result = await sendPush(
+        { endpoint: sub.endpoint, keys: sub.keys },
+        {
+          title: habit.name,
+          body: `Time for ${habit.name}`,
+          tag: `habit-${habit.id}-${candidate.dayKey}`,
+          data: { url: '/?view=tracker' },
+        }
+      );
+
+      if (result === 'sent') {
+        await markSendResult(habit.id, candidate.dayKey, sub.endpoint, 'sent');
+      } else if (result === 'gone') {
+        await markSendResult(habit.id, candidate.dayKey, sub.endpoint, 'gone');
+        await disablePushSubscriptionByEndpoint(sub.householdId, sub.userId, sub.endpoint);
+      } else {
+        // Transient failure: release the claim so the next tick can retry
+        // while the minute is still inside the catch-up window.
+        await releaseClaim(habit.id, candidate.dayKey, sub.endpoint);
+      }
+    }
+  }
+}
+
+export interface ReminderSchedulerHandle {
+  stop: () => void;
+}
+
+/**
+ * Start the interval scheduler. Call only when isPushConfigured(); returns a
+ * handle whose stop() must run during graceful shutdown.
+ */
+export function startReminderScheduler(): ReminderSchedulerHandle {
+  let inFlight = false;
+
+  const safeTick = async (): Promise<void> => {
+    if (inFlight) return; // never overlap ticks on a slow DB
+    inFlight = true;
+    try {
+      if (isPushConfigured()) {
+        await runReminderTick(new Date());
+      }
+    } catch (error) {
+      // A failed tick must never crash the server; dedup + catch-up window
+      // mean the next tick heals anything transient.
+      console.error('[PushReminders] tick failed:', error);
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const interval = setInterval(() => void safeTick(), TICK_MS);
+  // Warmup tick shortly after boot so reminders in the current minute aren't
+  // missed while waiting for the first full interval.
+  const warmup = setTimeout(() => void safeTick(), 5_000);
+
+  console.log('[PushReminders] scheduler started (60s tick)');
+
+  return {
+    stop: () => {
+      clearInterval(interval);
+      clearTimeout(warmup);
+      console.log('[PushReminders] scheduler stopped');
+    },
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,7 +74,7 @@ export interface Habit {
     durationMinutes?: number;
 
     // Push Reminder Fields
-    reminderTime?: string; // HH:mm, device-local; unset = no reminder
+    reminderTime?: string | null; // HH:mm, device-local; null/unset = no reminder (null clears on PATCH)
     reminderEnabled?: boolean; // absent = enabled when reminderTime is set
 
     // Non-Negotiable Fields

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,6 +73,10 @@ export interface Habit {
     scheduledTime?: string; // HH:mm
     durationMinutes?: number;
 
+    // Push Reminder Fields
+    reminderTime?: string; // HH:mm, device-local; unset = no reminder
+    reminderEnabled?: boolean; // absent = enabled when reminderTime is set
+
     // Non-Negotiable Fields
     nonNegotiable?: boolean;
     nonNegotiableDays?: number[]; // 0=Sun, 6=Sat


### PR DESCRIPTION
# Web Push Habit Reminders

Adds per-habit push reminders — the first notification capability in HabitFlow. Users set a reminder time on a habit; the server sends a Web Push at that local time on the habit's assigned days, skipping habits already completed that day. Notifications are enabled per device from **Settings → Notifications** (iOS 16.4+ requires the PWA installed to the Home Screen).

## What's included

**Server**
- `pushSubscriptions` collection: one doc per user+device endpoint, per-device IANA timezone (refreshed on every app open), gone endpoints soft-disabled and revived on re-subscribe
- `pushSendLog` dedup ledger: unique `(habitId, dayKey, endpoint)` index with claim-by-insert makes sends **at-most-once** across restarts, overlapping ticks, and multiple instances; 48h TTL
- Habit fields `reminderTime` ("HH:mm", `null` clears) + `reminderEnabled` (toggle preserves the time) with strict validation on create/PATCH
- `/api/push` routes: `public-key`, `subscriptions` POST/DELETE, `test` — behind identity + demo guard; `501 PUSH_DISABLED` when unconfigured
- In-process scheduler (60s tick): per-timezone local-minute matching with a 5-minute catch-up window (dayKey computed per offset minute, so it's correct across local midnight and DST fall-back), completion check via habit entries (entries stay the single source of truth), 404/410 cleanup, transient-error retry; started only when configured, stopped on SIGTERM/SIGINT

**Client**
- `sw.js`: `push`, `notificationclick` (focus + navigate), `pushsubscriptionchange` handlers
- `src/lib/pushClient.ts`: support/standalone detection, status model, `enablePush()` built to run inside the user-gesture call stack (VAPID key prefetched so `Notification.requestPermission()` is the first await — required on iOS), never-throwing page-load re-sync
- Settings → Notifications section with state-specific guidance (needs-install / denied / enable / test / turn off)
- Add Habit Modal: reminder time input + "Send push reminder" toggle in Schedule & Streak (hidden for bundles)

**Docs:** FEATURES.md, API.md, DATA_MODEL.md, HABITFLOW_UI_ARCHITECTURE.md, and the "How HabitFlow Works" modal (Basics tab).

## Configuration (off by default)

```
PUSH_REMINDERS_ENABLED=true
VAPID_PUBLIC_KEY=…   # npx web-push generate-vapid-keys
VAPID_PRIVATE_KEY=…
VAPID_SUBJECT=mailto:you@example.com
```

⚠️ The in-process scheduler requires an **always-on** backend instance (Render paid tier — an idle-sleeping instance silently stops reminders). `runReminderTick()` is a pure function, so a cron-triggered endpoint is a small adapter if hosting changes. Rotating VAPID keys invalidates every existing device subscription.

## Tests

New suites (vitest + supertest + mongodb-memory-server, per repo convention):
- `pushSubscriptionRepository.test.ts` — upsert idempotency, revive-on-resubscribe, scoping, dedup claims
- `push.subscriptions.test.ts` — endpoint validation, 501 gating, idempotent subscribe, gone-endpoint disable (mocked sender)
- `habits.reminder.test.ts` — HH:mm validation, toggle, clear-with-null
- `reminderScheduler.test.ts` — timezone matching, catch-up window, midnight/DST-adjacent windows, assignedDays/enabled/archived/bundle exclusions, completed-day skip, cross-tick dedup, retry, multi-device/multi-timezone fan-out

**Note:** this sandbox's network policy blocks MongoDB binary downloads, so Mongo-backed suites could not run locally (pre-existing limitation — existing repo tests fail identically here). They are written to the repo's conventions and will run in CI. `npm run build` and `npm run lint:beta` (0 errors) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jznBrfDmKciyuZEBVLD4u

---
_Generated by [Claude Code](https://claude.ai/code/session_011jznBrfDmKciyuZEBVLD4u)_