### PR TITLE
Fix mobile habit tracking regressions

### DIFF
--- a/docs/audits/habit-history-preservation-follow-up-2026-08-02.md
+++ b/docs/audits/habit-history-preservation-follow-up-2026-08-02.md
@@ -1,0 +1,72 @@
+# Habit History Preservation Follow-up — 2026-08-02
+
+## Context and scope
+
+HabitFlowAI currently has one real user. The resolution therefore favors small, explicit safeguards over multi-user migration infrastructure, realtime synchronization, or generalized versioning services. Existing HabitEntry values and DayKeys remain untouched.
+
+## Resolutions
+
+### Target and schedule edits
+
+- A habit stores a small `trackingRevisions` array on its existing document.
+- The first completion/schedule edit records the current rule at the habit creation DayKey and the edited rule at the supplied local DayKey.
+- Later same-day edits replace that day's revision rather than producing noise.
+- Historical completion uses the numeric/boolean target that was effective on the entry DayKey.
+- Historical opportunity and weekly-quota calculations use the weekdays/quota effective on that DayKey or week.
+- A daily↔weekly streak-unit change starts a new comparable streak segment; days and weeks are never mixed into one streak number.
+- Existing HabitEntry documents are not rewritten or copied.
+
+This is deliberately not a separate definitions collection. Habits without revisions continue to use their current top-level configuration, so deployment requires no backfill.
+
+### Archive and restore
+
+- User archive appends a simple open `inactivePeriods` range beginning on the following local day. The archive day remains historical and any completion already recorded that day is preserved.
+- Restore closes the range on the day before restoration, making the restore day active.
+- Daily streaks skip inactive scheduled opportunities. A weekly quota period touched by an inactive range is excused as one unit.
+- A currently archived pre-change habit can infer its one open range from `archivedAt` when restored. Older completed archive/restore cycles cannot be reconstructed because no timestamps exist for them.
+
+### Backdated and imported entries
+
+- A real HabitEntry may predate its habit document because the user backdated it or history was imported/recreated.
+- `createdAt` still prevents the application from inventing missed opportunities before a new habit existed.
+- When an earlier real entry exists, that DayKey is the first evidenced opportunity for streaks and analytics. Schedule weekday rules still apply, and no opportunity is inferred before that entry.
+- A read-only calculation against the configured history confirmed that the ten consecutive `Rogain AM` DayKeys now derive `currentStreak: 10` and `bestStreak: 10`. No record was edited to obtain that result.
+
+### Adjacent derived views
+
+- Historical All/Today/Schedule cells and the history editor display the goal type, target, unit, and cadence effective on the viewed DayKey.
+- Dashboard heatmaps retain actual creation-day/backdated completions without inventing activity on neighboring dates.
+- The history editor mirrors the one-entry-per-habit/day storage rule; zero clears rather than creating redundant progress, and decimal drafts remain visible.
+- The weekly AI review now counts only scheduled target-reaching days; partial numeric entries no longer become “completed” facts.
+- Momentum uses the same caller-supplied local DayKey as progress instead of the server calendar day.
+- The remaining All-grid header delete mode was removed; normal boolean toggle-off and numeric Clear flows remain.
+
+### Existing duplicate HabitEntries
+
+The configured database was audited before modification:
+
+- 23 duplicate index-key groups
+- 44 redundant documents
+- zero groups with conflicting active entries
+- every group contained at most one active document; all collisions were already soft-deleted
+
+The apply run copied all 67 original documents in the affected groups to `habitEntryDedupeArchive`, removed only the 44 already-deleted collisions, and retained every active HabitEntry unchanged. Final verification reported zero duplicate keys and confirmed the canonical unique index is active.
+
+The migration now refuses to apply mixed freeze/choice/unknown-value groups. Boolean duplicates preserve entry-existence completion; numeric duplicates, if encountered later, preserve the summed quantity already shown by the application. Every original document, including the retained winner, is archived before modification.
+
+## Explicit product rules
+
+- `goal.frequency: total` affects cumulative goal aggregation only. The habit tracker still evaluates each DayKey against its daily target and uses those daily completions for streaks.
+- HabitEntry truth outranks a later habit-document creation timestamp for that evidenced DayKey; creation time only prevents unevidenced earlier misses.
+- Exact-day activity and weekly quota satisfaction remain different metrics.
+- One habit/day has at most one active entry. UI history state replaces the upserted day instead of appending a second visual row.
+- Cross-tab visibility/interval refresh is sufficient for the current single-user deployment; realtime conflict infrastructure and offline write queues are intentionally deferred.
+- Existing batch preflight, idempotent per-DayKey upserts, rollback, and authoritative refresh are sufficient for one user. MongoDB multi-document transactions are intentionally not added.
+- Automatic freezes remain disabled until their legacy service is reconciled with canonical completion.
+
+## Data impact
+
+- No active entry value, DayKey, habit ID, source, or timestamp was changed by the duplicate cleanup.
+- No existing HabitEntry is changed by target, schedule, archive, or restore handling.
+- New metadata is added lazily to a habit only when its tracking rule changes or it is archived.
+- Recovery copies from the duplicate cleanup remain in `habitEntryDedupeArchive`.

--- a/docs/audits/habit-tracking-audit-2026-08-01.md
+++ b/docs/audits/habit-tracking-audit-2026-08-01.md
@@ -13,7 +13,7 @@ This audit traced habit creation, daily entry writes, day views, client optimist
 - `goal.frequency`: `daily` or `total`. A `total` numeric habit still records daily contributions; cumulative goal reporting is separate from daily completion.
 - Weekly recurrence: `timesPerWeek`, or `assignedDays` with optional `requiredDaysPerWeek`.
 - Bundles: `choice` or `checklist`, with historical composition represented by temporal `bundleMemberships`; static `subHabitIds` is a legacy fallback.
-- Lifecycle: archive/restore and soft delete are supported. The model has no pause interval, so it cannot exclude an archived period while preserving later activity.
+- Lifecycle: archive/restore and soft delete are supported. User archive cycles now retain lightweight inactive DayKey ranges so restored-habit streaks exclude paused opportunities.
 - Excused occurrence: a freeze marker (`manual`, `auto`, or `soft`) protects streak continuity but is not a completion. There is no second habit-level skipped/excused state.
 
 ### Canonical write flow
@@ -53,17 +53,19 @@ No streak value is persisted. Historical entry edits/deletes and habit definitio
 
 ### Scheduling and streaks
 
-- A scheduled opportunity cannot precede the habit's creation DayKey in the supplied user timezone.
+- No missed opportunity is invented before the habit's creation DayKey. If a real backdated/imported HabitEntry predates `createdAt`, its DayKey starts evidenced history and is not discarded.
 - Assigned weekdays are the only eligible days when present. Unassigned days neither advance nor break a streak; an off-schedule completion does not satisfy a weekly quota.
 - A daily current streak is the consecutive sequence of protected scheduled opportunities through the reference day. An unfinished opportunity on the still-open reference day preserves the prior current streak and marks it at risk.
 - A strict assigned-day schedule (`requiredDaysPerWeek === assignedDays.length`) uses that daily opportunity streak. A flexible schedule with grace days uses week-level satisfaction, as do explicit `timesPerWeek` habits.
 - A weekly current streak is consecutive satisfied ISO Monday–Sunday weeks. An open, unsatisfied current week preserves the preceding streak until the week closes.
 - Longest streak is the largest completed historical sequence of scheduled daily opportunities or satisfied weekly periods.
-- Future entries, invalid DayKeys, and entries before creation do not affect current streak, longest streak, or last-completed date.
+- Future entries and invalid DayKeys do not affect current streak, longest streak, or last-completed date. Unevidenced days before creation are excluded; a real earlier entry is handled by the backdated-history rule above.
 - Weekly quotas count distinct completed scheduled days, not event count or numeric quantity. Duplicate entries cannot inflate progress.
 - Freeze markers protect an opportunity/weekly quota but never set `completedToday` or daily completion.
 - Checklist `streakType` is independent from daily success: `success`, `full`, and `any` are honored from historical child state.
 - Leap days, month/year boundaries, DST transitions, and range iteration use UTC-safe DayKey arithmetic. User-facing creation/reference boundaries use the supplied IANA timezone.
+- Target and schedule edits take effect from one local DayKey via same-document tracking revisions. Earlier dates continue using the rule that applied then; HabitEntries are never rewritten.
+- Changing between occurrence/day streaks and weekly-quota streaks starts a new comparable streak segment because days and weeks are different units.
 
 ### Bundles and historical edits
 
@@ -79,12 +81,12 @@ No streak value is persisted. Historical entry edits/deletes and habit definitio
 | Severity | Defect and impact | Root cause | Resolution |
 |---|---|---|---|
 | High | Numeric habits struck through below target while checkmark/labels disagreed. | UI paths used entry existence or `value > 0`; server paths used target completion; day-view fallbacks used target `1`. | Added one completion domain function and routed UI, server views, summaries, routines, health, reminders, and optimistic state through it. |
-| High | Current/longest streaks broke on unscheduled gaps and could include future data. | Calendar-day adjacency, incomplete lifetime bounds, and schedule branches implemented independently. | Replaced with scheduled-opportunity/weekly-period calculation, bounded by reference and creation DayKeys. |
+| High | Current/longest streaks broke on unscheduled gaps, could include future data, and discarded real backdated history. | Calendar-day adjacency, incomplete lifetime bounds, independent schedule branches, and a hard `createdAt` cutoff. | Replaced with scheduled-opportunity/weekly-period calculation bounded by the reference DayKey; creation bounds unevidenced history while an earlier real entry starts the calculation. |
 | High | Weekly quota streaks counted completions on days not in the configured schedule. | Weekly aggregation counted every completed DayKey. | Count only distinct scheduled completed days; freeze markers remain protective. |
 | High | Checklist completion and streak qualification disagreed. | Progress derived only the daily success rule and discarded `streakType`. | Preserve separate `completed` and `streakCompleted` states for parent bundles. |
 | High | Invalid or type-incompatible entry writes could create false progress. | PATCH/batch/alternate producers did not consistently load the habit or validate the merged value. | Central API validation for boolean/numeric values, date keys, and habit ownership; reconciled alternate producers. |
 | High | Numeric clear/update and multi-child bundle updates could leave partial client/server state under rapid or failed interactions. | Delete-then-create and per-item client mutations were non-atomic and optimistic rollback was fragmented. | Atomic per-key upsert/clear semantics, batch preflight, authoritative refetch, and consolidated rollback. |
-| High | MongoDB unique index could not be rebuilt even after the old dedupe procedure. | The full unique index includes soft-deleted rows, while detection/verification ignored them and the script only soft-deleted losers. | Detector/verifier now exactly match all index keys; dedupe archives losers and removes them from the indexed collection. |
+| High | MongoDB unique index could not be rebuilt even after the old dedupe procedure. | The full unique index includes soft-deleted rows, while detection/verification ignored them and the script only soft-deleted losers. | Detector/verifier now exactly match all index keys; dedupe archives every original and removes only redundant collisions from the indexed collection. |
 | High | Category reorder could silently fail to persist order or delete every category from a stale/empty payload, breaking habit grouping. | The repository deleted all scoped categories, reinserted client objects, and relied on MongoDB natural order. | Reorder now validates the exact scoped ID set and updates an internal sort position in place; stale/partial payloads return 400 without data loss. |
 | Medium | Analytics and reminders used server/UTC creation dates and some analytics paths reimplemented scheduling. | Timezone was not passed through; `date-fns`/manual weekday logic bypassed the schedule domain. | Shared schedule domain used by client/server, reminders, progress, category analytics, insights, heatmaps, and streaks. |
 | Medium | Analytics/progress could return another timezone/day/household's cached result, and category edits stayed stale for the TTL. | Cache keys omitted household, timezone, and reference day; category writes did not invalidate. | Scoped keys include all four dimensions; category mutations invalidate per-user read caches. |
@@ -92,6 +94,10 @@ No streak value is persisted. Historical entry edits/deletes and habit definitio
 | Medium | Invalid numeric targets, duplicate/out-of-range weekdays, contradictory weekly settings, bad times, and impossible checklist thresholds were accepted. | Form/API definition validation was fragmented. | Added typed whole-definition validation on create/edit and disabled invalid form submission. |
 | Medium | Today/Schedule UI could show stale progress after root numeric writes, refresh, or date navigation. | Local merge included bundle children but not root numeric entries and used a hard-coded target. | Shared local status resolver merges all relevant entries, uses habit-type targets, and refetches the authoritative day view. |
 | Medium | Boolean habits linked to unitless cumulative goals contributed `1` instead of the habit target. | The contribution multiplier was incorrectly nested under the goal-unit branch. | Boolean contribution now always uses the configured habit target; goal-unit display no longer changes arithmetic. |
+| Medium | Historical cells, summaries, and the weekly AI review used the current goal type/schedule or treated any entry as completion. | Several display/AI paths bypassed tracking revisions and canonical completion. | Historical DayKeys now resolve their effective type/target/unit/cadence; weekly AI facts count only target-reaching scheduled days. |
+| Medium | Momentum could shift at midnight in the server timezone. | Its seven-day window used `new Date()` instead of the progress request's local DayKey. | Momentum now uses deterministic DayKey arithmetic anchored to the already-resolved user-local reference day. |
+| Medium | The history editor could append a duplicate visual row and persist zero while the tracker treated zero as clear. | Local state ignored the one-entry-per-habit/day upsert contract and parsed input directly into numeric React state. | Existing days expose Edit only; same-day upserts replace local state, zero clears, and string-backed decimal drafts remain visible. |
+| Medium | Client heatmaps omitted real creation-day/backdated activity. | They compared full `createdAt` timestamps with each day's local midnight before checking for an actual completion. | Exact entry evidence is sufficient for the activity view; neighboring days remain empty because completion is still exact-DayKey derived. |
 
 Primary affected systems were `src/domain/habits/*`, `src/domain/time/dayKey.ts`, `streakService`, `dayViewService`, habit entry routes/repository, alternate entry producers, progress/analytics/reminder services, `HabitContext`, tracker/day-view components, category routes/repository, MongoDB index assurance, and migration tooling.
 
@@ -118,7 +124,7 @@ The actual browser reproduction used a numeric target of 10 and verified 1, 4, 1
 - assigned weekdays with unscheduled gaps; off-schedule weekly entries ignored
 - consecutive, missing, current-open, and at-risk ISO weeks
 - historical add/edit/delete recomputation and freeze protection
-- future/pre-creation entries excluded
+- future entries excluded; a real backdated/imported first entry starts history without creating earlier misses
 - checklist `success`/`full`/`any` streak qualification
 - duplicate daily writes deduplicated for weekly progress
 - leap day, month/year boundary, DST spring/fall, timezone creation boundary
@@ -126,7 +132,10 @@ The actual browser reproduction used a numeric target of 10 and verified 1, 4, 1
 ## Architecture and persistence changes
 
 - Added canonical completion, weekly-progress, schedule, DayKey, and definition-validation modules.
+- Added lightweight same-document rule revisions and archive inactive periods; both are populated lazily and require no history backfill.
 - Replaced business-rule copies in tracker cells, Today/Schedule, day view, day summary, progress, analytics, reminders, routines, and health writes.
+- Reconciled weekly AI facts, historical cell metadata, and momentum boundaries with those same canonical rules.
+- Reconciled history-editor cardinality/zero behavior and both client heatmaps with the canonical entry evidence rules.
 - Added server-side whole-habit validation and merged-state validation for PATCH.
 - Made numeric writes single-key operations; batch requests validate completely before mutation.
 - Preserved bundle historical membership and separate daily/streak qualification.
@@ -137,14 +146,13 @@ The actual browser reproduction used a numeric target of 10 and verified 1, 4, 1
 
 ## Remaining risks and product decisions
 
-- The configured database still contains 23 legacy duplicate habit-entry index-key groups. The code intentionally does not mutate data at startup. Run backfill/dedupe dry runs, review the archive plan, apply with backup/approval, verify, then restart to create the unique index.
-- Target and schedule edits currently reinterpret all historical entries because definitions are not versioned. Preserving old targets/schedules requires effective-dated habit definitions and a product decision.
-- Archive has a timestamp but there is no pause/resume interval history. A restored habit cannot distinguish a genuine missed archived period from an active period for historical streaks.
-- `goal.frequency: total` mixes daily completion presentation with lifetime goal aggregation. The desired daily checkmark/streak semantics for cumulative targets need an explicit product rule.
+- The 23 legacy duplicate groups were repaired after a zero-conflict dry run: all 67 originals were archived, only 44 already-deleted collisions were removed, verification found zero remaining keys, and the canonical unique index is active.
+- Rule revisions and inactive periods preserve behavior from this change forward. Definition edits and completed archive/restore cycles that happened before timestamps/revisions existed cannot be reconstructed without guessing; the current stored definition remains the historical baseline.
+- `goal.frequency: total` is now explicitly cumulative only for linked-goal aggregation. Habit-day completion and streaks continue to use the configured per-day target.
 - Weekly-quota analytics still expose both daily heatmap activity and week-level streak satisfaction. A future metric contract should distinguish “completed occurrences” from “quota completion rate” in naming and UI.
 - Static client bundle data is a compatibility fallback; older historical views can only be exact when temporal membership records exist.
-- Batch validation is all-or-nothing before writes, but MongoDB multi-document transactions are not used for routine or bundle child batches. A process failure mid-batch can still require reconciliation.
-- Cross-tab refresh is visibility/interval based, not realtime conflict resolution; offline writes are not queued.
+- Batch validation is all-or-nothing before writes, but MongoDB multi-document transactions are intentionally deferred for the single-user deployment. A process failure mid-batch can still require reconciliation.
+- Cross-tab refresh is visibility/interval based; realtime conflict resolution and offline write queues are intentionally deferred for the single-user deployment.
 - Auto-freeze generation remains a separate service with legacy entry-existence checks and has no active production caller. It should be reconciled before enabling automatic freezes.
 - Hardware haptics, true multi-device concurrency, midnight while the tab stays continuously open, and screen-reader announcements were not fully exercised in automation.
 - The browser reproduction used an isolated generated account and left an empty `Audit Numeric Habit` (target 10 pages) in an `Audit` category; its entry was cleared. No production-data cleanup was run without explicit approval.
@@ -155,14 +163,14 @@ Repository-wide failures outside this audit remain: a nondeterministic goal fore
 
 Focused verification during implementation:
 
-- TypeScript `npx tsc --noEmit`: passed.
-- Canonical completion/schedule/streak/analytics/client status suites: 188/188 passed across 21 files in the final focused run.
+- TypeScript `npx tsc --noEmit -p tsconfig.app.json --forceConsistentCasingInFileNames false`: passed.
+- Final follow-up completion/schedule/streak/analytics/history/mobile suites: 152/152 passed across 15 files; the earlier parent-audit focused suites also passed.
 - Reminder scheduler Mongo integration: passed (20 tests).
 - Habit-entry unique-index Mongo integration: passed (2 tests).
 - Scoped route/persistence restorations: bundle conversion + category routes 29/29, category repository/routes 38/38, deleted-habit goal history 7/7, linked-habit goal cleanup 2/2, and integrity report 1/1.
 - Browser UI: known numeric mismatch reproduced before the fix and the full target matrix above verified after the fix.
-- Full repository Vitest run: 949/957 passed; the eight failures are the unrelated remaining items listed above. All habit-audit regressions passed.
-- `npx vite build`: passed (2,821 modules; existing large-chunk warning).
+- Full repository Vitest run: 999/1007 passed; the eight failures are the unrelated remaining items listed above. All habit-audit regressions passed.
+- `npx vite build`: passed (2,824 modules; existing large-chunk warning).
 - `npm run typecheck` and `npm run build`: blocked by the pre-existing duplicate `src/components/Wellbeing` versus `src/components/wellbeing` casing conflict; direct non-project-reference TypeScript and Vite build both pass.
-- `npm run lint`: existing repository baseline is 429 findings (309 errors, 120 warnings).
-- `npm run check:invariants`: three unrelated existing `activity` wording violations in weekly-review/behavior-pattern files.
+- `npm run lint`: existing repository baseline is 414 findings (300 errors, 114 warnings). Focused lint over the new/tightly changed habit files passes.
+- `npm run check:invariants`: the run found one touched weekly-review wording match plus two duplicate findings for the intentional dashboard label “Days With Activity.” The touched wording was removed; direct source review leaves only the two intentional label matches.

--- a/docs/audits/habit-tracking-audit-2026-08-01.md
+++ b/docs/audits/habit-tracking-audit-2026-08-01.md
@@ -56,6 +56,7 @@ No streak value is persisted. Historical entry edits/deletes and habit definitio
 - A scheduled opportunity cannot precede the habit's creation DayKey in the supplied user timezone.
 - Assigned weekdays are the only eligible days when present. Unassigned days neither advance nor break a streak; an off-schedule completion does not satisfy a weekly quota.
 - A daily current streak is the consecutive sequence of protected scheduled opportunities through the reference day. An unfinished opportunity on the still-open reference day preserves the prior current streak and marks it at risk.
+- A strict assigned-day schedule (`requiredDaysPerWeek === assignedDays.length`) uses that daily opportunity streak. A flexible schedule with grace days uses week-level satisfaction, as do explicit `timesPerWeek` habits.
 - A weekly current streak is consecutive satisfied ISO Monday–Sunday weeks. An open, unsatisfied current week preserves the preceding streak until the week closes.
 - Longest streak is the largest completed historical sequence of scheduled daily opportunities or satisfied weekly periods.
 - Future entries, invalid DayKeys, and entries before creation do not affect current streak, longest streak, or last-completed date.

--- a/docs/audits/habit-tracking-mobile-regression-follow-up-2026-08-02.md
+++ b/docs/audits/habit-tracking-mobile-regression-follow-up-2026-08-02.md
@@ -1,0 +1,46 @@
+# Habit Tracking Mobile Regression Follow-up — 2026-08-02
+
+## Plan and scope
+
+- Reproduce the five reported regressions at a 390 × 844 mobile viewport.
+- Trace each symptom back through UI state, canonical completion, schedule mode, and persistence-derived progress.
+- Add deterministic regression coverage before/with focused fixes.
+- Verify the real mobile UI, focused tests, full tests, lint/typecheck/build, and final diff.
+
+## Confirmed defects and decisions
+
+| Severity | Defect | Root cause | Final behavior |
+|---|---|---|---|
+| High | Every Today/Schedule entry mutation replaced the habit list with “Loading…”. | The authoritative refetch set a blocking loading flag even when valid local/server data was already rendered. | Initial loads and date changes block; mutation revalidation keeps current content visible and rolls in the authoritative response in the background. |
+| High | Numeric entry appeared not to show the typed value on mobile. | The fixed-width flex input consumed the full row and the unbounded popover opened past the right viewport edge, pushing the value/save controls off-screen. | The popover is clamped to the visual viewport; the input can shrink; value, unit, save, and clear controls remain inside the row. |
+| High | Activity heatmaps showed activity on dates without entries. | The heatmaps reused week-level quota satisfaction, which returns true for every queried date in a satisfied week. | Heatmaps count only a completed occurrence on that exact DayKey. Weekly quota status remains available to Today/ring surfaces. |
+| Low | Tiny trash overlays appeared on completed All-grid cells. | A direct per-cell clear button was added to every stored entry. | The overlays are removed. Existing delete mode, long press, numeric clear, and history controls remain available. |
+| High | Ten consecutive daily completions displayed as a streak of one. | Default daily habits carry all seven `assignedDays` and `requiredDaysPerWeek: 7`; the service treated every such strict schedule as a week streak. | Strict schedules count scheduled occurrences (ten days = streak 10). Only explicit/flexible quotas count satisfied weeks. |
+
+## Regression matrix
+
+- Day-view initial load, same-day background refresh, date change, and failed background refresh.
+- Numeric draft value, new/existing value, right/left/bottom mobile viewport clamping, negative/zero behavior, and submit.
+- Weekly quota satisfied by three actual days: quota status true for the week, day activity true only on those three dates.
+- Strict seven-of-seven ten-day history and strict custom weekdays; flexible weekly histories retain week semantics.
+- All-grid completed entry has no inline trash overlay; delete mode still clears with a canonical DayKey.
+
+## Persistence and migration impact
+
+No schema or data migration is required. Completion and streaks remain derived from canonical habit entries. Deploying the service changes interpretation of strict schedule streaks on the next uncached read; habit-entry mutations already invalidate progress caches.
+
+## Verification
+
+- Focused completion, schedule, streak, progress-route, refresh-hook, numeric-popover, heatmap-semantic, and All-grid suites pass.
+- Production Vite build passes (2,823 modules; existing large-chunk warning).
+- TypeScript passes with the repository's known `Wellbeing`/`wellbeing` casing conflict temporarily disabled; the normal project-reference command remains blocked by that pre-existing conflict.
+- Full Vitest run: 961/969 passed. The eight failures are the existing goal forecast/category filtering, dashboard preferences, goal-track nullability, goal extension lineage, and password-reset rate-limit failures documented by the parent audit; no habit regression failed.
+- ESLint passes for every changed code and test file. Repository-wide lint remains blocked by the existing 310-error baseline.
+- Actual 390 × 844 browser verification confirmed: typed quantity and save control remain on-screen, mutation refresh never displays “Loading…”, partial `7/10` persists, inline cell trash is absent, and the 30-day activity grid reports zero completions for all dates when only partial progress exists. The temporary entry was cleared afterward.
+
+## Remaining risk
+
+- Target and schedule changes still reinterpret historical entries because habit definitions are not effective-dated.
+- Pause/archive intervals are not modeled, so restored-habit historical streak policy remains limited.
+- Cross-tab synchronization is refresh/visibility based rather than realtime.
+- Hardware-only iOS keyboard behavior still requires device confirmation, although the reported layout failure is reproduced and corrected at the matching viewport.

--- a/docs/audits/habit-tracking-mobile-regression-follow-up-2026-08-02.md
+++ b/docs/audits/habit-tracking-mobile-regression-follow-up-2026-08-02.md
@@ -13,34 +13,35 @@
 |---|---|---|---|
 | High | Every Today/Schedule entry mutation replaced the habit list with “Loading…”. | The authoritative refetch set a blocking loading flag even when valid local/server data was already rendered. | Initial loads and date changes block; mutation revalidation keeps current content visible and rolls in the authoritative response in the background. |
 | High | Numeric entry appeared not to show the typed value on mobile. | The fixed-width flex input consumed the full row and the unbounded popover opened past the right viewport edge, pushing the value/save controls off-screen. | The popover is clamped to the visual viewport; the input can shrink; value, unit, save, and clear controls remain inside the row. |
-| High | Activity heatmaps showed activity on dates without entries. | The heatmaps reused week-level quota satisfaction, which returns true for every queried date in a satisfied week. | Heatmaps count only a completed occurrence on that exact DayKey. Weekly quota status remains available to Today/ring surfaces. |
-| Low | Tiny trash overlays appeared on completed All-grid cells. | A direct per-cell clear button was added to every stored entry. | The overlays are removed. Existing delete mode, long press, numeric clear, and history controls remain available. |
-| High | Ten consecutive daily completions displayed as a streak of one. | Default daily habits carry all seven `assignedDays` and `requiredDaysPerWeek: 7`; the service treated every such strict schedule as a week streak. | Strict schedules count scheduled occurrences (ten days = streak 10). Only explicit/flexible quotas count satisfied weeks. |
+| High | Activity heatmaps showed activity on dates without entries and could omit a legitimate first/backdated day. | The heatmaps reused week-level quota satisfaction, which returns true for every queried date in a satisfied week, then filtered actual activity by comparing a habit timestamp with local midnight. | Heatmaps count only a completed occurrence on that exact DayKey. A real creation-day/backdated completion is retained; adjacent dates remain empty. Weekly quota status remains available to Today/ring surfaces. |
+| Low | Trash controls appeared in the All grid, including the “Daily Habits” header shown in the report. | A direct per-cell clear control and a second global delete mode had both been added. The first follow-up removed only the per-cell control. | Both added trash surfaces are removed. Boolean toggle-off, numeric Clear, history editing, and long press retain entry removal without a persistent destructive mode. |
+| High | Ten consecutive daily completions displayed as a streak of one. | Strict seven-day schedules were first misclassified as week streaks. After that correction, the live history still lost the first of ten records because its DayKey predates the habit document’s `createdAt` by one day. | Strict schedules count scheduled occurrences. A real backdated/imported entry may start history before `createdAt`, while no missed opportunities are invented before the first record. The actual “Rogain AM” history now derives current and best streaks of 10. |
+| Medium | The history editor could show two entries after “Add Entry” and allowed a redundant zero document. | Its local list appended the upsert response even though persistence permits one document per habit/day; zero handling differed from the tracker. | Existing dates expose Edit rather than Add. An upsert replaces stale same-day UI state, zero clears, and decimal drafts remain visible on mobile. |
 
 ## Regression matrix
 
 - Day-view initial load, same-day background refresh, date change, and failed background refresh.
 - Numeric draft value, new/existing value, right/left/bottom mobile viewport clamping, negative/zero behavior, and submit.
-- Weekly quota satisfied by three actual days: quota status true for the week, day activity true only on those three dates.
-- Strict seven-of-seven ten-day history and strict custom weekdays; flexible weekly histories retain week semantics.
-- All-grid completed entry has no inline trash overlay; delete mode still clears with a canonical DayKey.
+- Weekly quota satisfied by three actual days: quota status true for the week, day activity true only on those three dates; creation-day/backdated activity remains on its exact date.
+- Strict seven-of-seven ten-day history, an evidenced backdated first day, and strict custom weekdays; flexible weekly histories retain week semantics.
+- All-grid completed entry has no inline trash overlay or global delete-mode icon; ordinary toggling still uses a canonical DayKey.
+- Historical edit draft visibility, decimal save, zero-as-clear, and one-entry-per-habit/day UI behavior.
 
 ## Persistence and migration impact
 
-No schema or data migration is required. Completion and streaks remain derived from canonical habit entries. Deploying the service changes interpretation of strict schedule streaks on the next uncached read; habit-entry mutations already invalidate progress caches.
+Completion and streaks remain derived from canonical habit entries. Lightweight rule revisions and inactive periods are added lazily to the existing habit document; no HabitEntry backfill is required. A separate history-preservation follow-up repaired only already-deleted duplicate collisions after archiving every original and activated the canonical unique index.
 
 ## Verification
 
 - Focused completion, schedule, streak, progress-route, refresh-hook, numeric-popover, heatmap-semantic, and All-grid suites pass.
-- Production Vite build passes (2,823 modules; existing large-chunk warning).
+- Production Vite build passes (2,824 modules; existing large-chunk warning).
 - TypeScript passes with the repository's known `Wellbeing`/`wellbeing` casing conflict temporarily disabled; the normal project-reference command remains blocked by that pre-existing conflict.
-- Full Vitest run: 961/969 passed. The eight failures are the existing goal forecast/category filtering, dashboard preferences, goal-track nullability, goal extension lineage, and password-reset rate-limit failures documented by the parent audit; no habit regression failed.
-- ESLint passes for every changed code and test file. Repository-wide lint remains blocked by the existing 310-error baseline.
-- Actual 390 × 844 browser verification confirmed: typed quantity and save control remain on-screen, mutation refresh never displays “Loading…”, partial `7/10` persists, inline cell trash is absent, and the 30-day activity grid reports zero completions for all dates when only partial progress exists. The temporary entry was cleared afterward.
+- Final focused regression run: 152/152 passed across 15 files. Full Vitest run before the final malformed-input regression was added: 999/1007 passed; that added test also passes in the final focused run. The eight failures are the existing goal forecast/category filtering, dashboard preferences, goal-track nullability, goal extension lineage, and password-reset rate-limit failures documented by the parent audit; no habit regression failed.
+- Focused ESLint over the newly added and tightly changed habit implementation/regression files passes. Repository-wide lint remains blocked by the existing 300-error/114-warning baseline, including unrelated findings in several broadly touched legacy files.
+- Actual 390 × 844 browser verification confirmed: typed quantity and save control remain on-screen, mutation refresh never displays “Loading…”, partial `7/10` persists, inline cell trash is absent, and the 30-day activity grid reports zero completions for all dates when only partial progress exists. A later code check removed the remaining header delete-mode icon, and a read-only calculation over the real Rogaine history confirmed `10` current / `10` best. The temporary browser entry was cleared afterward.
 
 ## Remaining risk
 
-- Target and schedule changes still reinterpret historical entries because habit definitions are not effective-dated.
-- Pause/archive intervals are not modeled, so restored-habit historical streak policy remains limited.
-- Cross-tab synchronization is refresh/visibility based rather than realtime.
+- Pre-change target/schedule edits and completed archive cycles cannot be reconstructed where no historical metadata exists.
+- Cross-tab synchronization remains refresh/visibility based by design for the single-user deployment.
 - Hardware-only iOS keyboard behavior still requires device confirmation, although the reported layout failure is reproduced and corrected at the matching viewport.

--- a/docs/decision-log/recent-decisions-2026-03-30.md
+++ b/docs/decision-log/recent-decisions-2026-03-30.md
@@ -80,7 +80,36 @@ instead of a primary “non-negotiable” toggle.
 
 ---
 
-## Decision 4: Bundle completion remains child-entry driven, with stronger temporal membership handling
+## Decision 4: Preserve habit history with lightweight rule and inactive-day metadata
+
+- **Date:** 2026-08-02
+- **Status:** Accepted
+
+### Decision
+
+Keep revisions and archive gaps on the existing habit document rather than introducing a version collection or rewriting HabitEntries.
+
+- The first target/schedule edit records the current rule at creation and the new rule at the local effective DayKey.
+- Historical completion and scheduling resolve the rule effective on that date.
+- Archive begins an inactive range on the following day; restore closes it on the preceding day.
+- Switching between occurrence and weekly streak units starts a new comparable segment.
+- `goal.frequency: total` changes cumulative goal aggregation only; habit-day completion remains target-based.
+- A real backdated/imported entry may start evidenced history before the habit document's `createdAt`; no missed opportunities are inferred before that entry.
+
+### Reasoning
+
+HabitFlowAI has one real user. This preserves entry history and streak meaning with a small, testable data shape while avoiding multi-user migration and compatibility infrastructure.
+
+### Implications
+- Existing entries and historical DayKeys remain unchanged.
+- Metadata is added lazily only when a rule changes or a user archive starts.
+
+### Follow-up actions / open questions
+- Pre-change rule edits and completed archive cycles cannot be reconstructed without source timestamps.
+
+---
+
+## Decision 5: Bundle completion remains child-entry driven, with stronger temporal membership handling
 
 - **Date:** 2026-03-30
 - **Status:** Accepted (ongoing hardening)
@@ -105,7 +134,7 @@ instead of a primary “non-negotiable” toggle.
 
 ---
 
-## Decision 5: Preserve visibility and integrity across archive/delete linkage operations
+## Decision 6: Preserve visibility and integrity across archive/delete linkage operations
 
 - **Date:** 2026-03-30
 - **Status:** Accepted

--- a/docs/decision-log/recent-decisions-2026-03-30.md
+++ b/docs/decision-log/recent-decisions-2026-03-30.md
@@ -54,26 +54,28 @@ instead of a primary “non-negotiable” toggle.
 
 ---
 
-## Decision 3: Streaks for scheduled habits are week-satisfaction based; users can globally hide streak indicators
+## Decision 3: Strict schedules use occurrence streaks; flexible schedules use week streaks
 
-- **Date:** 2026-03-30
-- **Status:** Accepted (with policy clarification pending)
+- **Date:** 2026-03-30; clarified 2026-08-02
+- **Status:** Accepted
 
 ### Decision
-- Scheduled daily habit streaks are calculated by weekly satisfaction against `requiredDaysPerWeek`.
+- A strict schedule (`requiredDaysPerWeek === assignedDays.length`) counts consecutive completed scheduled occurrences. For example, ten completed days on an every-day habit is a ten-day streak.
+- A flexible schedule (`requiredDaysPerWeek < assignedDays.length`) counts consecutive ISO weeks that meet the required number of scheduled completions.
+- Explicit `timesPerWeek` habits remain week-based.
 - A user-level dashboard preference (`hideStreaks`) controls whether streak indicators are shown across UI surfaces.
 
 ### Reasoning
-- Weekly satisfaction provides flexibility and reduces punitive streak breaks.
+- Weekly satisfaction provides flexibility when grace days are configured, while strict schedules preserve the user's visible day-by-day run.
 - A hide-streaks preference supports users who find streak signals distracting or counterproductive.
 
 ### Implications
-- Streak semantics for scheduled habits are less rigid than strict day-specific adherence.
+- Streak units are derived from the schedule mode and must agree across the service and UI formatting.
 - Multiple components must respect a single preference source of truth.
 - Preference hydration/state sync quality becomes critical.
 
 ### Follow-up actions / open questions
-- Clarify product policy: should off-schedule completions count toward weekly requirement in all cases?
+- Off-schedule completions do not satisfy either strict opportunities or flexible weekly requirements.
 - Add regression coverage for dashboard preference hydration and cross-surface consistency.
 
 ---

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -154,7 +154,7 @@ Reports are saved to `docs/migrations/backfill-dayKey-<timestamp>.json`.
 
 Before enabling the unique index on `(householdId, userId, habitId, dayKey)` in production, every duplicate index key must be resolved, including documents already marked deleted. The index is full (not partial), so soft-deleting a loser does not remove the conflict.
 
-On apply, the dedupe script selects an active winner when possible, copies every loser to `habitEntryDedupeArchive` with recovery metadata, and then removes the loser from `habitEntries`. Backfill missing `dayKey` values first; the dedupe script refuses to invent a key from legacy fields because verification must exactly match the index.
+On apply, the dedupe script plans a history-preserving resolution for every group. It copies every original document (including the retained winner) to `habitEntryDedupeArchive` before changing anything, refuses to run if a mixed freeze/choice/unknown-value group needs manual review, removes only redundant documents, and then creates the canonical unique index. Numeric active duplicates are consolidated to the same summed value the application already derives; boolean duplicates retain entry-existence completion. Backfill missing `dayKey` values first; the script refuses to invent a key from legacy fields because verification must exactly match the index.
 
 **Dedupe — dry-run (read-only, writes report only):**
 
@@ -176,7 +176,7 @@ Reports are saved to `docs/migrations/dedupe-habitEntries-<timestamp>.json`.
 npx tsx scripts/migrations/verifyNoDuplicateHabitEntries.ts
 ```
 
-Exits 0 if no duplicates across all documents, 1 if any duplicate groups exist. After a successful apply and verify, restart the server so startup index assurance can create the unique index.
+Exits 0 only if no duplicates remain and the canonical unique index is active. After a successful apply and verify, no server restart is required for index creation.
 
 ---
 

--- a/docs/system-model/HABITFLOW_SYSTEM_RULES.md
+++ b/docs/system-model/HABITFLOW_SYSTEM_RULES.md
@@ -168,34 +168,33 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 
 ### R20: Daily Streak Calculation
 
-- Count consecutive completed/frozen days walking backward from today.
-- If completed today: start from today.
-- If not completed today: start from yesterday.
-- Frozen days (`isFrozen`) count as valid -- they prevent streak breakage.
-- `atRisk = currentStreak > 0 && !completedToday`.
-- **Source:** `streakService.ts:calculateDailyMetrics()`
+- Count consecutive protected scheduled opportunities through the reference DayKey.
+- Days when the habit is not scheduled neither advance nor break the streak.
+- An unfinished opportunity on the current reference day preserves the prior streak and marks it at risk.
+- Frozen days protect continuity but are not reported as completed days.
+- **Source:** `streakService.ts:calculateOpportunityMetrics()`
 
 ### R21: Weekly Streak Calculation
 
 - Count consecutive "satisfied" weeks walking backward from current week.
-- A week is satisfied if weekly progress >= target (`timesPerWeek` or `goal.target`).
+- A week is satisfied if distinct completed scheduled days meet the configured quota.
 - If current week satisfied: include it; if not: start from previous week.
-- For quantity habits: sum values; for frequency: count distinct days.
+- Numeric quantity only completes its individual day after reaching the daily numeric target; quantity does not inflate the number of completed occurrences.
 - `atRisk = currentStreak > 0 && !currentWeek.satisfied && daysLeftInWeek <= 2`.
 - **Source:** `streakService.ts:calculateWeeklyMetrics()`
 
 ### R22: Scheduled-Daily Streak Calculation
 
-- For habits with `assignedDays` + `requiredDaysPerWeek`.
-- Uses weekly windows: week satisfied if completions (on ANY day) >= `requiredDaysPerWeek`.
-- Note: completions on non-assigned days still count toward the week.
-- **Source:** `streakService.ts:calculateScheduledDailyMetrics()`
+- A strict schedule has `requiredDaysPerWeek === assignedDays.length`; it uses scheduled-opportunity streaks measured in days/occurrences.
+- A flexible schedule has `requiredDaysPerWeek < assignedDays.length`; it uses satisfied-week streaks.
+- Completions on non-assigned days do not advance either mode.
+- **Source:** `schedule.ts:usesWeeklyQuotaStreak()`, `streakService.ts`
 
 ### R23: Streak Mode Selection
 
-- If `habit.timesPerWeek > 0` -> weekly streak (`calculateWeeklyMetrics`).
-- Else if `habit.assignedDays?.length && habit.requiredDaysPerWeek` -> scheduled-daily streak (`calculateScheduledDailyMetrics`).
-- Else -> daily streak (`calculateDailyMetrics`).
+- If `habit.timesPerWeek > 0` -> weekly streak.
+- Else if `requiredDaysPerWeek < assignedDays.length` -> flexible weekly streak.
+- Else -> scheduled-opportunity streak.
 - **Source:** `streakService.ts:calculateHabitStreakMetrics()`
 
 ---

--- a/docs/system-model/HABITFLOW_SYSTEM_RULES.md
+++ b/docs/system-model/HABITFLOW_SYSTEM_RULES.md
@@ -35,7 +35,7 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 
 - Truth records (HabitEntry, WellbeingEntry) use a `deletedAt` timestamp for soft delete.
 - Queries must filter `deletedAt` unless explicitly including deleted records.
-- Habits use `archived: true` instead of deletion.
+- Habit archive is reversible; permanent habit removal sets `deletedAt` while retaining the document and its entries for historical/goal resolution.
 
 ### R5: Identity Scoping
 
@@ -52,24 +52,24 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 
 ### R6: Daily Boolean Habit Completion
 
-- Complete if: at least one non-deleted `HabitEntry` exists for `(habitId, dayKey)`.
+- Complete if: at least one active, non-freeze `HabitEntry` exists for `(habitId, dayKey)`.
 - Value is ignored for boolean habits -- any entry means complete.
-- **Source:** `dayViewService.ts:deriveDailyCompletion()` -- returns `true` when `entryViews.some(entry => entry.habitId === habitId && entry.dayKey === dayKey && !entry.deletedAt)`.
+- **Source:** `src/domain/habits/completion.ts:deriveDailyHabitCompletion()`.
 
 ### R7: Daily Numeric Habit Completion
 
-- Complete if: sum of entry values for `(habitId, dayKey)` >= `habit.goal.target`.
-- Multiple entries per day are summed.
-- **Source:** `dayViewService.ts` -- numeric completion is derived by summing `entry.value` across all non-deleted entries for the day.
+- Complete if: the non-negative finite value for `(habitId, dayKey)` reaches the positive target effective on that DayKey.
+- Below-target values are partial progress, never completion. Zero/empty is no progress; negative/non-finite writes are rejected.
+- The uniqueness key permits one canonical document per habit/day. Derivation still sums defensively if legacy input contains more than one record.
+- **Source:** `src/domain/habits/completion.ts:deriveDailyHabitCompletion()`.
 
 ### R8: Weekly Habit Completion
 
 - Week window: Monday to Sunday (`weekStartsOn: 1`).
-- Three sub-types determined by `deriveWeeklyProgress()`:
-  - **Quantity weekly** (`habit.goal.type === 'number'`): sum of entry values in week >= `timesPerWeek` / `goal.target`.
-  - **Frequency weekly** (`!isQuantity && target > 1`): count of distinct `dayKeys` with entries in week >= target.
-  - **Binary weekly** (single entry suffices): any non-deleted entry in week = complete.
-- **Source:** `dayViewService.ts:deriveWeeklyProgress()`
+- A weekly quota is satisfied when the count of distinct scheduled DayKeys that reached daily completion meets `timesPerWeek` or the flexible `requiredDaysPerWeek` rule.
+- Numeric quantity completes its own day only after reaching that day's target; raw quantity never inflates occurrence count.
+- Off-schedule entries do not satisfy the quota.
+- **Source:** `src/domain/habits/weeklyProgress.ts`, `src/server/services/streakService.ts`.
 
 ### R9: Checklist Bundle Completion
 
@@ -101,18 +101,17 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 - Frozen days count as valid for streak calculations (they prevent streak breakage).
 - Detection: `parseFreezeType(entry.note)` in progress utilities.
 - Freeze inventory: `habit.freezeCount`, max 3.
-- Auto-freeze: applied for yesterday only, consumes 1 inventory, only if day-2 had an entry (protecting an active streak).
+- Automatic freeze generation is disabled until the legacy service uses canonical completion and schedule rules.
 - **Source:** `src/server/services/freezeService.ts`
 
 ---
 
 ## 4. Scheduling Rules
 
-### R13: assignedDays Controls Visibility, Not Completion
+### R13: assignedDays Controls Opportunities
 
 - `assignedDays` determines which days a habit appears in the Day View and Schedule View.
-- A habit can still be completed on non-assigned days (entries are always accepted).
-- Completing on a non-assigned day still counts toward streaks and goals.
+- An off-schedule entry can remain in history and goal aggregation, but it does not advance a strict occurrence streak or satisfy a flexible weekly quota.
 
 ### R14: Scheduling Logic
 
@@ -197,6 +196,30 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 - Else -> scheduled-opportunity streak.
 - **Source:** `streakService.ts:calculateHabitStreakMetrics()`
 
+### R23A: Tracking Rule History
+
+- Target and schedule edits are effective from a canonical local DayKey.
+- The habit document keeps only tracking-relevant revisions: goal, assigned weekdays, and weekly quota fields.
+- Completion and scheduling resolve the revision effective on the historical DayKey; HabitEntries are not rewritten.
+- Repeated edits on one DayKey replace that revision.
+- A change between occurrence and weekly streak units starts a new comparable streak segment.
+- **Source:** `trackingHistory.ts`, `completion.ts`, `schedule.ts`, `streakService.ts`
+
+### R23B: Archive/Restore Opportunities
+
+- User archive preserves the archive day and starts an inactive interval the following local day.
+- Restore ends the inactive interval the previous local day, so the restore day is active.
+- Inactive daily opportunities do not advance or break a streak.
+- Weekly periods touched by an inactive interval are excused as a whole period.
+- **Source:** `habitRepository.ts`, `schedule.ts`, `streakService.ts`
+
+### R23C: Backdated and Imported History
+
+- `createdAt` prevents unevidenced missed opportunities before a habit existed.
+- If a real entry predates `createdAt`, the earliest such DayKey starts evidenced streak/statistics history.
+- The entry must still match the historical weekday rule; no opportunities are invented before it.
+- **Source:** `schedule.ts:matchesHabitScheduleOnDay()`, `streakService.ts`, `analyticsService.ts`.
+
 ---
 
 ## 7. Goal Progress Rules
@@ -239,7 +262,8 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 - Daily with `assignedDays`: 1 opportunity per assigned day in range.
 - Weekly habits with `assignedDays`: count assigned days in range.
 - Weekly without `assignedDays`: count distinct weeks in range.
-- **Source:** `scheduleEngine.ts:getExpectedOpportunitiesInRange()`
+- Before `createdAt`, count no opportunity unless a real entry exists on that matching schedule day; that evidenced day is included.
+- **Source:** `scheduleEngine.ts:getExpectedOpportunitiesInRange()`, `analyticsService.ts:isHabitAnalyticsOpportunityOnDay()`
 
 ---
 
@@ -247,7 +271,7 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 
 ### R29: Canonical Data Flow
 
-1. User action -> Frontend writes `HabitEntry` via `POST /api/entries`.
+1. User action -> Frontend upserts or clears a `HabitEntry` via the canonical entry API.
 2. Backend validates dayKey/timezone.
 3. Backend stores entry in `habitEntries` collection.
 4. Derived views computed from entries at read time (`GET /api/day-view`, `GET /api/progress`, etc.).
@@ -259,6 +283,7 @@ This document defines the invariant rules that govern HabitFlowAI's behavior. An
 - `timezone` must be valid IANA timezone.
 - Forbidden fields: stored completion status (completion is always derived).
 - `source` is validated against allowed values: `manual`, `routine`, `quick`, `import`, `apple_health`, `test`.
+- Numeric values must be finite and non-negative; numeric habits require a value.
 
 ---
 

--- a/scripts/migrations/dedupeHabitEntries.ts
+++ b/scripts/migrations/dedupeHabitEntries.ts
@@ -21,9 +21,14 @@ dotenv.config({ path: resolve(process.cwd(), '.env') });
 import { MongoClient, ObjectId } from 'mongodb';
 import { getMongoDbUri, getMongoDbName } from '../../src/server/config/env';
 import { writeFileSync, mkdirSync } from 'fs';
+import {
+  planDuplicateHabitEntries,
+  type DuplicateGroupPlan,
+} from './dedupeHabitEntriesPolicy';
 
 const COLLECTION = 'habitEntries';
 const ARCHIVE_COLLECTION = 'habitEntryDedupeArchive';
+const UNIQUE_INDEX_NAME = 'idx_habitEntries_user_habit_dayKey_active_unique';
 
 type Doc = {
   _id: ObjectId;
@@ -43,6 +48,9 @@ type DupeGroup = {
   key: { householdId: string | null; userId: string; habitId: string; dayKey: string };
   winner: Doc;
   losers: Doc[];
+  plan: DuplicateGroupPlan;
+  habitName?: string;
+  goalType?: 'boolean' | 'number';
 };
 
 type Report = {
@@ -55,6 +63,17 @@ type Report = {
   documentsMissingDayKey: number;
   docsArchived: number;
   docsRemoved: number;
+  uniqueIndexPresent: boolean;
+  manualReviewGroups: number;
+  resolutionCounts: Record<string, number>;
+  groups: Array<{
+    key: { householdId: string | null; userId: string; habitId: string; dayKey: string };
+    habitName?: string;
+    goalType?: 'boolean' | 'number';
+    winnerId: string;
+    loserIds: string[];
+    plan: DuplicateGroupPlan;
+  }>;
   sampleGroups: Array<{
     key: { householdId: string | null; userId: string; habitId: string; dayKey: string };
     winnerId: string;
@@ -121,6 +140,17 @@ async function main(): Promise<void> {
     await client.connect();
     const db = client.db(dbName);
     const coll = db.collection<Doc>(COLLECTION);
+    const habits = await db.collection('habits')
+      .find({}, { projection: { householdId: 1, userId: 1, id: 1, name: 1, 'goal.type': 1 } })
+      .toArray();
+    const habitByScopeAndId = new Map(habits.map(habit => [
+      JSON.stringify([
+        habit.householdId == null ? null : String(habit.householdId),
+        habit.userId,
+        habit.id,
+      ]),
+      habit,
+    ]));
 
     const documents = await coll.find({}).toArray();
     const documentsMissingDayKey = documents.filter(doc => !canonicalDayKey(doc)).length;
@@ -145,6 +175,14 @@ async function main(): Promise<void> {
       if (list.length <= 1) continue;
       list.sort(compareDocs);
       const householdId = list[0].householdId == null ? null : String(list[0].householdId);
+      const habit = habitByScopeAndId.get(JSON.stringify([
+        householdId,
+        list[0].userId,
+        list[0].habitId,
+      ]));
+      const goalType = habit?.goal?.type === 'boolean' || habit?.goal?.type === 'number'
+        ? habit.goal.type
+        : undefined;
       groups.push({
         key: {
           householdId,
@@ -154,6 +192,9 @@ async function main(): Promise<void> {
         },
         winner: list[0],
         losers: list.slice(1),
+        plan: planDuplicateHabitEntries(list, goalType),
+        habitName: typeof habit?.name === 'string' ? habit.name : undefined,
+        goalType,
       });
     }
 
@@ -163,6 +204,19 @@ async function main(): Promise<void> {
       winnerId: g.winner.id ?? g.winner._id.toString(),
       loserIds: g.losers.map((d) => d.id ?? d._id.toString()),
     }));
+    const groupDiagnostics = groups.map(g => ({
+      key: g.key,
+      habitName: g.habitName,
+      goalType: g.goalType,
+      winnerId: g.winner.id ?? g.winner._id.toString(),
+      loserIds: g.losers.map(d => d.id ?? d._id.toString()),
+      plan: g.plan,
+    }));
+    const manualReviewGroups = groups.filter(group => !group.plan.safeToApply).length;
+    const resolutionCounts = groups.reduce<Record<string, number>>((counts, group) => {
+      counts[group.plan.resolution] = (counts[group.plan.resolution] ?? 0) + 1;
+      return counts;
+    }, {});
 
     const report: Report = {
       timestamp: new Date().toISOString(),
@@ -174,6 +228,10 @@ async function main(): Promise<void> {
       documentsMissingDayKey,
       docsArchived: 0,
       docsRemoved: 0,
+      uniqueIndexPresent: false,
+      manualReviewGroups,
+      resolutionCounts,
+      groups: groupDiagnostics,
       sampleGroups,
     };
 
@@ -182,17 +240,23 @@ async function main(): Promise<void> {
       if (groups.length > 0) {
         console.log('[dry-run] Sample keys (householdId, userId, habitId, dayKey):', sampleGroups.map((s) => s.key));
       }
+      console.log('[dry-run] Resolution counts:', resolutionCounts, 'Manual review:', manualReviewGroups);
     } else {
+      if (manualReviewGroups > 0) {
+        throw new Error(
+          `${manualReviewGroups} duplicate group(s) require manual review. No database writes were performed.`,
+        );
+      }
       console.log('DB:', dbName, 'Host:', host);
-      console.log('Archiving and removing', duplicatesFound, 'loser(s) in', groups.length, 'group(s).');
+      console.log('Archiving originals and consolidating', duplicatesFound, 'duplicate(s) in', groups.length, 'group(s).');
       const now = new Date().toISOString();
       const archive = db.collection(ARCHIVE_COLLECTION);
       let archived = 0;
       let removed = 0;
       for (const g of groups) {
-        for (const loser of g.losers) {
-          const { _id, ...archiveDocument } = loser;
-          await archive.updateOne(
+        for (const original of [g.winner, ...g.losers]) {
+          const { _id, ...archiveDocument } = original;
+          const archiveResult = await archive.updateOne(
             { originalCollectionId: _id },
             { $setOnInsert: {
               ...archiveDocument,
@@ -201,18 +265,43 @@ async function main(): Promise<void> {
               dedupe: {
                 winnerId: g.winner.id ?? g.winner._id.toString(),
                 dedupedAt: now,
-                reason: 'unique-index-repair',
+                reason: 'history-preserving-unique-index-repair',
+                role: original._id.equals(g.winner._id) ? 'winner-original' : 'loser',
+                resolution: g.plan.resolution,
               },
             } },
             { upsert: true },
           );
-          archived++;
-          const deletion = await coll.deleteOne({ _id });
+          archived += archiveResult.upsertedCount;
+        }
+
+        if (g.plan.resolution === 'sum-numeric-duplicates') {
+          await coll.updateOne(
+            { _id: g.winner._id },
+            { $set: { value: g.plan.replacementValue } },
+          );
+        }
+
+        for (const loser of g.losers) {
+          const deletion = await coll.deleteOne({ _id: loser._id });
           removed += deletion.deletedCount;
         }
       }
       report.docsArchived = archived;
       report.docsRemoved = removed;
+
+      await coll.createIndex(
+        { householdId: 1, userId: 1, habitId: 1, dayKey: 1 },
+        { unique: true, name: UNIQUE_INDEX_NAME },
+      );
+      report.uniqueIndexPresent = true;
+    }
+
+    if (dryRun) {
+      const indexes = await coll.indexes();
+      report.uniqueIndexPresent = indexes.some(index => (
+        index.name === UNIQUE_INDEX_NAME && index.unique === true
+      ));
     }
 
     const reportDir = resolve(process.cwd(), 'docs', 'migrations');

--- a/scripts/migrations/dedupeHabitEntriesPolicy.test.ts
+++ b/scripts/migrations/dedupeHabitEntriesPolicy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { planDuplicateHabitEntries } from './dedupeHabitEntriesPolicy';
+
+describe('habit entry dedupe policy', () => {
+  it('removes only deleted collisions when one active document exists', () => {
+    expect(planDuplicateHabitEntries([
+      { value: 4 },
+      { value: 9, deletedAt: '2026-01-02T00:00:00.000Z' },
+    ], 'number')).toMatchObject({
+      resolution: 'remove-deleted-collisions',
+      safeToApply: true,
+      activeCount: 1,
+    });
+  });
+
+  it('collapses boolean duplicates without changing completion', () => {
+    expect(planDuplicateHabitEntries([{ value: 1 }, { value: 1 }], 'boolean')).toMatchObject({
+      resolution: 'collapse-boolean-duplicates',
+      safeToApply: true,
+    });
+  });
+
+  it('sums numeric duplicates to preserve current derived progress', () => {
+    expect(planDuplicateHabitEntries([{ value: 4 }, { value: 6 }], 'number')).toMatchObject({
+      resolution: 'sum-numeric-duplicates',
+      safeToApply: true,
+      replacementValue: 10,
+    });
+  });
+
+  it('stops when freeze and progress documents conflict', () => {
+    expect(planDuplicateHabitEntries([
+      { note: 'freeze:auto', value: 0 },
+      { value: 1 },
+    ], 'boolean')).toMatchObject({
+      resolution: 'manual-review',
+      safeToApply: false,
+    });
+  });
+
+  it('stops when multiple choices were stored for one day', () => {
+    expect(planDuplicateHabitEntries([
+      { bundleOptionId: 'walk' },
+      { bundleOptionId: 'run' },
+    ], 'boolean')).toMatchObject({
+      resolution: 'manual-review',
+      safeToApply: false,
+    });
+  });
+});

--- a/scripts/migrations/dedupeHabitEntriesPolicy.ts
+++ b/scripts/migrations/dedupeHabitEntriesPolicy.ts
@@ -1,0 +1,120 @@
+export type DuplicateEntryLike = {
+  deletedAt?: string;
+  value?: unknown;
+  note?: unknown;
+  bundleOptionId?: unknown;
+  choiceChildHabitId?: unknown;
+};
+
+export type DuplicateResolution =
+  | 'remove-deleted-collisions'
+  | 'collapse-boolean-duplicates'
+  | 'collapse-freeze-duplicates'
+  | 'sum-numeric-duplicates'
+  | 'manual-review';
+
+export interface DuplicateGroupPlan {
+  resolution: DuplicateResolution;
+  safeToApply: boolean;
+  activeCount: number;
+  deletedCount: number;
+  replacementValue?: number;
+  reason: string;
+}
+
+function freezeKind(entry: DuplicateEntryLike): 'freeze' | 'entry' {
+  return typeof entry.note === 'string' && entry.note.startsWith('freeze:')
+    ? 'freeze'
+    : 'entry';
+}
+
+function choiceKey(entry: DuplicateEntryLike): string | null {
+  const key = entry.choiceChildHabitId ?? entry.bundleOptionId;
+  return typeof key === 'string' && key.length > 0 ? key : null;
+}
+
+/**
+ * Build a repair plan that preserves the currently derived history.
+ * Numeric duplicates are summed because all current read paths sum active
+ * values for the DayKey; boolean duplicates collapse by entry existence.
+ */
+export function planDuplicateHabitEntries(
+  entries: DuplicateEntryLike[],
+  goalType?: 'boolean' | 'number',
+): DuplicateGroupPlan {
+  const active = entries.filter(entry => !entry.deletedAt);
+  const deletedCount = entries.length - active.length;
+
+  if (active.length <= 1) {
+    return {
+      resolution: 'remove-deleted-collisions',
+      safeToApply: true,
+      activeCount: active.length,
+      deletedCount,
+      reason: 'At most one active document exists, so visible history is unchanged.',
+    };
+  }
+
+  const freezeKinds = new Set(active.map(freezeKind));
+  if (freezeKinds.size > 1) {
+    return {
+      resolution: 'manual-review',
+      safeToApply: false,
+      activeCount: active.length,
+      deletedCount,
+      reason: 'The same DayKey contains both a freeze marker and ordinary progress.',
+    };
+  }
+  if (freezeKinds.has('freeze')) {
+    return {
+      resolution: 'collapse-freeze-duplicates',
+      safeToApply: true,
+      activeCount: active.length,
+      deletedCount,
+      reason: 'All active documents are equivalent streak-protection markers.',
+    };
+  }
+
+  const distinctChoices = new Set(active.map(choiceKey).filter((key): key is string => key !== null));
+  if (distinctChoices.size > 1) {
+    return {
+      resolution: 'manual-review',
+      safeToApply: false,
+      activeCount: active.length,
+      deletedCount,
+      reason: 'The same DayKey contains different choice selections.',
+    };
+  }
+
+  if (goalType === 'boolean') {
+    return {
+      resolution: 'collapse-boolean-duplicates',
+      safeToApply: true,
+      activeCount: active.length,
+      deletedCount,
+      reason: 'Boolean completion is based on entry existence, so one active document preserves it.',
+    };
+  }
+
+  if (goalType === 'number') {
+    const values = active.map(entry => entry.value);
+    if (values.every(value => typeof value === 'number' && Number.isFinite(value) && value >= 0)) {
+      return {
+        resolution: 'sum-numeric-duplicates',
+        safeToApply: true,
+        activeCount: active.length,
+        deletedCount,
+        replacementValue: (values as number[]).reduce((sum, value) => sum + value, 0),
+        reason: 'The replacement keeps the same summed quantity currently derived for this DayKey.',
+      };
+    }
+  }
+
+  return {
+    resolution: 'manual-review',
+    safeToApply: false,
+    activeCount: active.length,
+    deletedCount,
+    reason: 'Habit type or active values are insufficient for a history-preserving automatic repair.',
+  };
+}

--- a/scripts/migrations/verifyNoDuplicateHabitEntries.ts
+++ b/scripts/migrations/verifyNoDuplicateHabitEntries.ts
@@ -18,6 +18,7 @@ import { MongoClient } from 'mongodb';
 import { getMongoDbUri, getMongoDbName } from '../../src/server/config/env';
 
 const COLLECTION = 'habitEntries';
+const UNIQUE_INDEX_NAME = 'idx_habitEntries_user_habit_dayKey_active_unique';
 async function main(): Promise<void> {
   const uri = getMongoDbUri();
   const dbName = getMongoDbName();
@@ -59,7 +60,15 @@ async function main(): Promise<void> {
       process.exit(1);
     }
 
-    console.log('OK: No duplicate habit-entry index keys (per householdId, userId, habitId, dayKey).');
+    const indexes = await coll.indexes();
+    const uniqueIndex = indexes.find(index => index.name === UNIQUE_INDEX_NAME);
+    const expectedKey = JSON.stringify({ householdId: 1, userId: 1, habitId: 1, dayKey: 1 });
+    if (!uniqueIndex || uniqueIndex.unique !== true || JSON.stringify(uniqueIndex.key) !== expectedKey) {
+      console.error(`FAIL: Expected unique index ${UNIQUE_INDEX_NAME} is missing or has the wrong definition.`);
+      process.exit(1);
+    }
+
+    console.log('OK: No duplicate habit-entry keys and the canonical unique index is active.');
   } finally {
     await client.close();
   }

--- a/src/components/HabitHistoryModal.test.tsx
+++ b/src/components/HabitHistoryModal.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Habit, HabitEntry } from '../models/persistenceTypes';
+import { HabitHistoryModal } from './HabitHistoryModal';
+
+vi.mock('../store/HabitContext', () => ({ useHabitStore: vi.fn() }));
+vi.mock('../lib/persistenceClient', () => ({
+    fetchHabitEntries: vi.fn(),
+    updateHabitEntry: vi.fn(),
+    deleteHabitEntry: vi.fn(),
+    createHabitEntry: vi.fn(),
+}));
+
+import { useHabitStore } from '../store/HabitContext';
+import {
+    createHabitEntry,
+    deleteHabitEntry,
+    fetchHabitEntries,
+    updateHabitEntry,
+} from '../lib/persistenceClient';
+
+const habit: Habit = {
+    id: 'habit-1',
+    categoryId: 'cat-1',
+    name: 'Read',
+    goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+    archived: false,
+    createdAt: '2026-07-01T12:00:00.000Z',
+};
+
+const existingEntry: HabitEntry = {
+    id: 'entry-1',
+    habitId: habit.id,
+    dayKey: '2026-08-01',
+    date: '2026-08-01',
+    timestamp: '2026-08-01T16:00:00.000Z',
+    value: 5,
+    source: 'manual',
+    createdAt: '2026-08-01T16:00:00.000Z',
+    updatedAt: '2026-08-01T16:00:00.000Z',
+};
+
+describe('HabitHistoryModal', () => {
+    const refreshDayLogs = vi.fn().mockResolvedValue(undefined);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date(2026, 7, 2, 12, 0, 0));
+        vi.mocked(useHabitStore).mockReturnValue({
+            habits: [habit],
+            refreshDayLogs,
+        } as unknown as ReturnType<typeof useHabitStore>);
+        vi.mocked(fetchHabitEntries).mockResolvedValue([existingEntry]);
+        vi.mocked(deleteHabitEntry).mockResolvedValue({ success: true, dayLog: null });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    async function openExistingEntry() {
+        render(<HabitHistoryModal habitId={habit.id} onClose={() => {}} />);
+        const dateButton = await screen.findByRole('button', { name: /Sat, Aug 1, 2026/ });
+        fireEvent.click(dateButton);
+    }
+
+    it('treats an edited zero as clearing the entry', async () => {
+        await openExistingEntry();
+        fireEvent.click(screen.getByTitle('Edit'));
+
+        const input = screen.getByLabelText('Entry quantity') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '0' } });
+        expect(input.value).toBe('0');
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => expect(deleteHabitEntry).toHaveBeenCalledWith(existingEntry.id));
+        expect(updateHabitEntry).not.toHaveBeenCalled();
+        expect(refreshDayLogs).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a decimal draft visible and saves its numeric value', async () => {
+        vi.mocked(updateHabitEntry).mockResolvedValue({
+            entry: { ...existingEntry, value: 12.5 },
+            dayLog: null,
+        });
+        await openExistingEntry();
+        fireEvent.click(screen.getByTitle('Edit'));
+
+        const input = screen.getByLabelText('Entry quantity') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '12.5' } });
+        expect(input.value).toBe('12.5');
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(updateHabitEntry).toHaveBeenCalledWith(existingEntry.id, { value: 12.5 });
+        });
+    });
+
+    it('does not offer a second entry for a day that already has one', async () => {
+        await openExistingEntry();
+        expect(screen.queryByRole('button', { name: 'Add Entry' })).not.toBeInTheDocument();
+        expect(createHabitEntry).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/HabitHistoryModal.tsx
+++ b/src/components/HabitHistoryModal.tsx
@@ -23,6 +23,7 @@ import {
 } from 'date-fns';
 import { ChevronLeft, ChevronRight, Plus, Trash2, Pencil, X } from 'lucide-react';
 import { cn } from '../utils/cn';
+import { resolveHabitTrackingForDay } from '../domain/habits/trackingHistory';
 
 interface HabitHistoryModalProps {
     habitId: string;
@@ -40,8 +41,8 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
     const [currentMonth, setCurrentMonth] = useState(new Date());
     const [selectedDate, setSelectedDate] = useState<string | null>(null);
     const [editingId, setEditingId] = useState<string | null>(null);
-    const [editValue, setEditValue] = useState<number>(0);
-    const [newEntryValue, setNewEntryValue] = useState<number>(1);
+    const [editValue, setEditValue] = useState('');
+    const [newEntryValue, setNewEntryValue] = useState('1');
     const [showNewEntry, setShowNewEntry] = useState(false);
     const [saving, setSaving] = useState(false);
 
@@ -114,19 +115,25 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
 
     const handleStartEdit = (entry: HabitEntry) => {
         setEditingId(entry.id);
-        setEditValue(entry.value || 0);
+        setEditValue(typeof entry.value === 'number' ? String(entry.value) : '');
         setShowNewEntry(false);
     };
 
     const handleSaveEdit = async (entry: HabitEntry) => {
-        if (!Number.isFinite(editValue) || editValue < 0) {
+        const parsedValue = editValue.trim() === '' ? Number.NaN : Number(editValue);
+        if (!Number.isFinite(parsedValue) || parsedValue < 0) {
             alert('Quantity must be zero or greater.');
             return;
         }
         setSaving(true);
         try {
-            await updateHabitEntry(entry.id, { value: editValue });
-            setEntries(prev => prev.map(e => e.id === entry.id ? { ...e, value: editValue } : e));
+            if (parsedValue === 0) {
+                await deleteHabitEntry(entry.id);
+                setEntries(prev => prev.filter(e => e.id !== entry.id));
+            } else {
+                const result = await updateHabitEntry(entry.id, { value: parsedValue });
+                setEntries(prev => prev.map(e => e.id === entry.id ? result.entry : e));
+            }
             setEditingId(null);
             await refreshDayLogs();
         } catch (error) {
@@ -139,8 +146,9 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
 
     const handleCreateEntry = async () => {
         if (!selectedDate) return;
-        if (!Number.isFinite(newEntryValue) || newEntryValue < 0) {
-            alert('Quantity must be zero or greater.');
+        const parsedValue = newEntryValue.trim() === '' ? Number.NaN : Number(newEntryValue);
+        if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+            alert('Quantity must be greater than zero.');
             return;
         }
         setSaving(true);
@@ -148,13 +156,18 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
             const result = await createHabitEntry({
                 habitId,
                 dayKey: selectedDate,
-                value: newEntryValue,
+                value: parsedValue,
                 source: 'manual',
                 timestamp: new Date().toISOString(),
             });
-            setEntries(prev => [...prev, result.entry]);
+            // Storage is canonical at one document per habit/day. Replace a
+            // stale same-day item if one appeared while this request was open.
+            setEntries(prev => [
+                ...prev.filter(entry => (entry.dayKey || entry.date) !== selectedDate),
+                result.entry,
+            ]);
             setShowNewEntry(false);
-            setNewEntryValue(1);
+            setNewEntryValue('1');
             await refreshDayLogs();
         } catch (error) {
             console.error('Failed to create entry', error);
@@ -166,7 +179,8 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
 
     if (!habit) return null;
 
-    const isQuantity = habit.goal?.type === 'number';
+    const selectedTracking = resolveHabitTrackingForDay(habit, selectedDate ?? undefined);
+    const selectedUnit = selectedTracking.goal.unit;
     const selectedEntries = selectedDate ? (entriesByDay.get(selectedDate) || []) : [];
 
     return (
@@ -201,6 +215,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                     <button
                                         onClick={() => setCurrentMonth(prev => subMonths(prev, 1))}
                                         className="p-1.5 rounded-lg hover:bg-white/5 text-neutral-400 hover:text-white transition-colors"
+                                        aria-label="Previous month"
                                     >
                                         <ChevronLeft size={18} />
                                     </button>
@@ -211,6 +226,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                         onClick={() => setCurrentMonth(prev => addMonths(prev, 1))}
                                         className="p-1.5 rounded-lg hover:bg-white/5 text-neutral-400 hover:text-white transition-colors"
                                         disabled={isSameMonth(currentMonth, today)}
+                                        aria-label="Next month"
                                     >
                                         <ChevronRight size={18} className={isSameMonth(currentMonth, today) ? 'opacity-30' : ''} />
                                     </button>
@@ -236,12 +252,14 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                         const isSelected = selectedDate === dayKey;
                                         const dayEntries = entriesByDay.get(dayKey) || [];
                                         const dayTotal = dayEntries.reduce((sum, e) => sum + (e.value || 0), 0);
+                                        const dayIsQuantity = resolveHabitTrackingForDay(habit, dayKey).goal.type === 'number';
 
                                         return (
                                             <button
                                                 key={dayKey}
                                                 onClick={() => handleDateClick(day)}
                                                 disabled={isFuture}
+                                                aria-label={`${format(day, 'EEEE, MMMM d, yyyy')}${hasEntries ? ', has entry' : ', no entry'}`}
                                                 className={cn(
                                                     "relative flex flex-col items-center justify-center py-1.5 rounded-lg text-xs transition-all",
                                                     !inMonth && "opacity-30",
@@ -260,7 +278,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                         "mt-0.5 text-[8px] font-bold leading-none",
                                                         isSelected ? "text-emerald-400" : "text-emerald-500"
                                                     )}>
-                                                        {isQuantity ? dayTotal : '●'}
+                                                        {dayIsQuantity ? dayTotal : '●'}
                                                     </span>
                                                 )}
                                             </button>
@@ -280,29 +298,32 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                             <h3 className="text-sm font-semibold text-neutral-200">
                                                 {format(new Date(selectedDate + 'T12:00:00'), 'EEEE, MMM d, yyyy')}
                                             </h3>
-                                            <button
-                                                onClick={() => { setShowNewEntry(true); setEditingId(null); }}
-                                                className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10 rounded-md transition-colors"
-                                            >
-                                                <Plus size={14} />
-                                                Add Entry
-                                            </button>
+                                            {selectedEntries.length === 0 && (
+                                                <button
+                                                    onClick={() => { setShowNewEntry(true); setEditingId(null); }}
+                                                    className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10 rounded-md transition-colors"
+                                                >
+                                                    <Plus size={14} />
+                                                    Add Entry
+                                                </button>
+                                            )}
                                         </div>
 
                                         {/* New Entry Form */}
                                         {showNewEntry && (
                                             <div className="flex items-center gap-2 mb-3 p-3 bg-emerald-500/5 border border-emerald-500/20 rounded-lg">
                                                 <input
-                                                    type="number"
-                                                    min="0"
-                                                    step="any"
+                                                    type="text"
+                                                    inputMode="decimal"
+                                                    pattern="[0-9]*\.?[0-9]*"
                                                     value={newEntryValue}
-                                                    onChange={e => setNewEntryValue(Number(e.target.value))}
+                                                    onChange={e => setNewEntryValue(e.target.value)}
                                                     className="w-20 px-2 py-1.5 text-sm bg-neutral-800 border border-white/10 rounded-md text-neutral-200 focus:outline-none focus:border-emerald-500/50"
                                                     autoFocus
+                                                    aria-label="New entry quantity"
                                                 />
-                                                {habit.goal?.unit && (
-                                                    <span className="text-xs text-neutral-500">{habit.goal.unit}</span>
+                                                {selectedUnit && (
+                                                    <span className="text-xs text-neutral-500">{selectedUnit}</span>
                                                 )}
                                                 <div className="ml-auto flex gap-2">
                                                     <button
@@ -332,16 +353,17 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                         {editingId === entry.id ? (
                                                             <div className="flex items-center gap-2 flex-1">
                                                                 <input
-                                                                    type="number"
-                                                                    min="0"
-                                                                    step="any"
+                                                                    type="text"
+                                                                    inputMode="decimal"
+                                                                    pattern="[0-9]*\.?[0-9]*"
                                                                     value={editValue}
-                                                                    onChange={e => setEditValue(Number(e.target.value))}
+                                                                    onChange={e => setEditValue(e.target.value)}
                                                                     className="w-20 px-2 py-1.5 text-sm bg-neutral-800 border border-white/10 rounded-md text-neutral-200 focus:outline-none focus:border-emerald-500/50"
                                                                     autoFocus
+                                                                    aria-label="Entry quantity"
                                                                 />
-                                                                {habit.goal?.unit && (
-                                                                    <span className="text-xs text-neutral-500">{habit.goal.unit}</span>
+                                                                {selectedUnit && (
+                                                                    <span className="text-xs text-neutral-500">{selectedUnit}</span>
                                                                 )}
                                                                 <div className="ml-auto flex gap-2">
                                                                     <button
@@ -366,8 +388,8 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                                         <span className="font-mono font-bold text-neutral-200 text-sm">
                                                                             {entry.value ?? '—'}
                                                                         </span>
-                                                                        {habit.goal?.unit && (
-                                                                            <span className="text-xs text-neutral-500">{habit.goal.unit}</span>
+                                                                        {selectedUnit && (
+                                                                            <span className="text-xs text-neutral-500">{selectedUnit}</span>
                                                                         )}
                                                                     </div>
                                                                     <div className="text-[10px] text-neutral-600 mt-0.5">
@@ -388,6 +410,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                                         onClick={() => handleStartEdit(entry)}
                                                                         className="p-1.5 rounded-md text-neutral-500 hover:text-neutral-300 hover:bg-white/5 transition-colors"
                                                                         title="Edit"
+                                                                        aria-label={`Edit entry for ${selectedDate}`}
                                                                     >
                                                                         <Pencil size={14} />
                                                                     </button>
@@ -395,6 +418,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                                         onClick={() => handleDelete(entry.id)}
                                                                         className="p-1.5 rounded-md text-neutral-500 hover:text-red-400 hover:bg-white/5 transition-colors"
                                                                         title="Delete"
+                                                                        aria-label={`Delete entry for ${selectedDate}`}
                                                                     >
                                                                         <Trash2 size={14} />
                                                                     </button>
@@ -420,6 +444,7 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                     const dayEntries = entriesByDay.get(dayKey) || [];
                                                     const total = dayEntries.reduce((sum, e) => sum + (e.value || 0), 0);
                                                     const count = dayEntries.length;
+                                                    const historicalGoal = resolveHabitTrackingForDay(habit, dayKey).goal;
                                                     return (
                                                         <button
                                                             key={dayKey}
@@ -430,10 +455,10 @@ export const HabitHistoryModal: React.FC<HabitHistoryModalProps> = ({ habitId, o
                                                                 {format(new Date(dayKey + 'T12:00:00'), 'EEE, MMM d, yyyy')}
                                                             </span>
                                                             <div className="flex items-center gap-2">
-                                                                {isQuantity && (
+                                                                {historicalGoal.type === 'number' && (
                                                                     <span className="font-mono text-sm font-bold text-neutral-200">
                                                                         {total}
-                                                                        {habit.goal?.unit && <span className="text-xs text-neutral-500 ml-0.5">{habit.goal.unit}</span>}
+                                                                        {historicalGoal.unit && <span className="text-xs text-neutral-500 ml-0.5">{historicalGoal.unit}</span>}
                                                                     </span>
                                                                 )}
                                                                 {count > 1 && (

--- a/src/components/NumericInputPopover.test.tsx
+++ b/src/components/NumericInputPopover.test.tsx
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { NumericInputPopover } from './NumericInputPopover';
+import { getSafeNumericPopoverPosition } from './numericPopoverPosition';
 
 const baseProps = {
     isOpen: true,
@@ -20,6 +21,14 @@ const baseProps = {
 };
 
 describe('NumericInputPopover', () => {
+    it.each([
+        ['right edge', { top: 200, left: 333 }, { top: 200, left: 190 }],
+        ['left edge', { top: 200, left: -20 }, { top: 200, left: 8 }],
+        ['bottom edge', { top: 820, left: 100 }, { top: 772, left: 100 }],
+    ])('clamps the popover at the %s of a mobile viewport', (_label, position, expected) => {
+        expect(getSafeNumericPopoverPosition(position, { width: 390, height: 844 })).toEqual(expected);
+    });
+
     it('displays the existing value when opened for an entry that has one', () => {
         render(<NumericInputPopover {...baseProps} initialValue={40} />);
         const input = screen.getByRole('textbox') as HTMLInputElement;
@@ -38,6 +47,23 @@ describe('NumericInputPopover', () => {
         const input = screen.getByRole('textbox') as HTMLInputElement;
         fireEvent.change(input, { target: { value: '7' } });
         expect(input.value).toBe('7');
+        expect(input).toHaveClass('min-w-0', 'flex-1');
+    });
+
+    it('uses the clamped mobile position when the trigger is near the right edge', () => {
+        const originalWidth = window.innerWidth;
+        const originalHeight = window.innerHeight;
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844 });
+
+        const { container } = render(
+            <NumericInputPopover {...baseProps} position={{ top: 200, left: 333 }} />,
+        );
+        const positionedContainer = container.firstElementChild as HTMLElement;
+        expect(positionedContainer.style.left).toBe('190px');
+
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight });
     });
 
     it('submits the typed numeric value', () => {

--- a/src/components/NumericInputPopover.test.tsx
+++ b/src/components/NumericInputPopover.test.tsx
@@ -85,6 +85,16 @@ describe('NumericInputPopover', () => {
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
+    it('does not partially parse malformed input', () => {
+        const onSubmit = vi.fn();
+        render(<NumericInputPopover {...baseProps} initialValue={0} onSubmit={onSubmit} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '12oops' } });
+        fireEvent.submit(input.closest('form')!);
+
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
     it('treats zero as clearing the entry instead of storing redundant progress', () => {
         const onSubmit = vi.fn();
         const onClear = vi.fn();

--- a/src/components/NumericInputPopover.tsx
+++ b/src/components/NumericInputPopover.tsx
@@ -52,7 +52,7 @@ const NumericInputPopoverContent: React.FC<NumericInputPopoverContentProps> = ({
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        const numValue = parseFloat(value);
+        const numValue = value.trim() === '' ? Number.NaN : Number(value);
         if (!Number.isFinite(numValue) || numValue < 0) return;
         if (numValue === 0 && onClear) {
             onClear();
@@ -111,6 +111,7 @@ const NumericInputPopoverContent: React.FC<NumericInputPopoverContentProps> = ({
                         }}
                         className="shrink-0 p-1.5 text-red-400 hover:bg-red-500/20 rounded-lg transition-colors"
                         title="Clear entry"
+                        aria-label="Clear entry"
                     >
                         <Trash2 size={14} />
                     </button>

--- a/src/components/NumericInputPopover.tsx
+++ b/src/components/NumericInputPopover.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Check, Trash2 } from 'lucide-react';
+import { getSafeNumericPopoverPosition } from './numericPopoverPosition';
 
 interface NumericInputPopoverProps {
     isOpen: boolean;
@@ -11,8 +12,9 @@ interface NumericInputPopoverProps {
     position: { top: number; left: number };
 }
 
-export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
-    isOpen,
+type NumericInputPopoverContentProps = Omit<NumericInputPopoverProps, 'isOpen'>;
+
+const NumericInputPopoverContent: React.FC<NumericInputPopoverContentProps> = ({
     onClose,
     onSubmit,
     onClear,
@@ -24,21 +26,16 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-        if (isOpen) {
-            // Existing values are shown for editing; new entries start blank so the
-            // placeholder ("0") shows and the first typed digit always appears.
-            setValue(initialValue > 0 ? initialValue.toString() : '');
-            // Double-rAF ensures DOM is painted before focus (more reliable than setTimeout on iOS).
-            // Selection is handled by the input's onFocus (below) rather than a delayed select()
-            // call here: on iOS a late, programmatic select() races with the on-screen keyboard
-            // and can swallow the user's first keystroke, leaving the field looking empty.
+        // Double-rAF ensures DOM is painted before focus (more reliable than setTimeout on iOS).
+        // Selection is handled by the input's onFocus (below) rather than a delayed select()
+        // call here: on iOS a late, programmatic select() races with the on-screen keyboard
+        // and can swallow the user's first keystroke, leaving the field looking empty.
+        requestAnimationFrame(() => {
             requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    inputRef.current?.focus();
-                });
+                inputRef.current?.focus();
             });
-        }
-    }, [isOpen, initialValue]);
+        });
+    }, []);
 
     // Handle Escape key
     useEffect(() => {
@@ -48,14 +45,10 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
             }
         };
 
-        if (isOpen) {
-            window.addEventListener('keydown', handleKeyDown);
-        }
+        window.addEventListener('keydown', handleKeyDown);
 
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [isOpen, onClose]);
-
-    if (!isOpen) return null;
+    }, [onClose]);
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -71,16 +64,23 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
     };
 
     const showClear = initialValue > 0 && onClear;
+    const visualViewport = window.visualViewport;
+    const safePosition = getSafeNumericPopoverPosition(position, {
+        width: visualViewport?.width ?? window.innerWidth,
+        height: visualViewport?.height ?? window.innerHeight,
+        offsetLeft: visualViewport?.offsetLeft,
+        offsetTop: visualViewport?.offsetTop,
+    });
 
     return (
         <div
             className="fixed z-50"
-            style={{ top: position.top, left: position.left }}
+            style={{ top: safePosition.top, left: safePosition.left }}
         >
             <div className="fixed inset-0" onClick={onClose} />
             <form
                 onSubmit={handleSubmit}
-                className="relative bg-neutral-800 border border-white/10 rounded-xl p-3 shadow-xl flex items-center gap-2 w-48 animate-in fade-in zoom-in-95 duration-200"
+                className="relative bg-neutral-800 border border-white/10 rounded-xl p-3 shadow-xl flex items-center gap-2 w-48 max-w-[calc(100vw-1rem)] animate-in fade-in zoom-in-95 duration-200"
             >
                 <input
                     ref={inputRef}
@@ -90,15 +90,15 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
                     value={value}
                     onChange={(e) => setValue(e.target.value)}
                     onFocus={(e) => e.currentTarget.select()}
-                    className="w-full bg-neutral-900 border border-white/10 rounded-lg px-3 py-1.5 text-white text-sm focus:outline-none focus:border-emerald-500"
+                    className="min-w-0 flex-1 bg-neutral-900 border border-white/10 rounded-lg px-3 py-1.5 text-white text-sm focus:outline-none focus:border-emerald-500"
                     placeholder="0"
                     aria-label={`Quantity${unit ? ` in ${unit}` : ''}`}
                 />
-                {unit && <span className="text-xs text-neutral-500 font-medium">{unit}</span>}
+                {unit && <span className="max-w-12 truncate shrink-0 text-xs text-neutral-500 font-medium">{unit}</span>}
                 <button
                     type="submit"
                     aria-label="Save quantity"
-                    className="p-1.5 bg-emerald-500 text-neutral-900 rounded-lg hover:bg-emerald-400 transition-colors"
+                    className="shrink-0 p-1.5 bg-emerald-500 text-neutral-900 rounded-lg hover:bg-emerald-400 transition-colors"
                 >
                     <Check size={14} strokeWidth={3} />
                 </button>
@@ -109,7 +109,7 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
                             onClear();
                             onClose();
                         }}
-                        className="p-1.5 text-red-400 hover:bg-red-500/20 rounded-lg transition-colors"
+                        className="shrink-0 p-1.5 text-red-400 hover:bg-red-500/20 rounded-lg transition-colors"
                         title="Clear entry"
                     >
                         <Trash2 size={14} />
@@ -118,4 +118,11 @@ export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({
             </form>
         </div>
     );
+};
+
+export const NumericInputPopover: React.FC<NumericInputPopoverProps> = ({ isOpen, ...props }) => {
+    if (!isOpen) return null;
+    // Mounting content only while open resets its draft value for every editing
+    // session without a state-setting effect that can race the mobile keyboard.
+    return <NumericInputPopoverContent {...props} />;
 };

--- a/src/components/RecentHeatmapGrid.test.tsx
+++ b/src/components/RecentHeatmapGrid.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DayLog, Habit } from '../types';
+import { RecentHeatmapGrid } from './RecentHeatmapGrid';
+
+vi.mock('../store/HabitContext', () => ({ useHabitStore: vi.fn() }));
+vi.mock('react-tooltip', () => ({ Tooltip: () => null }));
+
+import { useHabitStore } from '../store/HabitContext';
+
+describe('RecentHeatmapGrid', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 7, 2, 12, 0, 0));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('shows an actual backdated completion without filling adjacent days', () => {
+        const habit: Habit = {
+            id: 'habit-1',
+            categoryId: 'cat-1',
+            name: 'Rogain AM',
+            goal: { type: 'boolean', frequency: 'daily' },
+            archived: false,
+            createdAt: '2026-07-25T12:00:00.000Z',
+        };
+        const completion: DayLog = {
+            habitId: habit.id,
+            date: '2026-07-24',
+            value: 1,
+            completed: true,
+        };
+        vi.mocked(useHabitStore).mockReturnValue({
+            logs: { [`${habit.id}-${completion.date}`]: completion },
+        } as unknown as ReturnType<typeof useHabitStore>);
+
+        const { container } = render(<RecentHeatmapGrid habits={[habit]} range="30d" />);
+
+        expect(
+            container.querySelector('[data-tooltip-content="Jul 24, 2026: 1 completions across 1 categories"]'),
+        ).not.toBeNull();
+        expect(
+            container.querySelector('[data-tooltip-content="Jul 25, 2026: 0 completions across 0 categories"]'),
+        ).not.toBeNull();
+    });
+});

--- a/src/components/RecentHeatmapGrid.tsx
+++ b/src/components/RecentHeatmapGrid.tsx
@@ -1,13 +1,14 @@
 import React, { useMemo, useRef } from 'react';
 import { useHabitStore } from '../store/HabitContext';
 import { getHeatmapColor } from '../utils/analytics';
-import { getBundleChildIds, isHabitComplete } from '../utils/habitUtils';
+import { getBundleChildIds, isHabitCompleteOnDay } from '../utils/habitUtils';
 import { eachDayOfInterval, subDays, format, startOfDay } from 'date-fns';
 import { Tooltip } from 'react-tooltip';
 import { HeatmapLegend } from './HeatmapLegend';
+import type { Habit } from '../types';
 
 interface RecentHeatmapGridProps {
-    habits: any[];
+    habits: Habit[];
     range: '90d' | '30d';
 }
 
@@ -44,7 +45,7 @@ export const RecentHeatmapGrid: React.FC<RecentHeatmapGridProps> = React.memo(({
 
             if (activeHabits.length > 0) {
                 activeHabits.forEach(habit => {
-                    if (isHabitComplete(habit, logs, dateStr)) {
+                    if (isHabitCompleteOnDay(habit, logs, dateStr)) {
                         completionCount++;
                         categoryIds.add(habit.categoryId);
                     }

--- a/src/components/RecentHeatmapGrid.tsx
+++ b/src/components/RecentHeatmapGrid.tsx
@@ -38,7 +38,9 @@ export const RecentHeatmapGrid: React.FC<RecentHeatmapGridProps> = React.memo(({
 
         const processedDays = dateInterval.map(date => {
             const dateStr = format(date, 'yyyy-MM-dd');
-            const activeHabits = habits.filter(h => new Date(h.createdAt) <= date && !h.archived && !childIds.has(h.id));
+            // This is an activity view, so an actual completion is sufficient
+            // evidence even when it was backdated or occurred on creation day.
+            const activeHabits = habits.filter(h => !h.archived && !childIds.has(h.id));
 
             let completionCount = 0;
             const categoryIds = new Set<string>();

--- a/src/components/TrackerGrid.clearEntry.test.tsx
+++ b/src/components/TrackerGrid.clearEntry.test.tsx
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { format } from 'date-fns';
+import { format, subDays } from 'date-fns';
 import { TrackerGrid } from './TrackerGrid';
 import type { Habit, DayLog } from '../types';
 
@@ -96,7 +96,7 @@ describe('TrackerGrid clear entry', () => {
         expect(container.querySelector('button[aria-label^="Clear entry for"]')).toBeNull();
     });
 
-    it('clears an entry through the existing delete mode', async () => {
+    it('does not expose a global delete-mode trash control', async () => {
         const habitId = 'habit-1';
         const today = new Date();
         const dayKey = format(today, 'yyyy-MM-dd');
@@ -117,7 +117,7 @@ describe('TrackerGrid clear entry', () => {
             />
         );
 
-        fireEvent.click(screen.getByTitle('Enter Delete Mode (mobile-friendly)'));
+        expect(screen.queryByTitle('Enter Delete Mode (mobile-friendly)')).not.toBeInTheDocument();
         const cellButtons = Array.from(container.querySelectorAll('button')).filter(
             btn => btn.className.includes('rounded-lg') && !btn.className.includes('p-1.5') && btn.closest('.w-16')
         );
@@ -125,9 +125,9 @@ describe('TrackerGrid clear entry', () => {
         fireEvent.click(cellButtons[0]);
 
         await waitFor(() => {
-            expect(mockDeleteHabitEntryByKey).toHaveBeenCalledWith(habitId, dayKey);
+            expect(mockToggleHabit).toHaveBeenCalledWith(habitId, dayKey);
         });
-        await waitFor(() => expect(mockRefreshProgress).toHaveBeenCalled());
+        expect(mockDeleteHabitEntryByKey).not.toHaveBeenCalled();
     });
 
     it('should NOT delete when double-clicking a cell (double-click delete removed)', async () => {
@@ -162,7 +162,7 @@ describe('TrackerGrid clear entry', () => {
         expect(mockDeleteHabitEntryByKey).not.toHaveBeenCalled();
     });
 
-    it('uses a canonical dayKey (YYYY-MM-DD) when clearing in delete mode', async () => {
+    it('uses a canonical dayKey (YYYY-MM-DD) when toggling an existing entry', async () => {
         const habitId = 'habit-3';
         const today = new Date();
         const dayKey = format(today, 'yyyy-MM-dd');
@@ -183,18 +183,54 @@ describe('TrackerGrid clear entry', () => {
             />
         );
 
-        fireEvent.click(screen.getByTitle('Enter Delete Mode (mobile-friendly)'));
         const cellButtons = Array.from(container.querySelectorAll('button')).filter(
             btn => btn.className.includes('rounded-lg') && !btn.className.includes('p-1.5') && btn.closest('.w-16')
         );
         expect(cellButtons.length).toBeGreaterThan(0);
         fireEvent.click(cellButtons[0]);
 
-        await waitFor(() => expect(mockDeleteHabitEntryByKey).toHaveBeenCalled());
-        const [id, date] = mockDeleteHabitEntryByKey.mock.calls[0];
+        await waitFor(() => expect(mockToggleHabit).toHaveBeenCalled());
+        const [id, date] = mockToggleHabit.mock.calls[0];
         expect(id).toBe(habitId);
         expect(date).toBe(dayKey);
         expect(date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('renders an older entry with the goal type that applied on that day', () => {
+        const today = new Date();
+        const todayKey = format(today, 'yyyy-MM-dd');
+        const historicalDayKey = format(subDays(today, 1), 'yyyy-MM-dd');
+        const habit: Habit = {
+            ...createBooleanHabit('changed-habit', 'Changed habit'),
+            trackingRevisions: [
+                {
+                    effectiveFromDayKey: '2025-01-01',
+                    goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+                },
+                {
+                    effectiveFromDayKey: todayKey,
+                    goal: { type: 'boolean', frequency: 'daily' },
+                },
+            ],
+        };
+
+        const { container } = render(
+            <TrackerGrid
+                habits={[habit]}
+                logs={{
+                    [`${habit.id}-${historicalDayKey}`]: createDayLog(habit.id, historicalDayKey, false, 5),
+                }}
+                onAddHabit={() => {}}
+                onEditHabit={() => {}}
+                onViewHistory={() => {}}
+                onToggle={async () => {}}
+                onUpdateValue={async () => {}}
+            />
+        );
+
+        const historicalValueCell = Array.from(container.querySelectorAll('.w-16 button'))
+            .find(button => button.textContent === '5');
+        expect(historicalValueCell).toBeTruthy();
     });
 
     it('delegates checklist parent completion as one canonical bundle action', async () => {

--- a/src/components/TrackerGrid.clearEntry.test.tsx
+++ b/src/components/TrackerGrid.clearEntry.test.tsx
@@ -1,7 +1,4 @@
-/**
- * Tests for the explicit clear-entry control (touch and keyboard accessible).
- * Double-click delete has been removed; clear is only via the control or delete mode.
- */
+/** Clear-entry regression coverage for the All grid. */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -12,6 +9,10 @@ import type { Habit, DayLog } from '../types';
 vi.mock('../store/HabitContext', () => ({ useHabitStore: vi.fn() }));
 vi.mock('../store/RoutineContext', () => ({ useRoutineStore: vi.fn() }));
 vi.mock('../lib/useProgressOverview', () => ({ useProgressOverview: vi.fn() }));
+vi.mock('../lib/useGoalsWithProgress', () => ({ useGoalsWithProgress: vi.fn() }));
+vi.mock('../store/DashboardPrefsContext', () => ({
+    useDashboardPrefs: () => ({ hideStreaks: false }),
+}));
 vi.mock('./Toast', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('./NumericInputPopover', () => ({ NumericInputPopover: () => null }));
 vi.mock('./HabitHistoryModal', () => ({ HabitHistoryModal: () => null }));
@@ -20,8 +21,9 @@ vi.mock('./HabitLogModal', () => ({ HabitLogModal: () => null }));
 import { useHabitStore } from '../store/HabitContext';
 import { useRoutineStore } from '../store/RoutineContext';
 import { useProgressOverview } from '../lib/useProgressOverview';
+import { useGoalsWithProgress } from '../lib/useGoalsWithProgress';
 
-describe('TrackerGrid clear entry (explicit menu)', () => {
+describe('TrackerGrid clear entry', () => {
     const mockDeleteHabitEntryByKey = vi.fn().mockResolvedValue({ dayLog: null });
     const mockUpsertHabitEntry = vi.fn();
     const mockDeleteHabit = vi.fn();
@@ -47,18 +49,29 @@ describe('TrackerGrid clear entry (explicit menu)', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        (useHabitStore as any).mockReturnValue({
+        vi.mocked(useHabitStore).mockReturnValue({
             deleteHabit: mockDeleteHabit,
             reorderHabits: mockReorderHabits,
             upsertHabitEntry: mockUpsertHabitEntry,
             deleteHabitEntryByKey: mockDeleteHabitEntryByKey,
             toggleHabit: mockToggleHabit,
+        } as unknown as ReturnType<typeof useHabitStore>);
+        vi.mocked(useRoutineStore).mockReturnValue({ routines: [] } as unknown as ReturnType<typeof useRoutineStore>);
+        vi.mocked(useProgressOverview).mockReturnValue({
+            data: undefined,
+            loading: false,
+            error: undefined,
+            refresh: mockRefreshProgress,
         });
-        (useRoutineStore as any).mockReturnValue({ routines: [] });
-        (useProgressOverview as any).mockReturnValue({ data: null, refresh: mockRefreshProgress });
+        vi.mocked(useGoalsWithProgress).mockReturnValue({
+            data: [],
+            loading: false,
+            error: null,
+            refetch: vi.fn(),
+        });
     });
 
-    it('should render grid with habit row and no double-click delete on cells', () => {
+    it('does not overlay tiny trash controls on completed cells', () => {
         const habitId = 'habit-1';
         const today = new Date();
         const dayKey = format(today, 'yyyy-MM-dd');
@@ -80,10 +93,10 @@ describe('TrackerGrid clear entry (explicit menu)', () => {
         );
 
         expect(screen.getByText('Morning Meditation')).toBeInTheDocument();
-        expect(container.querySelector('button[title="Clear entry"]')).toBeTruthy();
+        expect(container.querySelector('button[aria-label^="Clear entry for"]')).toBeNull();
     });
 
-    it('should call deleteHabitEntryByKey when the Clear entry control is clicked', async () => {
+    it('clears an entry through the existing delete mode', async () => {
         const habitId = 'habit-1';
         const today = new Date();
         const dayKey = format(today, 'yyyy-MM-dd');
@@ -104,11 +117,12 @@ describe('TrackerGrid clear entry (explicit menu)', () => {
             />
         );
 
-        const clearButton = container.querySelector('button[title="Clear entry"]');
-        if (!clearButton) {
-            throw new Error('Clear entry control not found');
-        }
-        fireEvent.click(clearButton);
+        fireEvent.click(screen.getByTitle('Enter Delete Mode (mobile-friendly)'));
+        const cellButtons = Array.from(container.querySelectorAll('button')).filter(
+            btn => btn.className.includes('rounded-lg') && !btn.className.includes('p-1.5') && btn.closest('.w-16')
+        );
+        expect(cellButtons.length).toBeGreaterThan(0);
+        fireEvent.click(cellButtons[0]);
 
         await waitFor(() => {
             expect(mockDeleteHabitEntryByKey).toHaveBeenCalledWith(habitId, dayKey);
@@ -148,7 +162,7 @@ describe('TrackerGrid clear entry (explicit menu)', () => {
         expect(mockDeleteHabitEntryByKey).not.toHaveBeenCalled();
     });
 
-    it('should use canonical dayKey (YYYY-MM-DD) when clearing via menu', async () => {
+    it('uses a canonical dayKey (YYYY-MM-DD) when clearing in delete mode', async () => {
         const habitId = 'habit-3';
         const today = new Date();
         const dayKey = format(today, 'yyyy-MM-dd');
@@ -169,9 +183,12 @@ describe('TrackerGrid clear entry (explicit menu)', () => {
             />
         );
 
-        const clearButton = container.querySelector('button[title="Clear entry"]');
-        if (!clearButton) throw new Error('Clear entry control not found');
-        fireEvent.click(clearButton);
+        fireEvent.click(screen.getByTitle('Enter Delete Mode (mobile-friendly)'));
+        const cellButtons = Array.from(container.querySelectorAll('button')).filter(
+            btn => btn.className.includes('rounded-lg') && !btn.className.includes('p-1.5') && btn.closest('.w-16')
+        );
+        expect(cellButtons.length).toBeGreaterThan(0);
+        fireEvent.click(cellButtons[0]);
 
         await waitFor(() => expect(mockDeleteHabitEntryByKey).toHaveBeenCalled());
         const [id, date] = mockDeleteHabitEntryByKey.mock.calls[0];

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -16,6 +16,7 @@ import { useRoutineStore } from '../store/RoutineContext';
 import { useProgressOverview } from '../lib/useProgressOverview';
 import { useGoalsWithProgress } from '../lib/useGoalsWithProgress';
 import { useDashboardPrefs } from '../store/DashboardPrefsContext';
+import { resolveHabitTrackingForDay } from '../domain/habits/trackingHistory';
 
 
 
@@ -205,7 +206,6 @@ interface HabitRowContentProps {
     onViewHistory: (habit: Habit) => void;
     potentialEvidence?: HabitPotentialEvidence[];
     onContextMenu: (e: React.MouseEvent, habit: Habit) => void;
-    isDeleteMode: boolean;
     onMoveToCategory?: (habit: Habit) => void;
     onAddToBundle?: (habit: Habit) => void;
 
@@ -239,7 +239,6 @@ const HabitRowContent = ({
     onViewHistory,
     potentialEvidence,
     onContextMenu,
-    isDeleteMode,
     onMoveToCategory,
     onAddToBundle,
     onCellPointerDown,
@@ -348,6 +347,8 @@ const HabitRowContent = ({
             <div className="flex relative z-0">
                 {dates.map((date) => {
                     const dateStr = format(date, 'yyyy-MM-dd');
+                    const tracking = resolveHabitTrackingForDay(habit, dateStr);
+                    const isNumericForDay = tracking.goal.type === 'number';
 
                     // Logic:
                     // If bundle, current status is computed from children.
@@ -364,7 +365,7 @@ const HabitRowContent = ({
                         hasValue = value > 0;
                     } else {
                         isCompleted = log?.completed || false;
-                        hasValue = habit.goal.type === 'number' && typeof log?.value === 'number' && log.value > 0;
+                        hasValue = isNumericForDay && typeof log?.value === 'number' && log.value > 0;
                         value = log?.value || 0;
                     }
 
@@ -413,7 +414,6 @@ const HabitRowContent = ({
                                                     : "bg-neutral-800/50 text-transparent hover:bg-neutral-800 hover:text-neutral-600 border border-white/5 hover:border-white/10",
                                     !isInteractive && isCompleted && "opacity-80 cursor-default",
                                     !isInteractive && "cursor-default hover:bg-neutral-800/50 hover:text-transparent",
-                                    isDeleteMode && hasExistingEntry && "ring-1 ring-red-500/60"
                                 )}
                                 title={
                                     habit.type === 'bundle'
@@ -454,7 +454,7 @@ const HabitRowContent = ({
                                         </span>
                                     </>
                                 ) : (
-                                    habit.goal.type === 'number' && value > 0 ? (
+                                    isNumericForDay && value > 0 ? (
                                         <span className="text-xs font-bold">{value}</span>
                                     ) : (
                                         <Check size={20} strokeWidth={3} className={cn("transition-transform duration-200", isCompleted ? "scale-100" : isFrozen ? "scale-100 opacity-50" : "scale-50")} />
@@ -487,7 +487,6 @@ const SortableHabitRow = ({
     onViewHistory,
     potentialEvidence,
     onContextMenu,
-    isDeleteMode,
     onMoveToCategory,
     onAddToBundle,
     onCellPointerDown,
@@ -511,7 +510,6 @@ const SortableHabitRow = ({
     onViewHistory: (habit: Habit) => void;
     potentialEvidence?: HabitPotentialEvidence[];
     onContextMenu: (e: React.MouseEvent, habit: Habit) => void;
-    isDeleteMode: boolean;
     onMoveToCategory?: (habit: Habit) => void;
     onAddToBundle?: (habit: Habit) => void;
 
@@ -608,7 +606,6 @@ const SortableHabitRow = ({
                 onViewHistory={onViewHistory}
                 potentialEvidence={potentialEvidence}
                 onContextMenu={onContextMenu}
-                isDeleteMode={isDeleteMode}
                 onMoveToCategory={onMoveToCategory}
                 onAddToBundle={onAddToBundle}
                 onCellPointerDown={onCellPointerDown}
@@ -638,7 +635,6 @@ const SortableHabitRow = ({
                     onViewHistory={onViewHistory}
                     potentialEvidence={potentialEvidence}
                     onContextMenu={onContextMenu}
-                    isDeleteMode={isDeleteMode}
                     onCellPointerDown={onCellPointerDown}
                     onCellPointerUp={onCellPointerUp}
                     onCellPointerMove={onCellPointerMove}
@@ -745,7 +741,6 @@ export const TrackerGrid = ({
     });
 
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
-    const [deleteMode, setDeleteMode] = useState(false);
     // Pending confirmation for removing a habit that is linked to one or more
     // goals. Shown via the Remove Habit modal after the user clicks trash twice —
     // the modal surfaces affected goals and offers Archive (default) or Delete
@@ -978,12 +973,13 @@ export const TrackerGrid = ({
 
     const handleOpenPopover = (e: React.MouseEvent, habit: Habit, date: string, val: number) => {
         const position = getPopoverPosition(e);
+        const tracking = resolveHabitTrackingForDay(habit, date);
         setPopoverState({
             isOpen: true,
             habitId: habit.id,
             date: date,
             initialValue: val,
-            unit: habit.goal.unit,
+            unit: tracking.goal.unit,
             position,
         });
     };
@@ -993,6 +989,7 @@ export const TrackerGrid = ({
         const last = lastHandledCellRef.current;
         if (last && last.habitId === habit.id && last.dateStr === dateStr && now - last.t < 400) return;
         lastHandledCellRef.current = { habitId: habit.id, dateStr, t: now };
+        const tracking = resolveHabitTrackingForDay(habit, dateStr);
 
         // Handle Unified Choice Children (Real Habits)
         // Write entries on the CHILD habit, not the parent. Parent completion is derived.
@@ -1003,7 +1000,7 @@ export const TrackerGrid = ({
                 const isCompleted = !!childLog?.completed;
 
                 if (isCompleted) {
-                    if (habit.goal.type === 'number') {
+                    if (tracking.goal.type === 'number') {
                         handleOpenPopover(e, habit, dateStr, childLog?.value || 0);
                     } else {
                         // Toggle off: delete child entry
@@ -1025,7 +1022,7 @@ export const TrackerGrid = ({
             const currentOptionValue = parentLog?.completedOptions?.[habit.associatedOptionId];
             const isOptionCompleted = currentOptionValue !== undefined && currentOptionValue !== null;
 
-            if (habit.goal.type === 'boolean') {
+            if (tracking.goal.type === 'boolean') {
                 if (isOptionCompleted) {
                     await deleteHabitEntryByKey(habit.bundleParentId, dateStr);
                 } else {
@@ -1043,7 +1040,7 @@ export const TrackerGrid = ({
                     habitId: habit.bundleParentId,
                     date: dateStr,
                     initialValue: typeof currentOptionValue === 'number' ? currentOptionValue : 0,
-                    unit: habit.goal.unit,
+                    unit: tracking.goal.unit,
                     bundleOptionId: habit.associatedOptionId,
                     position,
                 });
@@ -1057,22 +1054,8 @@ export const TrackerGrid = ({
             return;
         }
 
-        // Standard habit: delete mode clears entry on click
-        const hasExistingEntry = !!log;
-        if (deleteMode) {
-            if (hasExistingEntry) {
-                try {
-                    await deleteHabitEntryByKey(habit.id, dateStr);
-                    debouncedRefreshProgress();
-                } catch (error) {
-                    console.error('Failed to delete habit entry in delete mode:', error);
-                }
-            }
-            return;
-        }
-
         // Single tap: toggle (boolean) or open popover (numeric). Clear entry is via cell kebab menu.
-        if (habit.goal.type === 'boolean') {
+        if (tracking.goal.type === 'boolean') {
             handleToggle(habit.id, dateStr);
         } else {
             const position = getPopoverPosition(e);
@@ -1081,7 +1064,7 @@ export const TrackerGrid = ({
                 habitId: habit.id,
                 date: dateStr,
                 initialValue: log?.value || 0,
-                unit: habit.goal.unit,
+                unit: tracking.goal.unit,
                 position,
             });
         }
@@ -1103,22 +1086,8 @@ export const TrackerGrid = ({
                         <div className="w-max min-w-full">
                             {/* Header */}
                             <div className="sticky top-0 z-30 flex border-b border-white/5 bg-neutral-900 shadow-md">
-                                <div className="w-64 flex-shrink-0 p-4 font-medium text-emerald-400 border-r border-white/5 flex items-center justify-between bg-neutral-900 sticky left-0 z-40 group after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10">
+                                <div className="w-64 flex-shrink-0 p-4 font-medium text-emerald-400 border-r border-white/5 flex items-center bg-neutral-900 sticky left-0 z-40 group after:pointer-events-none after:absolute after:right-[-1px] after:top-0 after:h-full after:w-px after:bg-white/10">
                                     <span>Daily Habits</span>
-                                    <div className="flex items-center gap-1">
-                                        <button
-                                            onClick={() => setDeleteMode(prev => !prev)}
-                                            className={cn(
-                                                "p-1.5 rounded-lg transition-colors",
-                                                deleteMode
-                                                    ? "bg-red-500/20 text-red-400"
-                                                    : "hover:bg-neutral-800 text-neutral-500 hover:text-red-400"
-                                            )}
-                                            title={deleteMode ? 'Exit Delete Mode' : 'Enter Delete Mode (mobile-friendly)'}
-                                        >
-                                            <Trash2 size={16} />
-                                        </button>
-                                    </div>
                                 </div>
                                 <div className="flex bg-neutral-900">
                                     {dates.map((date) => (
@@ -1142,11 +1111,6 @@ export const TrackerGrid = ({
                             </div>
 
                             {/* Daily Rows */}
-                            {deleteMode && (
-                                <div className="px-4 py-2 text-xs text-red-300 bg-red-500/10 border-b border-red-500/20">
-                                    Delete mode active: tap any filled cell to remove that day&apos;s entry.
-                                </div>
-                            )}
                             <div className="flex-col">
                                 {loading ? (
                                     <div className="flex items-center justify-center p-12 text-neutral-500 text-sm">Loading habits…</div>
@@ -1175,7 +1139,6 @@ export const TrackerGrid = ({
                                                 onViewHistory={(h) => setHistoryModalHabitId(h.id)}
                                                 potentialEvidence={potentialEvidence}
                                                 onContextMenu={handleContextMenu}
-                                                isDeleteMode={deleteMode}
                                                 onMoveToCategory={(h) => setCategoryPickerHabit(h)}
                                                 onAddToBundle={(h) => setBundlePickerHabit(h)}
                                                 onCellPointerDown={onCellPointerDown}

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -212,7 +212,6 @@ interface HabitRowContentProps {
     onCellPointerDown?: (habitId: string, dateStr: string, e: React.PointerEvent) => void;
     onCellPointerUp?: () => void;
     onCellPointerMove?: () => void;
-    onClearEntry?: (habitId: string, dateStr: string) => Promise<void>;
 }
 
 const HabitRowContent = ({
@@ -246,7 +245,6 @@ const HabitRowContent = ({
     onCellPointerDown,
     onCellPointerUp,
     onCellPointerMove,
-    onClearEntry,
 }: HabitRowContentProps) => {
 
     const { hideStreaks } = useDashboardPrefs();
@@ -463,20 +461,6 @@ const HabitRowContent = ({
                                     )
                                 )}
                             </button>
-                            {habit.type !== 'bundle' && hasExistingEntry && onClearEntry && (
-                                <button
-                                    type="button"
-                                    onClick={(event) => {
-                                        event.stopPropagation();
-                                        void onClearEntry(habit.id, dateStr);
-                                    }}
-                                    className="absolute top-0.5 right-0.5 z-10 w-4 h-4 rounded-full bg-neutral-950/90 text-neutral-400 hover:text-red-300 hover:bg-red-500/20 flex items-center justify-center border border-white/10"
-                                    title="Clear entry"
-                                    aria-label={`Clear entry for ${habit.name} on ${dateStr}`}
-                                >
-                                    <Trash2 size={9} aria-hidden="true" />
-                                </button>
-                            )}
                         </div>
                     );
                 })}
@@ -509,7 +493,6 @@ const SortableHabitRow = ({
     onCellPointerDown,
     onCellPointerUp,
     onCellPointerMove,
-    onClearEntry,
 }: {
     habit: Habit;
     allHabits: Habit[];
@@ -535,7 +518,6 @@ const SortableHabitRow = ({
     onCellPointerDown?: (habitId: string, dateStr: string, e: React.PointerEvent) => void;
     onCellPointerUp?: () => void;
     onCellPointerMove?: () => void;
-    onClearEntry?: (habitId: string, dateStr: string) => Promise<void>;
 }) => {
     const {
         attributes,
@@ -579,7 +561,7 @@ const SortableHabitRow = ({
                     },
                     archived: false,
                     createdAt: habit.createdAt,
-                    type: 'bundle-option-virtual' as any, // Only for internal distinction if needed
+                    type: metricMode === 'required' ? 'number' : 'boolean',
                     isVirtual: true,
                     associatedOptionId: opt.id,
                     bundleParentId: habit.id,
@@ -632,7 +614,6 @@ const SortableHabitRow = ({
                 onCellPointerDown={onCellPointerDown}
                 onCellPointerUp={onCellPointerUp}
                 onCellPointerMove={onCellPointerMove}
-                onClearEntry={onClearEntry}
             />
 
             {/* Child Rows - Rendered when expanded */}
@@ -661,7 +642,6 @@ const SortableHabitRow = ({
                     onCellPointerDown={onCellPointerDown}
                     onCellPointerUp={onCellPointerUp}
                     onCellPointerMove={onCellPointerMove}
-                    onClearEntry={onClearEntry}
                 />
             ))}
         </div>
@@ -1201,7 +1181,6 @@ export const TrackerGrid = ({
                                                 onCellPointerDown={onCellPointerDown}
                                                 onCellPointerUp={onCellPointerUp}
                                                 onCellPointerMove={onCellPointerMove}
-                                                onClearEntry={handleClearEntry}
                                             />
                                         ))}
                                     </SortableContext>
@@ -1270,12 +1249,10 @@ export const TrackerGrid = ({
                 onSubmit={async (val) => {
                     try {
                         const { habitId, date } = popoverState;
-                        // Use type assertion to access potential extra fields
-                        const state = popoverState as any;
-                        if (state.bundleOptionId) {
+                        if (popoverState.bundleOptionId) {
                             await upsertHabitEntry(habitId, date, {
                                 value: val,
-                                bundleOptionId: state.bundleOptionId
+                                bundleOptionId: popoverState.bundleOptionId
                             });
                         } else {
                             await upsertHabitEntry(habitId, date, { value: val });

--- a/src/components/YearHeatmapGrid.tsx
+++ b/src/components/YearHeatmapGrid.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useHabitStore } from '../store/HabitContext';
 import { getHeatmapColor } from '../utils/analytics';
-import { getBundleChildIds, isHabitComplete } from '../utils/habitUtils';
+import { getBundleChildIds, isHabitCompleteOnDay } from '../utils/habitUtils';
 import { eachDayOfInterval, subDays, format, getDay, startOfWeek, endOfWeek, isSameMonth } from 'date-fns';
 import { Tooltip } from 'react-tooltip';
 import { HeatmapLegend } from './HeatmapLegend';
+import type { Habit } from '../types';
 
 interface YearHeatmapGridProps {
-    habits: any[];
+    habits: Habit[];
 }
 
 export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ habits }) => {
@@ -47,7 +48,7 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
 
             if (activeHabits.length > 0) {
                 activeHabits.forEach(habit => {
-                    if (isHabitComplete(habit, logs, dateStr)) {
+                    if (isHabitCompleteOnDay(habit, logs, dateStr)) {
                         completionCount++;
                         categoryIds.add(habit.categoryId);
                     }

--- a/src/components/YearHeatmapGrid.tsx
+++ b/src/components/YearHeatmapGrid.tsx
@@ -41,7 +41,9 @@ export const YearHeatmapGrid: React.FC<YearHeatmapGridProps> = React.memo(({ hab
         let maxCount = 0;
         const processedDays = days.map(date => {
             const dateStr = format(date, 'yyyy-MM-dd');
-            const activeHabits = habits.filter(h => new Date(h.createdAt) <= date && !h.archived && !childIds.has(h.id));
+            // This is an activity view, so an actual completion is sufficient
+            // evidence even when it was backdated or occurred on creation day.
+            const activeHabits = habits.filter(h => !h.archived && !childIds.has(h.id));
 
             let completionCount = 0;
             const categoryIds = new Set<string>();

--- a/src/components/day-view/DayCategorySection.tsx
+++ b/src/components/day-view/DayCategorySection.tsx
@@ -4,6 +4,7 @@ import type { Category, Habit } from '../../types';
 import { HabitGridCell } from './HabitGridCell';
 import { NumericInputPopover } from '../NumericInputPopover';
 import { cn } from '../../utils/cn';
+import { resolveHabitTrackingForDay } from '../../domain/habits/trackingHistory';
 
 interface DayViewHabitStatus {
     habit: Habit;
@@ -30,7 +31,7 @@ interface DayCategorySectionProps {
     /** Whether HabitGridCells in this section show the trash/archive button. */
     showRemove?: boolean;
     allHabitsLookup: Map<string, Habit>;
-    onUpdateHabitEntry: (habitId: string, dateKey: string, data: any) => Promise<void>;
+    onUpdateHabitEntry: (habitId: string, dateKey: string, data: unknown) => Promise<void>;
     deleteHabitEntryByKey: (habitId: string, dateKey: string) => Promise<void>;
     dragHandleProps?: Record<string, unknown>;
 }
@@ -98,11 +99,12 @@ export const DayCategorySection = ({
     const handleNumericClick = (e: React.MouseEvent, habit: Habit) => {
         const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
         const status = habitStatusMap.get(habit.id);
+        const tracking = resolveHabitTrackingForDay(habit, dateStr);
         setPopover({
             isOpen: true,
             habitId: habit.id,
             initialValue: status?.currentValue ?? 0,
-            unit: habit.goal?.unit,
+            unit: tracking.goal.unit,
             position: { top: rect.bottom + 4, left: rect.left }
         });
     };
@@ -212,6 +214,7 @@ export const DayCategorySection = ({
                                 subHabitStatuses={subHabitStatuses}
                                 habitStatus={status}
                                 childStatusMap={habit.type === 'bundle' && habit.bundleType === 'choice' ? habitStatusMap : undefined}
+                                dayKey={dateStr}
                                 onSubHabitToggle={async (subHabitId) => {
                                     if (pendingMutation) return;
                                     setPendingMutation(true);
@@ -224,7 +227,10 @@ export const DayCategorySection = ({
                                 onChoiceSelect={async (optionKey, e) => {
                                     if (pendingMutation) return;
                                     const childHabit = allHabitsLookup.get(optionKey);
-                                    const isNumeric = childHabit?.goal?.type === 'number';
+                                    const childTracking = childHabit
+                                        ? resolveHabitTrackingForDay(childHabit, dateStr)
+                                        : null;
+                                    const isNumeric = childTracking?.goal.type === 'number';
 
                                     // Numeric children: open popover for quantity input
                                     if (isNumeric) {
@@ -234,7 +240,7 @@ export const DayCategorySection = ({
                                             isOpen: true,
                                             habitId: optionKey,
                                             initialValue: childStatus?.currentValue ?? 0,
-                                            unit: childHabit?.goal?.unit,
+                                            unit: childTracking?.goal.unit,
                                             position: { top: rect.bottom + 4, left: rect.left }
                                         });
                                         return;

--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -152,7 +152,7 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory }: DayViewProps
             if (existing) {
                 map.set(habit.id, { ...existing, isComplete });
             } else {
-                const completion = deriveDailyHabitCompletion(habit, []);
+                const completion = deriveDailyHabitCompletion(habit, [], dateStr);
                 map.set(habit.id, {
                     habit,
                     isComplete,

--- a/src/components/day-view/DayView.tsx
+++ b/src/components/day-view/DayView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
 import { useHabitStore } from '../../store/HabitContext';
 import { getTodayHabitStats } from '../../utils/habitUtils';
 import { evaluateChecklistSuccess } from '../../shared/checklistSuccessRule';
@@ -8,7 +8,6 @@ import { CategoryPickerModal } from '../CategoryPickerModal';
 import { BundlePickerModal } from '../BundlePickerModal';
 import { format } from 'date-fns';
 import { Plus } from 'lucide-react';
-import { fetchDayView, getLocalTimeZone } from '../../lib/persistenceClient';
 import { HealthSuggestionBanner } from '../HealthSuggestionBanner';
 import { deriveDailyHabitCompletion } from '../../domain/habits/completion';
 import { resolveLocalHabitStatuses, type DayViewHabitStatus } from './habitStatusResolution';
@@ -32,11 +31,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 
 import type { Habit } from '../../types';
-
-interface DayViewData {
-    dayKey: string;
-    habits: DayViewHabitStatus[];
-}
+import { useDayViewData } from './useDayViewData';
 
 interface SortableCategoryWrapperProps {
     id: string;
@@ -112,31 +107,11 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory }: DayViewProps
     const dateStr = format(today, 'yyyy-MM-dd');
     const displayDate = format(today, 'EEEE · MMM d');
 
-    // Day View state (from truthQuery)
-    const [dayViewData, setDayViewData] = useState<DayViewData | null>(null);
-    const [dayViewLoading, setDayViewLoading] = useState(true);
-    const [dayViewError, setDayViewError] = useState<string | null>(null);
+    // Day View state (from truthQuery). Refreshes keep existing UI mounted so
+    // entry mutations never bounce the user through a blocking loading screen.
+    const { dayViewData, dayViewLoading, dayViewError, refreshDayView } = useDayViewData(dateStr, habits);
     const [categoryPickerHabit, setCategoryPickerHabit] = useState<Habit | null>(null);
     const [bundlePickerHabit, setBundlePickerHabit] = useState<Habit | null>(null);
-
-    // Fetch day view from truthQuery endpoint
-    const loadDayView = useCallback(async () => {
-            setDayViewLoading(true);
-            setDayViewError(null);
-            try {
-                const data = await fetchDayView(dateStr, getLocalTimeZone());
-                setDayViewData(data);
-            } catch (err) {
-                console.error('Failed to load day view:', err);
-                setDayViewError(err instanceof Error ? err.message : 'Failed to load day view');
-            } finally {
-                setDayViewLoading(false);
-            }
-    }, [dateStr]);
-
-    useEffect(() => {
-        void loadDayView();
-    }, [loadDayView, habits]);
 
     // Create lookup map for habit statuses (from API)
     const habitStatusMap = useMemo(() => {
@@ -247,17 +222,17 @@ export const DayView = ({ onAddHabit, onEditHabit, onViewHistory }: DayViewProps
     // Handlers
     const handleToggle = async (habitId: string) => {
         await toggleHabit(habitId, dateStr);
-        await loadDayView();
+        await refreshDayView();
     };
 
     const handleUpsertHabitEntry = async (habitId: string, dayKey: string, data: unknown) => {
         await upsertHabitEntry(habitId, dayKey, data);
-        await loadDayView();
+        await refreshDayView();
     };
 
     const handleDeleteHabitEntry = async (habitId: string, dayKey: string) => {
         await deleteHabitEntryByKey(habitId, dayKey);
-        await loadDayView();
+        await refreshDayView();
     };
 
     const handlePin = async (habitId: string) => {

--- a/src/components/day-view/HabitGridCell.test.tsx
+++ b/src/components/day-view/HabitGridCell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { Habit } from '../../types';
 import { HabitGridCell } from './HabitGridCell';
@@ -58,5 +58,49 @@ describe('HabitGridCell numeric completion state', () => {
         expect(checkbox).toHaveAttribute('aria-checked', 'true');
         expect(within(checkbox).getByTestId('numeric-complete-check')).toBeInTheDocument();
         expect(screen.getByText('Read pages')).toHaveClass('line-through');
+    });
+
+    it('uses the goal type and unit that applied on the displayed historical day', () => {
+        const onToggle = vi.fn();
+        const onNumericClick = vi.fn();
+        const changedHabit: Habit = {
+            ...numericHabit,
+            goal: { type: 'boolean', frequency: 'daily' },
+            trackingRevisions: [
+                {
+                    effectiveFromDayKey: '2026-01-01',
+                    goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+                },
+                {
+                    effectiveFromDayKey: '2026-02-01',
+                    goal: { type: 'boolean', frequency: 'daily' },
+                },
+            ],
+        };
+
+        render(
+            <HabitGridCell
+                habit={changedHabit}
+                dayKey="2026-01-15"
+                isCompleted={false}
+                isExpanded={false}
+                onToggle={onToggle}
+                onExpand={vi.fn()}
+                onPin={vi.fn()}
+                onNumericClick={onNumericClick}
+                habitStatus={{
+                    habit: changedHabit,
+                    isComplete: false,
+                    currentValue: 5,
+                    targetValue: 10,
+                    progressPercent: 50,
+                }}
+            />,
+        );
+
+        const checkbox = screen.getByRole('checkbox', { name: /5 of 10 pages/i });
+        fireEvent.click(checkbox);
+        expect(onNumericClick).toHaveBeenCalledOnce();
+        expect(onToggle).not.toHaveBeenCalled();
     });
 });

--- a/src/components/day-view/HabitGridCell.tsx
+++ b/src/components/day-view/HabitGridCell.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/cn';
 import { useHabitStore } from '../../store/HabitContext';
 import { useGoalsWithProgress } from '../../lib/useGoalsWithProgress';
 import { DeleteHabitConfirmModal } from '../DeleteHabitConfirmModal';
+import { resolveHabitTrackingForDay } from '../../domain/habits/trackingHistory';
 
 interface DayViewHabitStatus {
     habit: Habit;
@@ -49,6 +50,8 @@ interface HabitGridCellProps {
     habitStatus?: DayViewHabitStatus;
     onNumericClick?: (e: React.MouseEvent) => void;
     childStatusMap?: Map<string, DayViewHabitStatus>;
+    /** Calendar day whose historical target, unit, and cadence should be displayed. */
+    dayKey?: string;
 }
 
 export const HabitGridCell = ({
@@ -71,7 +74,8 @@ export const HabitGridCell = ({
     habitStatus,
     onNumericClick,
     log,
-    childStatusMap
+    childStatusMap,
+    dayKey,
 }: HabitGridCellProps) => {
     const { archiveHabit, deleteHabit } = useHabitStore();
     const { data: goalsWithProgress } = useGoalsWithProgress();
@@ -96,7 +100,8 @@ export const HabitGridCell = ({
 
     const isChecklistBundle = habit.type === 'bundle' && habit.bundleType === 'checklist';
     const isChoiceBundle = habit.type === 'bundle' && habit.bundleType === 'choice';
-    const isQuantity = habit.goal?.type === 'number';
+    const tracking = resolveHabitTrackingForDay(habit, dayKey);
+    const isQuantity = tracking.goal.type === 'number';
     const hasSubHabits = subHabits && subHabits.length > 0;
 
     // Compute local checklist progress from sub-habit statuses
@@ -171,7 +176,7 @@ export const HabitGridCell = ({
                     onClick={handleCheckboxClick}
                     role="checkbox"
                     aria-checked={isCompleted}
-                    aria-label={`${habit.name}: ${habitStatus.currentValue} of ${habitStatus.targetValue}${habit.goal?.unit ? ` ${habit.goal.unit}` : ''}`}
+                    aria-label={`${habit.name}: ${habitStatus.currentValue} of ${habitStatus.targetValue}${tracking.goal.unit ? ` ${tracking.goal.unit}` : ''}`}
                     className={cn(
                         "flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center transition-all duration-300",
                         isCompleted
@@ -180,7 +185,7 @@ export const HabitGridCell = ({
                                 ? "bg-sky-500/10 border-sky-500 text-transparent"
                             : "border-white/20 text-transparent hover:border-emerald-500/50"
                     )}
-                    title={`${habitStatus.currentValue}${habit.goal?.unit ? ` ${habit.goal.unit}` : ''}`}
+                    title={`${habitStatus.currentValue}${tracking.goal.unit ? ` ${tracking.goal.unit}` : ''}`}
                 >
                     {isCompleted && <Check data-testid="numeric-complete-check" size={12} strokeWidth={3} />}
                 </button>
@@ -289,27 +294,31 @@ export const HabitGridCell = ({
 
             {isChoiceBundle && hasSubHabits && (
                 <div className="flex flex-wrap gap-1.5 px-3 pb-2.5 pt-0.5">
-                    {subHabits!.map(option => (
-                        <button
-                            key={option.id}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                onChoiceSelect?.(option.id, e);
-                            }}
-                            className={cn(
-                                "px-2 py-1 rounded text-[10px] font-medium border transition-all",
-                                selectedChoices?.has(option.id)
-                                    ? "bg-amber-500/20 text-amber-300 border-amber-500/50"
-                                    : "bg-neutral-800 text-neutral-400 border-white/5 hover:border-white/20 hover:text-white"
-                            )}
-                        >
-                            {option.name}
-                            {option.goal?.type === 'number' && childStatusMap?.get(option.id)?.currentValue
-                                ? ` (${childStatusMap.get(option.id)!.currentValue}${option.goal.unit ? ` ${option.goal.unit}` : ''})`
-                                : null}
-                            {option.linkedGoalId && <Trophy size={10} className="flex-shrink-0 text-amber-500" />}
-                        </button>
-                    ))}
+                    {subHabits!.map(option => {
+                        const optionGoal = resolveHabitTrackingForDay(option, dayKey).goal;
+                        const optionValue = childStatusMap?.get(option.id)?.currentValue;
+                        return (
+                            <button
+                                key={option.id}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onChoiceSelect?.(option.id, e);
+                                }}
+                                className={cn(
+                                    "px-2 py-1 rounded text-[10px] font-medium border transition-all",
+                                    selectedChoices?.has(option.id)
+                                        ? "bg-amber-500/20 text-amber-300 border-amber-500/50"
+                                        : "bg-neutral-800 text-neutral-400 border-white/5 hover:border-white/20 hover:text-white"
+                                )}
+                            >
+                                {option.name}
+                                {optionGoal.type === 'number' && optionValue
+                                    ? ` (${optionValue}${optionGoal.unit ? ` ${optionGoal.unit}` : ''})`
+                                    : null}
+                                {option.linkedGoalId && <Trophy size={10} className="flex-shrink-0 text-amber-500" />}
+                            </button>
+                        );
+                    })}
                 </div>
             )}
 
@@ -319,7 +328,7 @@ export const HabitGridCell = ({
                     <div className="h-px w-full bg-white/5 mb-1" />
 
                     {/* Habit Metadata */}
-                    {(habit.timeEstimate || habit.timesPerWeek || habit.nonNegotiable || (isQuantity && habitStatus) || habit.assignedDays) && (
+                    {(habit.timeEstimate || tracking.timesPerWeek || habit.nonNegotiable || (isQuantity && habitStatus) || tracking.assignedDays) && (
                         <div className="flex flex-wrap gap-2">
                             {habit.timeEstimate && (
                                 <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
@@ -330,13 +339,13 @@ export const HabitGridCell = ({
                             {isQuantity && habitStatus && (
                                 <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
                                     <Target size={10} />
-                                    {habitStatus.currentValue}/{habitStatus.targetValue} {habit.goal?.unit || ''}
+                                    {habitStatus.currentValue}/{habitStatus.targetValue} {tracking.goal.unit || ''}
                                 </span>
                             )}
-                            {habit.timesPerWeek != null && habit.timesPerWeek > 0 && (
+                            {tracking.timesPerWeek != null && tracking.timesPerWeek > 0 && (
                                 <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
                                     <Repeat size={10} />
-                                    {habit.timesPerWeek}x/week
+                                    {tracking.timesPerWeek}x/week
                                 </span>
                             )}
                             {habit.nonNegotiable && (
@@ -345,10 +354,10 @@ export const HabitGridCell = ({
                                     Non-negotiable
                                 </span>
                             )}
-                            {habit.assignedDays && habit.assignedDays.length > 0 && habit.assignedDays.length < 7 && (
+                            {tracking.assignedDays && tracking.assignedDays.length > 0 && tracking.assignedDays.length < 7 && (
                                 <span className="flex items-center gap-1 text-[10px] text-neutral-500 bg-white/5 px-2 py-0.5 rounded-full">
                                     <Calendar size={10} />
-                                    {habit.assignedDays.map(d => ['Su','Mo','Tu','We','Th','Fr','Sa'][d]).join(', ')}
+                                    {tracking.assignedDays.map(d => ['Su','Mo','Tu','We','Th','Fr','Sa'][d]).join(', ')}
                                 </span>
                             )}
                         </div>

--- a/src/components/day-view/ScheduleView.tsx
+++ b/src/components/day-view/ScheduleView.tsx
@@ -4,17 +4,12 @@ import { DayCategorySection } from './DayCategorySection';
 import { CategoryPickerModal } from '../CategoryPickerModal';
 import { format, startOfWeek, endOfWeek, addDays, subWeeks, addWeeks } from 'date-fns';
 import { Calendar, ChevronLeft, ChevronRight, ChevronDown, ChevronUp } from 'lucide-react';
-import { fetchDayView, getLocalTimeZone } from '../../lib/persistenceClient';
-import { useEffect } from 'react';
+import { getLocalTimeZone } from '../../lib/persistenceClient';
 
 import type { Habit } from '../../types';
 import { resolveLocalHabitStatuses, type DayViewHabitStatus } from './habitStatusResolution';
 import { isHabitScheduledOnDay } from '../../domain/habits/schedule';
-
-interface DayViewData {
-    dayKey: string;
-    habits: DayViewHabitStatus[];
-}
+import { useDayViewData } from './useDayViewData';
 
 export const ScheduleView = () => {
     const {
@@ -47,29 +42,9 @@ export const ScheduleView = () => {
     const selectedDate = weekDays[selectedDayIndex];
     const selectedDayKey = format(selectedDate, 'yyyy-MM-dd');
 
-    const [dayViewData, setDayViewData] = useState<DayViewData | null>(null);
-    const [dayViewLoading, setDayViewLoading] = useState(true);
-    const [dayViewError, setDayViewError] = useState<string | null>(null);
+    const { dayViewData, dayViewLoading, dayViewError, refreshDayView } = useDayViewData(selectedDayKey, habits);
     const [categoryPickerHabit, setCategoryPickerHabit] = useState<Habit | null>(null);
     const [showDailyHabits, setShowDailyHabits] = useState(false);
-
-    const loadDayView = useCallback(async () => {
-            setDayViewLoading(true);
-            setDayViewError(null);
-            try {
-                const data = await fetchDayView(selectedDayKey, getLocalTimeZone());
-                setDayViewData(data);
-            } catch (err) {
-                console.error('Failed to load day view:', err);
-                setDayViewError(err instanceof Error ? err.message : 'Failed to load day view');
-            } finally {
-                setDayViewLoading(false);
-            }
-    }, [selectedDayKey]);
-
-    useEffect(() => {
-        void loadDayView();
-    }, [loadDayView, habits]);
 
     const habitStatusMap = useMemo(() => {
         if (!dayViewData) return new Map<string, DayViewHabitStatus>();
@@ -138,7 +113,7 @@ export const ScheduleView = () => {
 
     // Group habits by category
     const UNCATEGORIZED_ID = '__uncategorized__';
-    const groupByCategory = (habitList: Habit[]) => {
+    const groupByCategory = useCallback((habitList: Habit[]) => {
         const groups = new Map<string, Habit[]>();
         categories.forEach(c => groups.set(c.id, []));
 
@@ -152,24 +127,24 @@ export const ScheduleView = () => {
             }
         });
         return groups;
-    };
+    }, [categories]);
 
-    const scheduledGrouped = useMemo(() => groupByCategory(scheduledHabits), [scheduledHabits, categories]);
-    const dailyGrouped = useMemo(() => groupByCategory(dailyHabits), [dailyHabits, categories]);
+    const scheduledGrouped = useMemo(() => groupByCategory(scheduledHabits), [scheduledHabits, groupByCategory]);
+    const dailyGrouped = useMemo(() => groupByCategory(dailyHabits), [dailyHabits, groupByCategory]);
 
     const handleToggle = async (habitId: string) => {
         await toggleHabit(habitId, selectedDayKey);
-        await loadDayView();
+        await refreshDayView();
     };
 
     const handleUpsertHabitEntry = async (habitId: string, dayKey: string, data: unknown) => {
         await upsertHabitEntry(habitId, dayKey, data);
-        await loadDayView();
+        await refreshDayView();
     };
 
     const handleDeleteHabitEntry = async (habitId: string, dayKey: string) => {
         await deleteHabitEntryByKey(habitId, dayKey);
-        await loadDayView();
+        await refreshDayView();
     };
 
     const handlePin = async (habitId: string) => {

--- a/src/components/day-view/ScheduleView.tsx
+++ b/src/components/day-view/ScheduleView.tsx
@@ -9,6 +9,7 @@ import { getLocalTimeZone } from '../../lib/persistenceClient';
 import type { Habit } from '../../types';
 import { resolveLocalHabitStatuses, type DayViewHabitStatus } from './habitStatusResolution';
 import { isHabitScheduledOnDay } from '../../domain/habits/schedule';
+import { resolveHabitTrackingForDay } from '../../domain/habits/trackingHistory';
 import { useDayViewData } from './useDayViewData';
 
 export const ScheduleView = () => {
@@ -72,8 +73,9 @@ export const ScheduleView = () => {
             if (childIds.has(h.id)) return;
             if (!isHabitScheduledOnDay(h, selectedDayKey, getLocalTimeZone())) return;
 
-            const hasAssignedDays = h.assignedDays && h.assignedDays.length > 0;
-            const hasTimesPerWeek = h.timesPerWeek != null && h.timesPerWeek > 0;
+            const tracking = resolveHabitTrackingForDay(h, selectedDayKey);
+            const hasAssignedDays = !!tracking.assignedDays?.length;
+            const hasTimesPerWeek = tracking.timesPerWeek != null && tracking.timesPerWeek > 0;
 
             // Habits with specific days or weekly quota are "scheduled"
             if (hasAssignedDays || hasTimesPerWeek) {

--- a/src/components/day-view/habitStatusResolution.test.ts
+++ b/src/components/day-view/habitStatusResolution.test.ts
@@ -54,4 +54,38 @@ describe('resolveLocalHabitStatuses', () => {
     expect(result.targetValue).toBe(10);
     expect(result.isComplete).toBe(false);
   });
+
+  it('keeps an optimistic historical entry on its historical target', () => {
+    const revisedHabit: Habit = {
+      ...numericHabit,
+      goal: { type: 'number', frequency: 'daily', target: 20, unit: 'pages' },
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-02-01',
+          goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+        },
+        {
+          effectiveFromDayKey: '2026-03-01',
+          goal: { type: 'number', frequency: 'daily', target: 20, unit: 'pages' },
+        },
+      ],
+    };
+
+    const result = resolveLocalHabitStatuses({
+      baseStatuses: new Map(),
+      habits: [revisedHabit],
+      logs: {
+        [`${numericHabit.id}-2026-02-18`]: {
+          habitId: numericHabit.id,
+          date: '2026-02-18',
+          value: 10,
+          completed: false,
+        },
+      },
+      dayKey: '2026-02-18',
+    }).get(numericHabit.id)!;
+
+    expect(result.targetValue).toBe(10);
+    expect(result.isComplete).toBe(true);
+  });
 });

--- a/src/components/day-view/habitStatusResolution.ts
+++ b/src/components/day-view/habitStatusResolution.ts
@@ -2,6 +2,7 @@ import type { DayLog, Habit } from '../../types';
 import { deriveDailyHabitCompletion } from '../../domain/habits/completion';
 import { getIsoWeekStartDayKey } from '../../domain/time/dayKey';
 import { deriveWeeklyHabitProgress, getIsoWeekEndDayKey } from '../../domain/habits/weeklyProgress';
+import { hasExplicitWeeklyQuotaOnDay } from '../../domain/habits/schedule';
 
 export interface DayViewHabitStatus {
   habit: Habit;
@@ -41,7 +42,7 @@ export function resolveLocalHabitStatuses({
     const existing = resolved.get(habit.id);
     const currentDayLog = logs[`${habit.id}-${dayKey}`];
 
-    if (habit.timesPerWeek != null && habit.timesPerWeek > 0) {
+    if (hasExplicitWeeklyQuotaOnDay(habit, dayKey)) {
       // Recompute only when the local cache has evidence for this week or the
       // server has not returned the newly-created habit yet.
       const weekStartDayKey = getIsoWeekStartDayKey(dayKey);
@@ -69,6 +70,7 @@ export function resolveLocalHabitStatuses({
       const completion = deriveDailyHabitCompletion(
         habit,
         currentDayLog ? [{ value: currentDayLog.value }] : [],
+        dayKey,
       );
       resolved.set(habit.id, {
         ...(existing ?? { habit }),

--- a/src/components/day-view/useDayViewData.test.tsx
+++ b/src/components/day-view/useDayViewData.test.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Habit } from '../../types';
+import { fetchDayView } from '../../lib/persistenceClient';
+import { useDayViewData } from './useDayViewData';
+
+vi.mock('../../lib/persistenceClient', () => ({
+    fetchDayView: vi.fn(),
+    getLocalTimeZone: () => 'America/New_York',
+}));
+
+const habits: Habit[] = [];
+const initialData = { dayKey: '2026-08-02', habits: [] };
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('useDayViewData', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('keeps existing day content visible during a mutation refresh', async () => {
+        vi.mocked(fetchDayView).mockResolvedValueOnce(initialData);
+        const { result } = renderHook(() => useDayViewData(initialData.dayKey, habits));
+
+        await waitFor(() => expect(result.current.dayViewData).toEqual(initialData));
+        expect(result.current.dayViewLoading).toBe(false);
+
+        const backgroundRequest = deferred<typeof initialData>();
+        vi.mocked(fetchDayView).mockReturnValueOnce(backgroundRequest.promise);
+
+        let refreshPromise!: Promise<void>;
+        act(() => {
+            refreshPromise = result.current.refreshDayView();
+        });
+
+        expect(result.current.dayViewLoading).toBe(false);
+        expect(result.current.dayViewData).toEqual(initialData);
+
+        await act(async () => {
+            backgroundRequest.resolve(initialData);
+            await refreshPromise;
+        });
+    });
+
+    it('uses a blocking state when navigating to a different day', async () => {
+        vi.mocked(fetchDayView).mockResolvedValueOnce(initialData);
+        const nextRequest = deferred<{ dayKey: string; habits: [] }>();
+        const { result, rerender } = renderHook(
+            ({ dayKey }) => useDayViewData(dayKey, habits),
+            { initialProps: { dayKey: initialData.dayKey } },
+        );
+        await waitFor(() => expect(result.current.dayViewData).toEqual(initialData));
+
+        vi.mocked(fetchDayView).mockReturnValueOnce(nextRequest.promise);
+        rerender({ dayKey: '2026-08-01' });
+
+        expect(result.current.dayViewLoading).toBe(true);
+        expect(result.current.dayViewData).toBeNull();
+
+        await act(async () => {
+            nextRequest.resolve({ dayKey: '2026-08-01', habits: [] });
+            await nextRequest.promise;
+        });
+        await waitFor(() => expect(result.current.dayViewLoading).toBe(false));
+    });
+
+    it('retains existing content when a background refresh fails', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.mocked(fetchDayView).mockResolvedValueOnce(initialData);
+        const { result } = renderHook(() => useDayViewData(initialData.dayKey, habits));
+        await waitFor(() => expect(result.current.dayViewData).toEqual(initialData));
+
+        vi.mocked(fetchDayView).mockRejectedValueOnce(new Error('offline'));
+        await act(async () => {
+            await result.current.refreshDayView();
+        });
+
+        expect(result.current.dayViewData).toEqual(initialData);
+        expect(result.current.dayViewLoading).toBe(false);
+        expect(result.current.dayViewError).toBeNull();
+        expect(consoleError).toHaveBeenCalledWith('Failed to load day view:', expect.any(Error));
+        consoleError.mockRestore();
+    });
+});

--- a/src/components/day-view/useDayViewData.ts
+++ b/src/components/day-view/useDayViewData.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchDayView, getLocalTimeZone } from '../../lib/persistenceClient';
+import type { Habit } from '../../types';
+import type { DayViewHabitStatus } from './habitStatusResolution';
+
+export interface DayViewData {
+    dayKey: string;
+    habits: DayViewHabitStatus[];
+}
+
+type DayViewRequestState = {
+    dayKey: string | null;
+    data: DayViewData | null;
+    loading: boolean;
+    error: string | null;
+};
+
+const INITIAL_STATE: DayViewRequestState = {
+    dayKey: null,
+    data: null,
+    loading: true,
+    error: null,
+};
+
+/**
+ * Loads canonical day-view data without replacing already rendered content
+ * with a blocking loading state during mutation refreshes.
+ */
+export function useDayViewData(dayKey: string, habits: readonly Habit[]) {
+    const [state, setState] = useState<DayViewRequestState>(INITIAL_STATE);
+    const stateRef = useRef(state);
+    const requestIdRef = useRef(0);
+
+    const updateState = useCallback((next: DayViewRequestState) => {
+        stateRef.current = next;
+        setState(next);
+    }, []);
+
+    const refresh = useCallback(async () => {
+        const requestId = ++requestIdRef.current;
+        const currentState = stateRef.current;
+        const hasCurrentData = currentState.dayKey === dayKey && currentState.data !== null;
+
+        try {
+            const data = await fetchDayView(dayKey, getLocalTimeZone()) as DayViewData;
+            if (requestId !== requestIdRef.current) return;
+            updateState({ dayKey, data, loading: false, error: null });
+        } catch (err) {
+            if (requestId !== requestIdRef.current) return;
+            console.error('Failed to load day view:', err);
+
+            // A background refresh failure must not hide valid, locally updated
+            // content. Initial/date-change failures still surface normally.
+            if (!hasCurrentData) {
+                updateState({
+                    dayKey,
+                    data: null,
+                    loading: false,
+                    error: err instanceof Error ? err.message : 'Failed to load day view',
+                });
+            }
+        }
+    }, [dayKey, updateState]);
+
+    useEffect(() => {
+        const timeoutId = window.setTimeout(() => {
+            void refresh();
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, [refresh, habits]);
+
+    useEffect(() => () => {
+        requestIdRef.current += 1;
+    }, []);
+
+    if (state.dayKey !== dayKey) {
+        return { dayViewData: null, dayViewLoading: true, dayViewError: null, refreshDayView: refresh };
+    }
+
+    return {
+        dayViewData: state.data,
+        dayViewLoading: state.loading,
+        dayViewError: state.error,
+        refreshDayView: refresh,
+    };
+}

--- a/src/components/numericPopoverPosition.ts
+++ b/src/components/numericPopoverPosition.ts
@@ -1,0 +1,28 @@
+export interface NumericPopoverViewport {
+    width: number;
+    height: number;
+    offsetLeft?: number;
+    offsetTop?: number;
+}
+
+const POPOVER_WIDTH = 192;
+const POPOVER_HEIGHT = 64;
+const VIEWPORT_GUTTER = 8;
+
+/** Keep the fixed quantity popover fully inside the visual viewport. */
+export function getSafeNumericPopoverPosition(
+    position: { top: number; left: number },
+    viewport: NumericPopoverViewport,
+): { top: number; left: number } {
+    const viewportLeft = viewport.offsetLeft ?? 0;
+    const viewportTop = viewport.offsetTop ?? 0;
+    const minLeft = viewportLeft + VIEWPORT_GUTTER;
+    const minTop = viewportTop + VIEWPORT_GUTTER;
+    const maxLeft = Math.max(minLeft, viewportLeft + viewport.width - POPOVER_WIDTH - VIEWPORT_GUTTER);
+    const maxTop = Math.max(minTop, viewportTop + viewport.height - POPOVER_HEIGHT - VIEWPORT_GUTTER);
+
+    return {
+        left: Math.min(Math.max(position.left, minLeft), maxLeft),
+        top: Math.min(Math.max(position.top, minTop), maxTop),
+    };
+}

--- a/src/domain/habits/completion.test.ts
+++ b/src/domain/habits/completion.test.ts
@@ -63,4 +63,23 @@ describe('deriveDailyHabitCompletion', () => {
     );
     expect(result).toMatchObject({ currentValue: 3, isComplete: false, isPartial: true });
   });
+
+  it('uses the target that was effective on the historical day', () => {
+    const config = {
+      goal: { type: 'number' as const, target: 20, frequency: 'daily' as const },
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-01-01',
+          goal: { type: 'number' as const, target: 10, frequency: 'daily' as const },
+        },
+        {
+          effectiveFromDayKey: '2026-08-01',
+          goal: { type: 'number' as const, target: 20, frequency: 'daily' as const },
+        },
+      ],
+    };
+
+    expect(deriveDailyHabitCompletion(config, [{ value: 10 }], '2026-07-31').isComplete).toBe(true);
+    expect(deriveDailyHabitCompletion(config, [{ value: 10 }], '2026-08-01').isComplete).toBe(false);
+  });
 });

--- a/src/domain/habits/completion.ts
+++ b/src/domain/habits/completion.ts
@@ -1,4 +1,6 @@
 import type { Habit } from '../../models/persistenceTypes';
+import type { HabitTrackingRevision } from '../../shared/habitTracking';
+import { resolveHabitTrackingForDay } from './trackingHistory';
 
 export interface CompletionEntry {
   value?: number | null;
@@ -13,20 +15,22 @@ export interface HabitCompletionState {
   progressPercent: number;
 }
 
-type HabitWithGoal = Pick<Habit, 'goal'>;
+type HabitWithGoal = Pick<Habit, 'goal'> & { trackingRevisions?: HabitTrackingRevision[] };
 
 /** A numeric habit cannot have a meaningful completion state without a positive target. */
-export function hasValidNumericTarget(habit: HabitWithGoal): boolean {
-  return habit.goal.type === 'number'
-    && typeof habit.goal.target === 'number'
-    && Number.isFinite(habit.goal.target)
-    && habit.goal.target > 0;
+export function hasValidNumericTarget(habit: HabitWithGoal, dayKey?: string): boolean {
+  const { goal } = resolveHabitTrackingForDay(habit, dayKey);
+  return goal.type === 'number'
+    && typeof goal.target === 'number'
+    && Number.isFinite(goal.target)
+    && goal.target > 0;
 }
 
 /** Value used when an interaction explicitly means "complete this habit". */
-export function getCompletionEntryValue(habit: HabitWithGoal): number | null {
-  if (habit.goal.type === 'boolean') return 1;
-  return hasValidNumericTarget(habit) ? habit.goal.target! : null;
+export function getCompletionEntryValue(habit: HabitWithGoal, dayKey?: string): number | null {
+  const { goal } = resolveHabitTrackingForDay(habit, dayKey);
+  if (goal.type === 'boolean') return 1;
+  return hasValidNumericTarget(habit, dayKey) ? goal.target! : null;
 }
 
 function sumNonNegativeFiniteValues(entries: readonly CompletionEntry[]): number {
@@ -49,8 +53,11 @@ function sumNonNegativeFiniteValues(entries: readonly CompletionEntry[]): number
 export function deriveDailyHabitCompletion(
   habit: HabitWithGoal,
   entries: readonly CompletionEntry[],
+  dayKey?: string,
 ): HabitCompletionState {
-  if (habit.goal.type === 'boolean') {
+  const { goal } = resolveHabitTrackingForDay(habit, dayKey);
+
+  if (goal.type === 'boolean') {
     const isComplete = entries.length > 0;
     return {
       currentValue: isComplete ? 1 : 0,
@@ -63,7 +70,7 @@ export function deriveDailyHabitCompletion(
   }
 
   const currentValue = sumNonNegativeFiniteValues(entries);
-  const targetValue = hasValidNumericTarget(habit) ? habit.goal.target! : 0;
+  const targetValue = hasValidNumericTarget(habit, dayKey) ? goal.target! : 0;
   const isComplete = targetValue > 0 && currentValue >= targetValue;
   const hasProgress = currentValue > 0;
 

--- a/src/domain/habits/schedule.ts
+++ b/src/domain/habits/schedule.ts
@@ -6,6 +6,8 @@ import {
   getIsoWeekStartDayKey,
   isValidDayKey,
 } from '../time/dayKey';
+import type { HabitInactivePeriod, HabitTrackingGoal, HabitTrackingRevision } from '../../shared/habitTracking';
+import { isHabitInactiveOnDay, resolveHabitTrackingForDay } from './trackingHistory';
 
 export interface SchedulableHabit {
   archived?: boolean;
@@ -15,6 +17,9 @@ export interface SchedulableHabit {
   timesPerWeek?: number;
   assignedDays?: number[];
   requiredDaysPerWeek?: number;
+  goal: HabitTrackingGoal;
+  trackingRevisions?: HabitTrackingRevision[];
+  inactivePeriods?: HabitInactivePeriod[];
 }
 
 /**
@@ -23,14 +28,41 @@ export interface SchedulableHabit {
  * streak is expressed in completed scheduled days rather than collapsing a
  * long daily run into a single week.
  */
-export function usesWeeklyQuotaStreak(habit: SchedulableHabit): boolean {
-  if (habit.timesPerWeek != null && habit.timesPerWeek > 0) return true;
+export function usesWeeklyQuotaStreak(habit: SchedulableHabit, dayKey?: string): boolean {
+  const tracking = resolveHabitTrackingForDay(habit, dayKey);
+  if (tracking.timesPerWeek != null && tracking.timesPerWeek > 0) return true;
 
   return !!(
-    habit.assignedDays?.length
-    && habit.requiredDaysPerWeek != null
-    && habit.requiredDaysPerWeek < habit.assignedDays.length
+    tracking.assignedDays?.length
+    && tracking.requiredDaysPerWeek != null
+    && tracking.requiredDaysPerWeek < tracking.assignedDays.length
   );
+}
+
+export function getWeeklyQuotaTargetOnDay(
+  habit: SchedulableHabit,
+  dayKey: string,
+): number | null {
+  const tracking = resolveHabitTrackingForDay(habit, dayKey);
+  if (tracking.timesPerWeek != null && tracking.timesPerWeek > 0) {
+    return tracking.timesPerWeek;
+  }
+  if (
+    tracking.assignedDays?.length
+    && tracking.requiredDaysPerWeek != null
+    && tracking.requiredDaysPerWeek < tracking.assignedDays.length
+  ) {
+    return tracking.requiredDaysPerWeek;
+  }
+  return null;
+}
+
+export function hasExplicitWeeklyQuotaOnDay(
+  habit: SchedulableHabit,
+  dayKey: string,
+): boolean {
+  const tracking = resolveHabitTrackingForDay(habit, dayKey);
+  return tracking.timesPerWeek != null && tracking.timesPerWeek > 0;
 }
 
 export function getHabitCreatedDayKey(habit: SchedulableHabit, timeZone?: string): string | null {
@@ -53,6 +85,19 @@ export function isTrackableHabit(habit: SchedulableHabit): boolean {
   return !habit.archived && !habit.deletedAt && habit.type !== 'bundle';
 }
 
+/** Match schedule rules without applying the habit document creation boundary. */
+export function matchesHabitScheduleOnDay(
+  habit: SchedulableHabit,
+  dayKey: string,
+): boolean {
+  if (isHabitInactiveOnDay(habit, dayKey)) return false;
+
+  const tracking = resolveHabitTrackingForDay(habit, dayKey);
+  const dayOfWeek = getDayOfWeekForDayKey(dayKey);
+  if (tracking.assignedDays?.length) return tracking.assignedDays.includes(dayOfWeek);
+  return true;
+}
+
 export function isHabitScheduledOnDay(
   habit: SchedulableHabit,
   dayKey: string,
@@ -60,10 +105,7 @@ export function isHabitScheduledOnDay(
 ): boolean {
   const createdDayKey = getHabitCreatedDayKey(habit, timeZone);
   if (createdDayKey && dayKey < createdDayKey) return false;
-
-  const dayOfWeek = getDayOfWeekForDayKey(dayKey);
-  if (habit.assignedDays?.length) return habit.assignedDays.includes(dayOfWeek);
-  return true;
+  return matchesHabitScheduleOnDay(habit, dayKey);
 }
 
 export function getScheduledHabitsForDay<T extends SchedulableHabit>(
@@ -88,22 +130,17 @@ export function getExpectedOpportunitiesInRange(
 
   if (totalDays <= 0) return 0;
 
-  if (habit.timesPerWeek != null && habit.timesPerWeek > 0 && !habit.assignedDays?.length) {
-    const weeks = new Set<string>();
-    for (let offset = 0; offset < totalDays; offset++) {
-      weeks.add(getIsoWeekStartDayKey(addDaysToDayKey(effectiveStartDayKey, offset)));
+  const quotaWeeks = new Set<string>();
+  let dailyOpportunities = 0;
+  for (let offset = 0; offset < totalDays; offset++) {
+    const dayKey = addDaysToDayKey(effectiveStartDayKey, offset);
+    if (!isHabitScheduledOnDay(habit, dayKey, timeZone)) continue;
+    const tracking = resolveHabitTrackingForDay(habit, dayKey);
+    if (tracking.timesPerWeek != null && tracking.timesPerWeek > 0 && !tracking.assignedDays?.length) {
+      quotaWeeks.add(getIsoWeekStartDayKey(dayKey));
+    } else {
+      dailyOpportunities += 1;
     }
-    return weeks.size;
   }
-
-  if (habit.assignedDays?.length) {
-    let count = 0;
-    for (let offset = 0; offset < totalDays; offset++) {
-      const dayOfWeek = getDayOfWeekForDayKey(addDaysToDayKey(effectiveStartDayKey, offset));
-      if (habit.assignedDays.includes(dayOfWeek)) count++;
-    }
-    return count;
-  }
-
-  return totalDays;
+  return dailyOpportunities + quotaWeeks.size;
 }

--- a/src/domain/habits/schedule.ts
+++ b/src/domain/habits/schedule.ts
@@ -14,6 +14,23 @@ export interface SchedulableHabit {
   createdAt?: string;
   timesPerWeek?: number;
   assignedDays?: number[];
+  requiredDaysPerWeek?: number;
+}
+
+/**
+ * Flexible weekly quotas are measured in completed weeks. A strict schedule
+ * (every assigned day is required) remains an occurrence-based habit, so its
+ * streak is expressed in completed scheduled days rather than collapsing a
+ * long daily run into a single week.
+ */
+export function usesWeeklyQuotaStreak(habit: SchedulableHabit): boolean {
+  if (habit.timesPerWeek != null && habit.timesPerWeek > 0) return true;
+
+  return !!(
+    habit.assignedDays?.length
+    && habit.requiredDaysPerWeek != null
+    && habit.requiredDaysPerWeek < habit.assignedDays.length
+  );
 }
 
 export function getHabitCreatedDayKey(habit: SchedulableHabit, timeZone?: string): string | null {

--- a/src/domain/habits/trackingHistory.test.ts
+++ b/src/domain/habits/trackingHistory.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isHabitInactiveOnDay,
+  recordHabitTrackingRevision,
+  resolveHabitTrackingForDay,
+  trackingRulesEqual,
+  type HabitTrackingFields,
+} from './trackingHistory';
+
+function tracking(overrides: Partial<HabitTrackingFields> = {}): HabitTrackingFields {
+  return {
+    goal: { type: 'number', target: 10, unit: 'pages', frequency: 'daily' },
+    assignedDays: [1, 3, 5],
+    requiredDaysPerWeek: 3,
+    ...overrides,
+  };
+}
+
+describe('habit tracking history', () => {
+  it('falls back to the current rule when no revisions exist', () => {
+    expect(resolveHabitTrackingForDay(tracking(), '2026-07-01')).toMatchObject({
+      goal: { target: 10 },
+      assignedDays: [1, 3, 5],
+    });
+  });
+
+  it('resolves historical target and schedule rules without changing entries', () => {
+    const habit = tracking({
+      goal: { type: 'number', target: 20, unit: 'pages', frequency: 'daily' },
+      assignedDays: [1, 2, 3, 4, 5],
+      requiredDaysPerWeek: 5,
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-01-01',
+          goal: { type: 'number', target: 10, unit: 'pages', frequency: 'daily' },
+          assignedDays: [1, 3, 5],
+          requiredDaysPerWeek: 3,
+        },
+        {
+          effectiveFromDayKey: '2026-08-01',
+          goal: { type: 'number', target: 20, unit: 'pages', frequency: 'daily' },
+          assignedDays: [1, 2, 3, 4, 5],
+          requiredDaysPerWeek: 5,
+        },
+      ],
+    });
+
+    expect(resolveHabitTrackingForDay(habit, '2026-07-31')).toMatchObject({
+      goal: { target: 10 },
+      assignedDays: [1, 3, 5],
+    });
+    expect(resolveHabitTrackingForDay(habit, '2026-08-01')).toMatchObject({
+      goal: { target: 20 },
+      assignedDays: [1, 2, 3, 4, 5],
+    });
+  });
+
+  it('records one baseline and replaces repeated same-day edits', () => {
+    const original = tracking();
+    const firstEdit = tracking({ goal: { type: 'number', target: 15, unit: 'pages', frequency: 'daily' } });
+    const first = recordHabitTrackingRevision(original, firstEdit, '2026-08-02', '2026-01-01');
+    const secondEdit = tracking({
+      goal: { type: 'number', target: 20, unit: 'pages', frequency: 'daily' },
+      trackingRevisions: first,
+    });
+    const second = recordHabitTrackingRevision(
+      { ...firstEdit, trackingRevisions: first },
+      secondEdit,
+      '2026-08-02',
+      '2026-01-01',
+    );
+
+    expect(second).toHaveLength(2);
+    expect(second[0].goal.target).toBe(10);
+    expect(second[1].goal.target).toBe(20);
+  });
+
+  it('normalizes schedules before comparing rules', () => {
+    expect(trackingRulesEqual(
+      tracking({ assignedDays: [5, 1, 3] }),
+      tracking({ assignedDays: [1, 3, 5] }),
+    )).toBe(true);
+  });
+
+  it('compares goal values independently of object property insertion order', () => {
+    expect(trackingRulesEqual(
+      tracking(),
+      tracking({
+        goal: { frequency: 'daily', unit: 'pages', target: 10, type: 'number' },
+      }),
+    )).toBe(true);
+  });
+
+  it('treats only inclusive inactive intervals as paused days', () => {
+    const habit = {
+      inactivePeriods: [{ startDayKey: '2026-07-10', endDayKey: '2026-07-12' }],
+    };
+    expect(isHabitInactiveOnDay(habit, '2026-07-09')).toBe(false);
+    expect(isHabitInactiveOnDay(habit, '2026-07-10')).toBe(true);
+    expect(isHabitInactiveOnDay(habit, '2026-07-12')).toBe(true);
+    expect(isHabitInactiveOnDay(habit, '2026-07-13')).toBe(false);
+  });
+});

--- a/src/domain/habits/trackingHistory.ts
+++ b/src/domain/habits/trackingHistory.ts
@@ -1,0 +1,151 @@
+import type {
+  HabitInactivePeriod,
+  HabitTrackingGoal,
+  HabitTrackingRevision,
+} from '../../shared/habitTracking';
+import { isValidDayKey } from '../time/dayKey';
+
+export interface HabitTrackingFields {
+  goal: HabitTrackingGoal;
+  assignedDays?: number[] | null;
+  timesPerWeek?: number | null;
+  requiredDaysPerWeek?: number | null;
+  trackingRevisions?: HabitTrackingRevision[];
+  inactivePeriods?: HabitInactivePeriod[];
+}
+
+export type ResolvedHabitTracking = Omit<HabitTrackingRevision, 'effectiveFromDayKey'>;
+
+function optionalPositiveInteger(value: number | null | undefined): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function normalizeAssignedDays(days: number[] | null | undefined): number[] | undefined {
+  if (!Array.isArray(days) || days.length === 0) return undefined;
+  return [...new Set(days)].sort((a, b) => a - b);
+}
+
+function normalizeGoal(goal: HabitTrackingGoal): HabitTrackingGoal {
+  return {
+    type: goal.type,
+    frequency: goal.frequency,
+    ...(typeof goal.target === 'number' ? { target: goal.target } : {}),
+    ...(typeof goal.unit === 'string' && goal.unit.length > 0 ? { unit: goal.unit } : {}),
+  };
+}
+
+/** Capture only the fields that can change completion or scheduled opportunities. */
+export function snapshotHabitTracking(habit: HabitTrackingFields): ResolvedHabitTracking {
+  const assignedDays = normalizeAssignedDays(habit.assignedDays);
+  const timesPerWeek = optionalPositiveInteger(habit.timesPerWeek);
+  const requiredDaysPerWeek = optionalPositiveInteger(habit.requiredDaysPerWeek);
+  return {
+    goal: normalizeGoal(habit.goal),
+    ...(assignedDays ? { assignedDays } : {}),
+    ...(timesPerWeek !== undefined ? { timesPerWeek } : {}),
+    ...(requiredDaysPerWeek !== undefined ? { requiredDaysPerWeek } : {}),
+  };
+}
+
+function normalizeRevision(revision: HabitTrackingRevision): HabitTrackingRevision {
+  return {
+    effectiveFromDayKey: revision.effectiveFromDayKey,
+    ...snapshotHabitTracking(revision),
+  };
+}
+
+function validSortedRevisions(habit: HabitTrackingFields): HabitTrackingRevision[] {
+  return (habit.trackingRevisions ?? [])
+    .filter(revision => isValidDayKey(revision.effectiveFromDayKey))
+    .map(normalizeRevision)
+    .sort((a, b) => a.effectiveFromDayKey.localeCompare(b.effectiveFromDayKey));
+}
+
+/** Resolve the target and schedule that governed one historical DayKey. */
+export function resolveHabitTrackingForDay(
+  habit: HabitTrackingFields,
+  dayKey?: string,
+): ResolvedHabitTracking {
+  if (!dayKey || !isValidDayKey(dayKey)) return snapshotHabitTracking(habit);
+
+  const revisions = validSortedRevisions(habit);
+  if (revisions.length === 0) return snapshotHabitTracking(habit);
+
+  let selected = revisions[0];
+  for (const revision of revisions) {
+    if (revision.effectiveFromDayKey > dayKey) break;
+    selected = revision;
+  }
+
+  const { effectiveFromDayKey: _, ...tracking } = selected;
+  return tracking;
+}
+
+function trackingSignature(tracking: ResolvedHabitTracking): string {
+  return JSON.stringify({
+    goal: tracking.goal,
+    assignedDays: tracking.assignedDays ?? null,
+    timesPerWeek: tracking.timesPerWeek ?? null,
+    requiredDaysPerWeek: tracking.requiredDaysPerWeek ?? null,
+  });
+}
+
+export function trackingRulesEqual(
+  left: HabitTrackingFields,
+  right: HabitTrackingFields,
+): boolean {
+  return trackingSignature(snapshotHabitTracking(left)) === trackingSignature(snapshotHabitTracking(right));
+}
+
+/**
+ * Add a baseline plus a new effective revision, replacing an edit made again
+ * on the same DayKey. Existing HabitEntry documents are never touched.
+ */
+export function recordHabitTrackingRevision(
+  existingHabit: HabitTrackingFields,
+  updatedHabit: HabitTrackingFields,
+  effectiveFromDayKey: string,
+  baselineDayKey: string,
+): HabitTrackingRevision[] {
+  if (!isValidDayKey(effectiveFromDayKey) || !isValidDayKey(baselineDayKey)) {
+    throw new Error('Tracking revisions require valid DayKeys');
+  }
+
+  const revisions = validSortedRevisions(existingHabit);
+  if (revisions.length === 0) {
+    revisions.push({
+      effectiveFromDayKey: baselineDayKey,
+      ...snapshotHabitTracking(existingHabit),
+    });
+  }
+
+  const nextRevision: HabitTrackingRevision = {
+    effectiveFromDayKey,
+    ...snapshotHabitTracking(updatedHabit),
+  };
+  const withoutSameDay = revisions.filter(
+    revision => revision.effectiveFromDayKey !== effectiveFromDayKey,
+  );
+  withoutSameDay.push(nextRevision);
+  withoutSameDay.sort((a, b) => a.effectiveFromDayKey.localeCompare(b.effectiveFromDayKey));
+
+  // A habit created and edited on the same day needs only the final rule.
+  return withoutSameDay.filter((revision, index, all) => (
+    index === 0
+    || trackingSignature(revision) !== trackingSignature(all[index - 1])
+  ));
+}
+
+export function isHabitInactiveOnDay(
+  habit: Pick<HabitTrackingFields, 'inactivePeriods'>,
+  dayKey: string,
+): boolean {
+  if (!isValidDayKey(dayKey)) return false;
+  return (habit.inactivePeriods ?? []).some(period => (
+    isValidDayKey(period.startDayKey)
+    && period.startDayKey <= dayKey
+    && (!period.endDayKey || (isValidDayKey(period.endDayKey) && dayKey <= period.endDayKey))
+  ));
+}

--- a/src/domain/habits/weeklyProgress.ts
+++ b/src/domain/habits/weeklyProgress.ts
@@ -1,6 +1,8 @@
 import type { Habit } from '../../models/persistenceTypes';
-import { addDaysToDayKey, getDayOfWeekForDayKey, type DayKey } from '../time/dayKey';
+import { addDaysToDayKey, type DayKey } from '../time/dayKey';
 import { deriveDailyHabitCompletion } from './completion';
+import { isHabitScheduledOnDay } from './schedule';
+import { resolveHabitTrackingForDay } from './trackingHistory';
 
 export interface WeeklyProgressEntry {
   habitId: string;
@@ -27,7 +29,7 @@ export function deriveWeeklyHabitProgress(
   weekEndDayKey: DayKey,
   entries: WeeklyProgressEntry[],
 ): WeeklyHabitProgress {
-  const targetValue = habit.timesPerWeek ?? 1;
+  const targetValue = resolveHabitTrackingForDay(habit, weekEndDayKey).timesPerWeek ?? 1;
   const entriesByDay = new Map<DayKey, WeeklyProgressEntry[]>();
 
   for (const entry of entries) {
@@ -37,7 +39,7 @@ export function deriveWeeklyHabitProgress(
       || entry.dayKey > weekEndDayKey
       || entry.deletedAt
       || entry.note?.startsWith('freeze:')
-      || (habit.assignedDays?.length && !habit.assignedDays.includes(getDayOfWeekForDayKey(entry.dayKey)))
+      || !isHabitScheduledOnDay(habit, entry.dayKey)
     ) {
       continue;
     }
@@ -48,7 +50,7 @@ export function deriveWeeklyHabitProgress(
   }
 
   const currentValue = Array.from(entriesByDay.values())
-    .filter(dayEntries => deriveDailyHabitCompletion(habit, dayEntries).isComplete)
+    .filter(dayEntries => deriveDailyHabitCompletion(habit, dayEntries, dayEntries[0]?.dayKey).isComplete)
     .length;
 
   return {

--- a/src/lib/persistenceClient.ts
+++ b/src/lib/persistenceClient.ts
@@ -19,6 +19,7 @@ import { invalidateGoalDataCache, invalidateGoalCaches } from './goalDataCache';
 import { ACTIVE_USER_MODE_STORAGE_KEY, DEMO_USER_ID, type ActiveUserMode } from '../shared/demo';
 import { DEMO_WRITE_BLOCKED_EVENT, DEMO_READ_ONLY_MESSAGE, getBootModeOverride } from './demoMode';
 import { warnIfPersonaLeaksIntoHabitEntryRequest } from '../shared/invariants/personaInvariants';
+import { getNowDayKey } from '../domain/time/dayKey';
 
 
 
@@ -739,7 +740,11 @@ export async function updateHabit(
 
   const response = await apiRequest<{ habit: Habit }>(`/habits/${id}`, {
     method: 'PATCH',
-    body: JSON.stringify(patch),
+    body: JSON.stringify({
+      ...patch,
+      trackingEffectiveDayKey: getNowDayKey(getLocalTimeZone()),
+      timeZone: getLocalTimeZone(),
+    }),
   });
 
   return response.habit;
@@ -766,6 +771,10 @@ export async function deleteHabit(id: string): Promise<void> {
 export async function archiveHabit(id: string): Promise<Habit> {
   const response = await apiRequest<{ habit: Habit }>(`/habits/${id}/archive`, {
     method: 'POST',
+    body: JSON.stringify({
+      trackingEffectiveDayKey: getNowDayKey(getLocalTimeZone()),
+      timeZone: getLocalTimeZone(),
+    }),
   });
   return response.habit;
 }
@@ -776,6 +785,10 @@ export async function archiveHabit(id: string): Promise<Habit> {
 export async function unarchiveHabit(id: string): Promise<Habit> {
   const response = await apiRequest<{ habit: Habit }>(`/habits/${id}/unarchive`, {
     method: 'POST',
+    body: JSON.stringify({
+      trackingEffectiveDayKey: getNowDayKey(getLocalTimeZone()),
+      timeZone: getLocalTimeZone(),
+    }),
   });
   return response.habit;
 }

--- a/src/lib/useProgressOverview.test.tsx
+++ b/src/lib/useProgressOverview.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProgressOverview } from '../types';
+import { fetchProgressOverview } from './persistenceClient';
+import { invalidateAllGoalCaches } from './goalDataCache';
+import { useProgressOverview } from './useProgressOverview';
+
+vi.mock('./persistenceClient', () => ({
+    fetchProgressOverview: vi.fn(),
+}));
+
+function overview(todayDate: string): ProgressOverview {
+    return {
+        todayDate,
+        habitsToday: [],
+        goalsWithProgress: [],
+        momentum: {
+            global: { state: 'Ready', activeDays: 0, trend: 'neutral', copy: '' },
+            category: {},
+        },
+    };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(resolvePromise => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+describe('useProgressOverview', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        invalidateAllGoalCaches();
+    });
+
+    it('keeps cached progress visible and non-blocking during a manual refresh', async () => {
+        const initial = overview('2026-08-01');
+        vi.mocked(fetchProgressOverview).mockResolvedValueOnce(initial);
+        const { result } = renderHook(() => useProgressOverview());
+
+        await waitFor(() => expect(result.current.data).toEqual(initial));
+        expect(result.current.loading).toBe(false);
+
+        const backgroundRequest = deferred<ProgressOverview>();
+        vi.mocked(fetchProgressOverview).mockReturnValueOnce(backgroundRequest.promise);
+        act(() => result.current.refresh());
+
+        expect(result.current.loading).toBe(false);
+        expect(result.current.data).toEqual(initial);
+
+        const refreshed = overview('2026-08-02');
+        await act(async () => {
+            backgroundRequest.resolve(refreshed);
+            await backgroundRequest.promise;
+        });
+        await waitFor(() => expect(result.current.data).toEqual(refreshed));
+    });
+});

--- a/src/lib/useProgressOverview.ts
+++ b/src/lib/useProgressOverview.ts
@@ -87,10 +87,9 @@ export function useProgressOverview(): {
         loading,
         error,
         refresh: () => {
-            // Invalidate cache and trigger reload
-            // We can't easily force the effect to re-run without a state change,
-            // so we'll just call fetchProgressOverview directly and update state.
-            setLoading(true);
+            // Keep stale progress visible during mutation-driven revalidation.
+            // A blocking loading state is only appropriate before first data.
+            if (!data) setLoading(true);
             fetchProgressOverview()
                 .then(newData => {
                     setCachedProgressOverview(newData);

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -1,3 +1,5 @@
+import type { HabitInactivePeriod, HabitTrackingRevision } from '../shared/habitTracking';
+
 /**
  * Explicit Data Models for Persistent Entities
  * 
@@ -66,7 +68,8 @@ export interface HabitGoal {
 
     /**
      * Tracking frequency: 'daily' or 'total' (cumulative goal)
-     * 'total' means the goal is cumulative across all time (e.g., "Run 100 miles total")
+     * 'total' means linked-goal aggregation is cumulative across all time.
+     * Habit-day completion still evaluates each DayKey against this target.
      * Note: 'weekly' was removed — use timesPerWeek on the Habit instead.
      */
     frequency: 'daily' | 'total';
@@ -133,6 +136,12 @@ export interface Habit {
      * by category deletion (which is auto-recovered on the next session).
      */
     archivedReason?: 'user' | 'category_deleted';
+
+    /** Historical completion/schedule rules, recorded only when those rules change. */
+    trackingRevisions?: HabitTrackingRevision[];
+
+    /** Closed/open local-day ranges excluded from restored-habit opportunities. */
+    inactivePeriods?: HabitInactivePeriod[];
 
     /**
      * Soft delete marker (ISO 8601). When set, the habit is removed from
@@ -1990,4 +1999,3 @@ export interface HealthSuggestion {
     createdAt: string;
     updatedAt: string;
 }
-

--- a/src/server/repositories/habitRepository.ts
+++ b/src/server/repositories/habitRepository.ts
@@ -9,6 +9,8 @@ import type { ClientSession } from 'mongodb';
 import { getDb } from '../lib/mongoClient';
 import { scopeFilter, requireScope } from '../lib/scoping';
 import { MONGO_COLLECTIONS, type Habit, type Goal } from '../../models/persistenceTypes';
+import { addDaysToDayKey } from '../../domain/time/dayKey';
+import { getDayKeyForTimestamp } from '../utils/dayKey';
 
 const COLLECTION_NAME = 'habits';
 const GOALS_COLLECTION = MONGO_COLLECTIONS.GOALS;
@@ -236,10 +238,25 @@ export async function updateHabit(
 export async function archiveHabit(
   id: string,
   householdId: string,
-  userId: string
+  userId: string,
+  archiveDayKey: string,
 ): Promise<Habit | null> {
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
+
+  const existingDocument = await collection.findOne(
+    scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
+  );
+  if (!existingDocument) return null;
+  const existingHabit = stripScope(existingDocument);
+  if (existingHabit.archived) return existingHabit;
+
+  // The archive day remains part of history. Missed opportunities begin the
+  // following local day, so a completion already recorded today is untouched.
+  const inactivePeriods = [
+    ...(existingHabit.inactivePeriods ?? []),
+    { startDayKey: addDaysToDayKey(archiveDayKey, 1) },
+  ];
 
   const result = await collection.findOneAndUpdate(
     scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
@@ -248,6 +265,7 @@ export async function archiveHabit(
         archived: true,
         archivedAt: new Date().toISOString(),
         archivedReason: 'user',
+        inactivePeriods,
       },
     },
     { returnDocument: 'after' }
@@ -264,15 +282,58 @@ export async function archiveHabit(
 export async function unarchiveHabit(
   id: string,
   householdId: string,
-  userId: string
+  userId: string,
+  restoreDayKey: string,
+  timeZone?: string,
 ): Promise<Habit | null> {
   const db = await getDb();
   const collection = db.collection(COLLECTION_NAME);
 
+  const existingDocument = await collection.findOne(
+    scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
+  );
+  if (!existingDocument) return null;
+  const existingHabit = stripScope(existingDocument);
+  if (!existingHabit.archived) return existingHabit;
+
+  const inactivePeriods = [...(existingHabit.inactivePeriods ?? [])];
+  const restorePreviousDayKey = addDaysToDayKey(restoreDayKey, -1);
+  let openPeriodIndex = -1;
+  for (let index = inactivePeriods.length - 1; index >= 0; index--) {
+    if (!inactivePeriods[index].endDayKey) {
+      openPeriodIndex = index;
+      break;
+    }
+  }
+  if (openPeriodIndex >= 0) {
+    const openPeriod = inactivePeriods[openPeriodIndex];
+    if (openPeriod.startDayKey <= restorePreviousDayKey) {
+      inactivePeriods[openPeriodIndex] = {
+        ...openPeriod,
+        endDayKey: restorePreviousDayKey,
+      };
+    } else {
+      inactivePeriods.splice(openPeriodIndex, 1);
+    }
+  } else if (existingHabit.archivedAt) {
+    // A currently archived pre-change habit has no open interval yet. Recover
+    // the one interval we can infer without guessing about older archive cycles.
+    const inferredStartDayKey = addDaysToDayKey(
+      getDayKeyForTimestamp(existingHabit.archivedAt, timeZone),
+      1,
+    );
+    if (inferredStartDayKey <= restorePreviousDayKey) {
+      inactivePeriods.push({
+        startDayKey: inferredStartDayKey,
+        endDayKey: restorePreviousDayKey,
+      });
+    }
+  }
+
   const result = await collection.findOneAndUpdate(
     scopeFilter(householdId, userId, { id, deletedAt: { $exists: false } }),
     {
-      $set: { archived: false },
+      $set: { archived: false, inactivePeriods },
       $unset: { archivedAt: '', archivedReason: '' },
     },
     { returnDocument: 'after' }

--- a/src/server/routes/__tests__/aiWeeklyReview.test.ts
+++ b/src/server/routes/__tests__/aiWeeklyReview.test.ts
@@ -8,20 +8,7 @@ vi.mock('../../middleware/identity', () => ({
 }));
 
 // --- Mock data sources ---
-const habitsData = [
-  {
-    id: 'h-walk',
-    name: 'Walk',
-    archived: false,
-    timesPerWeek: undefined,
-    assignedDays: undefined,
-  },
-  {
-    id: 'h-archived',
-    name: 'Old Habit',
-    archived: true,
-  },
-];
+let habitsData: Array<Record<string, unknown>> = [];
 
 // dayKeys for the reviewed week, filled in beforeEach from the resolved Monday.
 let weekDays: string[] = [];
@@ -29,14 +16,12 @@ let habitEntriesData: Array<Record<string, unknown>> = [];
 let wellbeingData: Array<Record<string, unknown>> = [];
 let journalData: Array<Record<string, unknown>> = [];
 
-vi.mock('../../lib/mongoClient', () => ({
-  getDb: vi.fn(async () => ({
-    collection: (name: string) => ({
-      find: () => ({
-        toArray: async () => (name === 'habits' ? habitsData : habitEntriesData),
-      }),
-    }),
-  })),
+vi.mock('../../repositories/habitRepository', () => ({
+  getHabitsByUser: vi.fn(async () => habitsData),
+}));
+
+vi.mock('../../repositories/habitEntryRepository', () => ({
+  getHabitEntriesByUserInRange: vi.fn(async () => habitEntriesData),
 }));
 
 vi.mock('../../repositories/journal', () => ({
@@ -51,6 +36,10 @@ vi.mock('../../repositories/goalRepository', () => ({
   getGoalsByUser: vi.fn(async () => [
     { id: 'g-1', title: 'Run a 10k', type: 'onetime', linkedHabitIds: ['h-walk'], completedAt: null },
   ]),
+}));
+
+vi.mock('../../repositories/aiReportRepository', () => ({
+  saveAIReport: vi.fn(async () => undefined),
 }));
 
 import { postWeeklyReview } from '../aiWeeklyReview';
@@ -76,6 +65,25 @@ function geminiOk(modelOutput: unknown) {
 
 describe('postWeeklyReview', () => {
   beforeEach(() => {
+    habitsData = [
+      {
+        id: 'h-walk',
+        categoryId: 'cat-1',
+        name: 'Walk',
+        archived: false,
+        createdAt: '2026-01-01T12:00:00.000Z',
+        goal: { type: 'boolean', frequency: 'daily' },
+      },
+      {
+        id: 'h-archived',
+        categoryId: 'cat-1',
+        name: 'Old Habit',
+        archived: true,
+        createdAt: '2026-01-01T12:00:00.000Z',
+        goal: { type: 'boolean', frequency: 'daily' },
+      },
+    ];
+
     const monday = startOfWeek(parseISO(REQUESTED_WEEK), { weekStartsOn: 1 });
     weekDays = Array.from({ length: 7 }, (_, i) => {
       const d = new Date(monday);
@@ -112,8 +120,10 @@ describe('postWeeklyReview', () => {
   });
 
   it('sends only grounded observed facts to Gemini and returns a normalized review', async () => {
-    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
-      geminiOk({
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      void url;
+      void init;
+      return geminiOk({
         summary: 'Solid week overall.',
         facts: ['Logged Walk 5 of 7 days', ''], // empty string should be filtered out
         journalThemes: ['Reflected positively on the day'],
@@ -127,8 +137,8 @@ describe('postWeeklyReview', () => {
         ],
         dataLimitations: ['Only two days of sleep data this week'],
         // Note: model does NOT supply weekStart/weekEnd — the server must own them.
-      }),
-    );
+      });
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     const res = createRes();
@@ -143,7 +153,7 @@ describe('postWeeklyReview', () => {
     const promptBody = JSON.parse(vi.mocked(fetchMock).mock.calls[0][1].body as string);
     const promptText = promptBody.contents[0].parts[0].text as string;
     expect(promptText).toContain('Walk');
-    expect(promptText).toContain('daysLogged');
+    expect(promptText).toContain('daysCompleted');
     expect(promptText).toContain('Sleep score'); // friendly wellbeing label
     expect(promptText).toContain('Run a 10k'); // active goal
     expect(promptText).not.toContain('Old Habit'); // archived habit excluded
@@ -178,6 +188,53 @@ describe('postWeeklyReview', () => {
     expect(body.meta.daysWithHabitData).toBe(5);
     expect(body.meta.journalEntries).toBe(1);
     expect(body.meta.wellbeingDaysRecorded).toBe(2);
+  });
+
+  it('counts only target-reaching numeric entries as completed days', async () => {
+    habitsData.push({
+      id: 'h-water',
+      categoryId: 'cat-1',
+      name: 'Water',
+      archived: false,
+      createdAt: '2026-01-01T12:00:00.000Z',
+      goal: { type: 'number', frequency: 'daily', target: 8, unit: 'glasses' },
+    });
+    habitEntriesData.push(
+      { id: 'water-partial', habitId: 'h-water', dayKey: weekDays[0], value: 3 },
+      { id: 'water-complete', habitId: 'h-water', dayKey: weekDays[1], value: 8 },
+    );
+
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      void url;
+      void init;
+      return geminiOk({
+        summary: 'Review.',
+        facts: [],
+        journalThemes: [],
+        wins: [],
+        areasForAttention: [],
+        patterns: [],
+        recommendations: [],
+        dataLimitations: [],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = createRes();
+    await postWeeklyReview(
+      { body: { geminiApiKey: 'a-valid-key-123', weekStart: REQUESTED_WEEK, timeZone: 'UTC' } } as unknown as Request,
+      res,
+    );
+
+    const promptBody = JSON.parse(vi.mocked(fetchMock).mock.calls[0][1].body as string);
+    const promptText = promptBody.contents[0].parts[0].text as string;
+    const observedJson = promptText.split('OBSERVED FACTS (JSON):\n')[1].split('\n\nNotes for interpretation:')[0];
+    const observedFacts = JSON.parse(observedJson);
+    const water = observedFacts.habits.find((habit: { name: string }) => habit.name === 'Water');
+
+    expect(water).toMatchObject({ daysCompleted: 1, targetDays: 7 });
+    expect(observedFacts.dayByDay[0].habitsCompleted).toBe(1); // Walk only; Water is partial.
+    expect(observedFacts.dayByDay[1].habitsCompleted).toBe(2);
   });
 
   it('returns a well-formed review even when Gemini reports only data limitations', async () => {

--- a/src/server/routes/__tests__/daySummary.test.ts
+++ b/src/server/routes/__tests__/daySummary.test.ts
@@ -253,6 +253,55 @@ describe('getDaySummary', () => {
     }
   });
 
+  it('derives historical log values with the goal type effective on each day', async () => {
+    const habit: Habit = {
+      id: 'habit-changed-type',
+      categoryId: 'cat-1',
+      name: 'Changed type',
+      goal: { type: 'boolean', frequency: 'daily' },
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-01-01',
+          goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+        },
+        {
+          effectiveFromDayKey: '2026-02-01',
+          goal: { type: 'boolean', frequency: 'daily' },
+        },
+      ],
+      archived: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    vi.mocked(getHabitsByUser).mockResolvedValue([habit]);
+    vi.mocked(getHabitEntriesByUser).mockResolvedValue([
+      createEntry({
+        id: 'historical-partial',
+        habitId: habit.id,
+        dayKey: '2026-01-15',
+        timestamp: '2026-01-15T12:00:00.000Z',
+        source: 'manual',
+        value: 5,
+      }),
+    ]);
+
+    const req = {
+      householdId: 'test-household',
+      userId: 'test-user',
+      query: {
+        startDayKey: '2026-01-15',
+        endDayKey: '2026-01-15',
+        timeZone: 'UTC',
+      },
+    } as unknown as Request;
+    const res = createRes();
+
+    await getDaySummary(req, res);
+
+    expect(vi.mocked(res.json).mock.calls[0][0].logs['habit-changed-type-2026-01-15']).toEqual(
+      expect.objectContaining({ completed: false, value: 5 }),
+    );
+  });
+
   it('derived bundle parent respects membership daysOfWeek filter', async () => {
     // 2026-01-07 is a Wednesday (day-of-week = 3).
     // 2026-01-08 is a Thursday (day-of-week = 4).

--- a/src/server/routes/__tests__/habits.scheduling.test.ts
+++ b/src/server/routes/__tests__/habits.scheduling.test.ts
@@ -14,6 +14,8 @@ import {
   getHabits,
   createHabitRoute,
   updateHabitRoute,
+  archiveHabitRoute,
+  unarchiveHabitRoute,
 } from '../habits';
 import {
   createCategoryRoute,
@@ -40,6 +42,8 @@ describe('Habit Scheduling (assignedDays + requiredDaysPerWeek)', () => {
     app.get('/api/habits', getHabits);
     app.post('/api/habits', createHabitRoute);
     app.patch('/api/habits/:id', updateHabitRoute);
+    app.post('/api/habits/:id/archive', archiveHabitRoute);
+    app.post('/api/habits/:id/unarchive', unarchiveHabitRoute);
     app.post('/api/categories', createCategoryRoute);
   });
 
@@ -244,5 +248,96 @@ describe('Habit Scheduling (assignedDays + requiredDaysPerWeek)', () => {
       .patch(`/api/habits/${createRes.body.habit.id}`)
       .send({ goal: { type: 'number', frequency: 'daily', target: -3 } });
     expect(invalidTarget.status).toBe(400);
+  });
+
+  it('records lightweight rule revisions instead of reinterpreting old entries', async () => {
+    const createRes = await request(app)
+      .post('/api/habits')
+      .send({
+        name: 'Historical pages',
+        categoryId: category.id,
+        goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+        assignedDays: [1, 3, 5],
+        requiredDaysPerWeek: 3,
+      });
+    expect(createRes.status).toBe(201);
+
+    const testDb = await getTestDb();
+    await testDb.collection('habits').updateOne(
+      { id: createRes.body.habit.id },
+      { $set: { createdAt: '2026-01-01T12:00:00.000Z' } },
+    );
+
+    const updateRes = await request(app)
+      .patch(`/api/habits/${createRes.body.habit.id}`)
+      .send({
+        goal: { type: 'number', frequency: 'daily', target: 20, unit: 'pages' },
+        assignedDays: [1, 2, 3, 4, 5],
+        requiredDaysPerWeek: 5,
+        trackingEffectiveDayKey: '2026-08-01',
+        timeZone: 'America/New_York',
+      });
+
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.habit.trackingRevisions).toEqual([
+      {
+        effectiveFromDayKey: '2026-01-01',
+        goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+        assignedDays: [1, 3, 5],
+        requiredDaysPerWeek: 3,
+      },
+      {
+        effectiveFromDayKey: '2026-08-01',
+        goal: { type: 'number', frequency: 'daily', target: 20, unit: 'pages' },
+        assignedDays: [1, 2, 3, 4, 5],
+        requiredDaysPerWeek: 5,
+      },
+    ]);
+  });
+
+  it('records archive gaps without modifying existing HabitEntries', async () => {
+    const createRes = await request(app)
+      .post('/api/habits')
+      .send({
+        name: 'Pause-safe habit',
+        categoryId: category.id,
+        goal: { type: 'boolean', frequency: 'daily' },
+      });
+    expect(createRes.status).toBe(201);
+
+    const testDb = await getTestDb();
+    const storedEntry = {
+      id: 'history-entry-1',
+      householdId: TEST_HOUSEHOLD_ID,
+      userId: TEST_USER_ID,
+      habitId: createRes.body.habit.id,
+      dayKey: '2026-02-10',
+      timestamp: '2026-02-10T12:00:00.000Z',
+      value: 1,
+      source: 'manual',
+      createdAt: '2026-02-10T12:00:00.000Z',
+      updatedAt: '2026-02-10T12:00:00.000Z',
+    };
+    await testDb.collection('habitEntries').insertOne(storedEntry);
+    const beforeEntry = await testDb.collection('habitEntries').findOne({ id: storedEntry.id });
+
+    const archiveRes = await request(app)
+      .post(`/api/habits/${createRes.body.habit.id}/archive`)
+      .send({ trackingEffectiveDayKey: '2026-02-10', timeZone: 'UTC' });
+    expect(archiveRes.status).toBe(200);
+    expect(archiveRes.body.habit.inactivePeriods).toEqual([
+      { startDayKey: '2026-02-11' },
+    ]);
+
+    const restoreRes = await request(app)
+      .post(`/api/habits/${createRes.body.habit.id}/unarchive`)
+      .send({ trackingEffectiveDayKey: '2026-02-15', timeZone: 'UTC' });
+    expect(restoreRes.status).toBe(200);
+    expect(restoreRes.body.habit.inactivePeriods).toEqual([
+      { startDayKey: '2026-02-11', endDayKey: '2026-02-14' },
+    ]);
+
+    const afterEntry = await testDb.collection('habitEntries').findOne({ id: storedEntry.id });
+    expect(afterEntry).toEqual(beforeEntry);
   });
 });

--- a/src/server/routes/__tests__/progress.overview.test.ts
+++ b/src/server/routes/__tests__/progress.overview.test.ts
@@ -137,6 +137,35 @@ describe('getProgressOverview', () => {
     expect(habitToday.atRisk).toBe(true);
   });
 
+  it('reports ten strict daily completions as a ten-day streak', async () => {
+    vi.setSystemTime(new Date('2026-02-19T12:00:00.000Z'));
+
+    const habit: Habit = {
+      ...dailyHabit('habit-strict-daily'),
+      assignedDays: [0, 1, 2, 3, 4, 5, 6],
+      requiredDaysPerWeek: 7,
+      createdAt: '2026-02-10T00:00:00.000Z',
+    };
+    vi.mocked(getHabitsByUser).mockResolvedValue([habit]);
+    vi.mocked(getHabitEntriesByUser).mockResolvedValue(
+      Array.from({ length: 10 }, (_, index) => (
+        entry(habit.id, `2026-02-${String(index + 10).padStart(2, '0')}`)
+      )),
+    );
+
+    const req = createReq();
+    const res = createRes();
+
+    await getProgressOverview(req, res);
+
+    const body = vi.mocked(res.json).mock.calls[0][0];
+    const habitToday = body.habitsToday[0];
+    expect(habitToday.currentStreak).toBe(10);
+    expect(habitToday.bestStreak).toBe(10);
+    expect(habitToday.formattedStreak).toBe('10 days');
+    expect(habitToday.weekSatisfied).toBeUndefined();
+  });
+
   it('computes weekly streak and atRisk from weekly progress', async () => {
     vi.setSystemTime(new Date('2026-02-20T12:00:00.000Z'));
 

--- a/src/server/routes/__tests__/progress.overview.test.ts
+++ b/src/server/routes/__tests__/progress.overview.test.ts
@@ -166,6 +166,42 @@ describe('getProgressOverview', () => {
     expect(habitToday.weekSatisfied).toBeUndefined();
   });
 
+  it('keeps pre-edit numeric completions in the streak under their historical target', async () => {
+    vi.setSystemTime(new Date('2026-03-02T12:00:00.000Z'));
+
+    const habit: Habit = {
+      ...dailyHabit('habit-revised-target'),
+      goal: { type: 'number', frequency: 'daily', target: 20, unit: 'pages' },
+      createdAt: '2026-02-27T00:00:00.000Z',
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-02-27',
+          goal: { type: 'number', frequency: 'daily', target: 10, unit: 'pages' },
+        },
+        {
+          effectiveFromDayKey: '2026-03-01',
+          goal: { type: 'number', frequency: 'daily', target: 20, unit: 'pages' },
+        },
+      ],
+    };
+    vi.mocked(getHabitsByUser).mockResolvedValue([habit]);
+    vi.mocked(getHabitEntriesByUser).mockResolvedValue([
+      entry(habit.id, '2026-02-27', 10),
+      entry(habit.id, '2026-02-28', 10),
+      entry(habit.id, '2026-03-01', 20),
+      entry(habit.id, '2026-03-02', 20),
+    ]);
+
+    const req = createReq();
+    const res = createRes();
+    await getProgressOverview(req, res);
+
+    const habitToday = vi.mocked(res.json).mock.calls[0][0].habitsToday[0];
+    expect(habitToday.currentStreak).toBe(4);
+    expect(habitToday.bestStreak).toBe(4);
+    expect(habitToday.completed).toBe(true);
+  });
+
   it('computes weekly streak and atRisk from weekly progress', async () => {
     vi.setSystemTime(new Date('2026-02-20T12:00:00.000Z'));
 

--- a/src/server/routes/aiWeeklyReview.ts
+++ b/src/server/routes/aiWeeklyReview.ts
@@ -4,7 +4,7 @@
  * POST /api/ai/weekly-review
  *
  * Gathers a single week of the user's real data (habit entries, sleep & mood
- * from wellbeing check-ins, journal activity, and goals), aggregates it into
+ * from wellbeing check-ins, journal entries, and goals), aggregates it into
  * a compact set of *observed facts*, and asks Gemini to produce a grounded,
  * structured weekly review.
  *
@@ -19,14 +19,21 @@
 import type { Request, Response } from 'express';
 import { startOfWeek, endOfWeek, parseISO, format, getDay } from 'date-fns';
 import { getRequestIdentity } from '../middleware/identity';
-import { getDb } from '../lib/mongoClient';
 import { getEntriesByUser } from '../repositories/journal';
 import { getWellbeingEntries } from '../repositories/wellbeingEntryRepository';
 import { getGoalsByUser } from '../repositories/goalRepository';
+import { getHabitsByUser } from '../repositories/habitRepository';
+import { getHabitEntriesByUserInRange } from '../repositories/habitEntryRepository';
 import { saveAIReport } from '../repositories/aiReportRepository';
 import { GEMINI_MODEL, buildGeminiUrl, GEMINI_THINKING_CONFIG, extractGeminiText } from '../lib/gemini';
 import { resolveTimeZone, getNowDayKey } from '../utils/dayKey';
 import { isValidDayKey } from '../../domain/time/dayKey';
+import {
+  getWeeklyQuotaTargetOnDay,
+  isHabitScheduledOnDay,
+  matchesHabitScheduleOnDay,
+} from '../../domain/habits/schedule';
+import { buildDayStatesByHabit } from '../services/analyticsService';
 import type {
   WeeklyAIReview,
   WeeklyReviewPattern,
@@ -103,49 +110,48 @@ export async function postWeeklyReview(req: Request, res: Response): Promise<voi
     }
 
     // ---- Collect raw data for the week ----
-    const db = await getDb();
     const [habits, habitEntries, allJournal, wellbeingEntries, goals] = await Promise.all([
-      db.collection('habits').find({ userId, householdId }).toArray(),
-      db
-        .collection('habitEntries')
-        .find({
-          userId,
-          householdId,
-          dayKey: { $gte: startDayKey, $lte: endDayKey },
-          deletedAt: { $exists: false },
-        })
-        .toArray(),
+      getHabitsByUser(householdId, userId),
+      getHabitEntriesByUserInRange(householdId, userId, startDayKey, endDayKey),
       getEntriesByUser(userId, { startDate: startDayKey, endDate: endDayKey }),
       getWellbeingEntries({ userId, startDayKey, endDayKey }),
       getGoalsByUser(householdId, userId),
     ]);
 
-    const activeHabits = habits.filter((h) => !h.archived && !h.deletedAt);
+    const activeHabits = habits.filter((habit) => !habit.archived && !habit.deletedAt);
     const habitNameMap = new Map<string, string>();
     for (const h of habits) habitNameMap.set(h.id, h.name);
 
-    // ---- Per-habit weekly aggregation (days logged vs. target) ----
-    const daysLoggedByHabit = new Map<string, Set<string>>();
-    for (const entry of habitEntries) {
-      if (!daysLoggedByHabit.has(entry.habitId)) daysLoggedByHabit.set(entry.habitId, new Set());
-      daysLoggedByHabit.get(entry.habitId)!.add(entry.dayKey);
-    }
+    // ---- Per-habit weekly aggregation (canonical completed days vs. target) ----
+    // Bundle parents are derived from children and do not own entries. The
+    // review reports leaf habits so a parent is not falsely described as 0/7.
+    const dayStatesByHabit = buildDayStatesByHabit(habitEntries, activeHabits, timeZone);
+    const isReviewOpportunity = (habit: typeof activeHabits[number], dayKey: string) => (
+      isHabitScheduledOnDay(habit, dayKey, timeZone)
+      || (
+        dayStatesByHabit.get(habit.id)?.has(dayKey) === true
+        && matchesHabitScheduleOnDay(habit, dayKey)
+      )
+    );
+    const reviewHabits = activeHabits.filter((habit) => {
+      if (habit.type === 'bundle') return false;
+      return weekDayKeys.some(dayKey => isReviewOpportunity(habit, dayKey));
+    });
 
-    const habitFacts = activeHabits.map((h) => {
-      const daysLogged = daysLoggedByHabit.get(h.id)?.size ?? 0;
-      // Target days this week: weekly habits use timesPerWeek; otherwise daily (7) or assigned days.
-      let targetDays = 7;
-      if (typeof h.timesPerWeek === 'number' && h.timesPerWeek > 0) targetDays = h.timesPerWeek;
-      else if (Array.isArray(h.assignedDays) && h.assignedDays.length > 0)
-        targetDays = h.assignedDays.length;
+    const habitFacts = reviewHabits.map((habit) => {
+      const completedDays = weekDayKeys.filter(dayKey => (
+        isReviewOpportunity(habit, dayKey)
+        && dayStatesByHabit.get(habit.id)?.get(dayKey)?.completed
+      ));
+      const weekEndQuota = getWeeklyQuotaTargetOnDay(habit, endDayKey);
+      const targetDays = weekEndQuota ?? weekDayKeys.filter(
+        dayKey => isReviewOpportunity(habit, dayKey),
+      ).length;
       return {
-        name: h.name as string,
-        daysLogged,
+        name: habit.name,
+        daysCompleted: completedDays.length,
         targetDays,
-        cadence:
-          typeof h.timesPerWeek === 'number' && h.timesPerWeek > 0
-            ? `${h.timesPerWeek}x/week`
-            : 'daily',
+        cadence: weekEndQuota != null ? `${weekEndQuota}x/week` : 'scheduled days',
       };
     });
 
@@ -161,15 +167,27 @@ export async function postWeeklyReview(req: Request, res: Response): Promise<voi
       m.get(w.metricKey)!.push(w.value);
     }
 
-    const habitDaysByDay = new Map<string, Set<string>>();
+    const completedHabitIdsByDay = new Map<string, Set<string>>();
+    for (const habit of reviewHabits) {
+      const dayMap = dayStatesByHabit.get(habit.id);
+      if (!dayMap) continue;
+      for (const dayKey of weekDayKeys) {
+        if (!isReviewOpportunity(habit, dayKey)) continue;
+        if (!dayMap.get(dayKey)?.completed) continue;
+        const completedHabitIds = completedHabitIdsByDay.get(dayKey) ?? new Set<string>();
+        completedHabitIds.add(habit.id);
+        completedHabitIdsByDay.set(dayKey, completedHabitIds);
+      }
+    }
+
+    const habitDataDays = new Set<string>();
     for (const entry of habitEntries) {
-      if (!habitDaysByDay.has(entry.dayKey)) habitDaysByDay.set(entry.dayKey, new Set());
-      habitDaysByDay.get(entry.dayKey)!.add(entry.habitId);
+      if (isValidDayKey(entry.dayKey)) habitDataDays.add(entry.dayKey);
     }
 
     const dayBreakdown = weekDayKeys.map((dayKey) => {
       const weekday = WEEKDAY_NAMES[getDay(parseISO(dayKey))];
-      const habitsCompleted = habitDaysByDay.get(dayKey)?.size ?? 0;
+      const habitsCompleted = completedHabitIdsByDay.get(dayKey)?.size ?? 0;
       const metrics: Record<string, number> = {};
       const dayMetrics = wellbeingByDay.get(dayKey);
       if (dayMetrics) {
@@ -236,8 +254,8 @@ export async function postWeeklyReview(req: Request, res: Response): Promise<voi
       journal: journalFacts,
       goals: goalFacts,
       totals: {
-        activeHabits: activeHabits.length,
-        daysWithHabitData: habitDaysByDay.size,
+        activeHabits: reviewHabits.length,
+        daysWithHabitData: habitDataDays.size,
         journalEntries: journalFacts.length,
         wellbeingDaysRecorded,
       },
@@ -279,7 +297,7 @@ OBSERVED FACTS (JSON):
 ${JSON.stringify(observedFacts, null, 2)}
 
 Notes for interpretation:
-- "daysLogged" vs "targetDays" reflects how often each habit was completed relative to its cadence this week.
+- "daysCompleted" vs "targetDays" reflects how often each habit reached its completion target on a scheduled day this week. Partial numeric progress is not completion.
 - "dayByDay" lets you look for relationships (e.g. sleep score vs. next-day habits completed, mood vs. journaling).
 - Wellbeing values are on the user's own check-in scales; treat them as relative within this week, not absolute.
 - "journal[].snippet" holds short excerpts of what the user wrote; use these for "journalThemes" only.
@@ -456,8 +474,8 @@ Return the review as JSON matching the provided schema.`;
       meta: {
         weekStart: startDayKey,
         weekEnd: endDayKey,
-        habitsTracked: activeHabits.length,
-        daysWithHabitData: habitDaysByDay.size,
+        habitsTracked: reviewHabits.length,
+        daysWithHabitData: habitDataDays.size,
         journalEntries: journalFacts.length,
         wellbeingDaysRecorded,
       },

--- a/src/server/routes/daySummary.ts
+++ b/src/server/routes/daySummary.ts
@@ -9,6 +9,7 @@ import { evaluateChecklistSuccess } from '../services/checklistSuccessService';
 import { resolveTimeZone, getNowDayKey, getDayKeyForDate, getCanonicalDayKeyFromEntry } from '../utils/dayKey';
 import { getRequestIdentity } from '../middleware/identity';
 import { deriveDailyHabitCompletion } from '../../domain/habits/completion';
+import { resolveHabitTrackingForDay } from '../../domain/habits/trackingHistory';
 
 type AggregatedDayEntry = {
   habitId: string;
@@ -152,16 +153,17 @@ export async function getDaySummary(req: Request, res: Response): Promise<void> 
       if (!habit) continue;
 
       const isFrozen = aggregate.hasFreeze && aggregate.count === 0;
+      const tracking = resolveHabitTrackingForDay(habit, aggregate.dayKey);
 
       const completionEntries = isFrozen || aggregate.count === 0
         ? []
-        : habit.goal.type === 'number'
+        : tracking.goal.type === 'number'
           ? [{ value: aggregate.valueSum }]
           : [{}];
-      const completion = deriveDailyHabitCompletion(habit, completionEntries);
+      const completion = deriveDailyHabitCompletion(habit, completionEntries, aggregate.dayKey);
       const value = habit.bundleType === 'choice'
         ? undefined
-        : habit.goal.type === 'number'
+        : tracking.goal.type === 'number'
           ? completion.currentValue
           : (isFrozen ? 0 : (aggregate.valueSum > 0 ? aggregate.valueSum : aggregate.count));
       const completed = completion.isComplete;

--- a/src/server/routes/habitEntries.ts
+++ b/src/server/routes/habitEntries.ts
@@ -625,7 +625,7 @@ export async function batchCreateEntriesRoute(req: Request, res: Response): Prom
                 return;
             }
 
-            const value = getCompletionEntryValue(habit);
+            const value = getCompletionEntryValue(habit, dayKey);
             if (value === null) {
                 res.status(400).json({ error: `${habit.name}: numeric habit has no valid completion target` });
                 return;

--- a/src/server/routes/habits.ts
+++ b/src/server/routes/habits.ts
@@ -28,6 +28,13 @@ import type { Habit } from '../../models/persistenceTypes';
 import { getRequestIdentity } from '../middleware/identity';
 import { invalidateUserCaches } from '../lib/cacheInstances';
 import { validateHabitDefinition } from '../../domain/habits/definitionValidation';
+import { getHabitCreatedDayKey } from '../../domain/habits/schedule';
+import {
+  recordHabitTrackingRevision,
+  trackingRulesEqual,
+} from '../../domain/habits/trackingHistory';
+import { isValidDayKey } from '../../domain/time/dayKey';
+import { getNowDayKey, resolveTimeZone } from '../utils/dayKey';
 
 // One-time recovery: track which users have been recovered to avoid repeated DB calls.
 // Both recovery layers run at most once per user per server process to avoid
@@ -159,7 +166,7 @@ export async function createHabitRoute(req: Request, res: Response): Promise<voi
       linkedGoalId, linkedRoutineIds,
       requiredDaysPerWeek, timesPerWeek,
       checklistSuccessRule, streakType,
-      reminderTime, reminderEnabled
+      reminderTime, reminderEnabled,
     } = req.body;
 
     // null is treated as "no reminder" so create and PATCH share one contract
@@ -343,7 +350,8 @@ export async function updateHabitRoute(req: Request, res: Response): Promise<voi
       linkedGoalId, linkedRoutineIds,
       requiredDaysPerWeek, timesPerWeek,
       checklistSuccessRule, streakType,
-      reminderTime, reminderEnabled
+      reminderTime, reminderEnabled,
+      trackingEffectiveDayKey, timeZone,
     } = req.body;
 
     if (!id) {
@@ -428,6 +436,29 @@ export async function updateHabitRoute(req: Request, res: Response): Promise<voi
         error: { code: 'VALIDATION_ERROR', message: definitionValidation.error },
       });
       return;
+    }
+
+    const updatedHabitDefinition = { ...existingHabit, ...patch };
+    if (!trackingRulesEqual(existingHabit, updatedHabitDefinition)) {
+      if (trackingEffectiveDayKey !== undefined && !isValidDayKey(trackingEffectiveDayKey)) {
+        res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'trackingEffectiveDayKey must use YYYY-MM-DD format',
+          },
+        });
+        return;
+      }
+
+      const effectiveDayKey = trackingEffectiveDayKey ?? getNowDayKey(timeZone);
+      const baselineDayKey = getHabitCreatedDayKey(existingHabit, resolveTimeZone(timeZone))
+        ?? effectiveDayKey;
+      patch.trackingRevisions = recordHabitTrackingRevision(
+        existingHabit,
+        updatedHabitDefinition,
+        effectiveDayKey,
+        baselineDayKey,
+      );
     }
 
     if (patch.categoryId) {
@@ -561,8 +592,16 @@ export async function archiveHabitRoute(req: Request, res: Response): Promise<vo
       return;
     }
 
+    const { trackingEffectiveDayKey, timeZone } = req.body ?? {};
+    if (trackingEffectiveDayKey !== undefined && !isValidDayKey(trackingEffectiveDayKey)) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'trackingEffectiveDayKey must use YYYY-MM-DD format' },
+      });
+      return;
+    }
+    const archiveDayKey = trackingEffectiveDayKey ?? getNowDayKey(timeZone);
     const { householdId, userId } = getRequestIdentity(req);
-    const habit = await archiveHabit(id, householdId, userId);
+    const habit = await archiveHabit(id, householdId, userId, archiveDayKey);
 
     if (!habit) {
       res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Habit not found' } });
@@ -598,8 +637,22 @@ export async function unarchiveHabitRoute(req: Request, res: Response): Promise<
       return;
     }
 
+    const { trackingEffectiveDayKey, timeZone } = req.body ?? {};
+    if (trackingEffectiveDayKey !== undefined && !isValidDayKey(trackingEffectiveDayKey)) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: 'trackingEffectiveDayKey must use YYYY-MM-DD format' },
+      });
+      return;
+    }
+    const restoreDayKey = trackingEffectiveDayKey ?? getNowDayKey(timeZone);
     const { householdId, userId } = getRequestIdentity(req);
-    const habit = await unarchiveHabit(id, householdId, userId);
+    const habit = await unarchiveHabit(
+      id,
+      householdId,
+      userId,
+      restoreDayKey,
+      resolveTimeZone(timeZone),
+    );
 
     if (!habit) {
       res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Habit not found' } });

--- a/src/server/routes/progress.ts
+++ b/src/server/routes/progress.ts
@@ -13,6 +13,7 @@ import { getAllMembershipsByUser } from '../repositories/bundleMembershipReposit
 import { computeGoalsWithProgressFromData } from '../utils/goalProgressUtilsV2';
 import { calculateGlobalMomentum, calculateCategoryMomentum, getMomentumCopy } from '../services/momentumService';
 import { calculateHabitStreakMetrics, type HabitDayState } from '../services/streakService';
+import { usesWeeklyQuotaStreak } from '../../domain/habits/schedule';
 import { resolveTimeZone, getNowDayKey, getCanonicalDayKeyFromEntry } from '../utils/dayKey';
 import type { MomentumState } from '../../types';
 import type { CompletionRecord } from '../services/momentumService';
@@ -190,8 +191,7 @@ export async function getProgressOverview(req: Request, res: Response): Promise<
       const value = habit.goal.type === 'number' && todayState ? todayState.value : undefined;
       const streak = streakMetrics.currentStreak;
 
-      const isWeeklyStreak = (habit.timesPerWeek != null && habit.timesPerWeek > 0) ||
-        (habit.assignedDays?.length && habit.requiredDaysPerWeek);
+      const isWeeklyStreak = usesWeeklyQuotaStreak(habit);
       const formattedStreak = isWeeklyStreak
         ? `${streak} ${streak === 1 ? 'week' : 'weeks'}`
         : `${streak} ${streak === 1 ? 'day' : 'days'}`;

--- a/src/server/routes/progress.ts
+++ b/src/server/routes/progress.ts
@@ -23,6 +23,7 @@ import { evaluateChecklistSuccess } from '../services/checklistSuccessService';
 import type { Habit } from '../../models/persistenceTypes';
 import { buildUserScopedCacheKey, progressCache } from '../lib/cacheInstances';
 import { deriveDailyHabitCompletion, type CompletionEntry } from '../../domain/habits/completion';
+import { resolveHabitTrackingForDay } from '../../domain/habits/trackingHistory';
 
 function parseFreezeType(entry: { freezeType?: string; note?: string }): 'manual' | 'auto' | 'soft' | undefined {
   // Prefer dedicated field; fall back to legacy note parsing
@@ -107,6 +108,7 @@ export async function getProgressOverview(req: Request, res: Response): Promise<
         const completion = deriveDailyHabitCompletion(
           habit,
           completionEntriesByHabitDay.get(`${habitId}|${state.dayKey}`) ?? [],
+          state.dayKey,
         );
         state.value = completion.currentValue;
         state.completed = completion.isComplete;
@@ -155,7 +157,7 @@ export async function getProgressOverview(req: Request, res: Response): Promise<
         }))
     );
 
-    const globalMomentum = calculateGlobalMomentum(completionLogs);
+    const globalMomentum = calculateGlobalMomentum(completionLogs, todayDate);
 
     // Group habits by category for Category Momentum
     const categoryHabitMap: Record<string, string[]> = {};
@@ -166,7 +168,7 @@ export async function getProgressOverview(req: Request, res: Response): Promise<
 
     const categoryMomentum: Record<string, MomentumState> = {};
     Object.keys(categoryHabitMap).forEach(catId => {
-      const result = calculateCategoryMomentum(completionLogs, categoryHabitMap[catId]);
+      const result = calculateCategoryMomentum(completionLogs, categoryHabitMap[catId], todayDate);
       categoryMomentum[catId] = result.state;
     });
 
@@ -188,10 +190,11 @@ export async function getProgressOverview(req: Request, res: Response): Promise<
       );
 
       const completed = streakMetrics.completedToday;
-      const value = habit.goal.type === 'number' && todayState ? todayState.value : undefined;
+      const todayTracking = resolveHabitTrackingForDay(habit, todayDate);
+      const value = todayTracking.goal.type === 'number' && todayState ? todayState.value : undefined;
       const streak = streakMetrics.currentStreak;
 
-      const isWeeklyStreak = usesWeeklyQuotaStreak(habit);
+      const isWeeklyStreak = usesWeeklyQuotaStreak(habit, todayDate);
       const formattedStreak = isWeeklyStreak
         ? `${streak} ${streak === 1 ? 'week' : 'weeks'}`
         : `${streak} ${streak === 1 ? 'day' : 'days'}`;

--- a/src/server/routes/routines.ts
+++ b/src/server/routes/routines.ts
@@ -1007,7 +1007,7 @@ export async function submitRoutineRoute(req: Request, res: Response): Promise<v
         res.status(404).json({ error: { code: 'NOT_FOUND', message: `Active habit not found: ${habitId}` } });
         return;
       }
-      const value = getCompletionEntryValue(habit);
+      const value = getCompletionEntryValue(habit, logDate);
       if (value === null) {
         res.status(400).json({
           error: { code: 'VALIDATION_ERROR', message: `${habit.name} has no valid numeric completion target` },

--- a/src/server/services/analyticsService.test.ts
+++ b/src/server/services/analyticsService.test.ts
@@ -256,6 +256,19 @@ describe('computeHeatmapData', () => {
     expect(result.dataPoints[0].completedCount).toBe(1);
     expect(result.dataPoints[0].scheduledCount).toBe(2);
   });
+
+  it('shows a real backdated completion without inventing earlier opportunities', () => {
+    const habit = createHabit({ createdAt: '2026-04-02T12:00:00.000Z' });
+    const entries = [createEntry(habit.id, '2026-04-01')];
+
+    const result = computeHeatmapData([habit], entries, '2026-04-02', 3, 'UTC');
+
+    expect(result.dataPoints).toEqual([
+      expect.objectContaining({ dayKey: '2026-03-31', scheduledCount: 0, completedCount: 0 }),
+      expect.objectContaining({ dayKey: '2026-04-01', scheduledCount: 1, completedCount: 1 }),
+      expect.objectContaining({ dayKey: '2026-04-02', scheduledCount: 1, completedCount: 0 }),
+    ]);
+  });
 });
 
 // ─── Trends Tests ────────────────────────────────────────────────────────────

--- a/src/server/services/analyticsService.ts
+++ b/src/server/services/analyticsService.ts
@@ -10,7 +10,7 @@ import type { Habit, HabitEntry, Category, Routine, RoutineLog, Goal } from '../
 import type { BundleMembershipRecord } from '../domain/canonicalTypes';
 import { calculateHabitStreakMetrics, type HabitDayState } from './streakService';
 import { getCanonicalDayKeyFromEntry } from '../utils/dayKey';
-import { isHabitScheduledOnDay, isTrackableHabit, getScheduledHabitsForDay } from './scheduleEngine';
+import { isHabitScheduledOnDay, isTrackableHabit, matchesHabitScheduleOnDay } from './scheduleEngine';
 import { deriveDailyHabitCompletion, type CompletionEntry } from '../../domain/habits/completion';
 import { addDaysToDayKey, differenceInDayKeys } from '../../domain/time/dayKey';
 
@@ -159,6 +159,7 @@ export function buildDayStatesByHabit(
       const completion = deriveDailyHabitCompletion(
         habit,
         completionEntriesByHabitDay.get(`${habitId}|${state.dayKey}`) ?? [],
+        state.dayKey,
       );
       state.value = completion.currentValue;
       state.completed = completion.isComplete;
@@ -182,14 +183,42 @@ function generateDayKeyRange(startDayKey: string, endDayKey: string): string[] {
   return days;
 }
 
-// getScheduledHabitsForDay and isTrackableHabit are imported from scheduleEngine.ts
-// (shared with streakService and progress views for consistent opportunity counting)
+// Canonical schedule predicates are imported from scheduleEngine.ts and then
+// augmented only for evidenced pre-creation history below.
 
 /**
  * Filter to trackable habits using the shared schedule engine predicate.
  */
 function getTrackableHabits(habits: Habit[]): Habit[] {
   return habits.filter(isTrackableHabit);
+}
+
+/**
+ * Do not invent missed opportunities before a habit document existed, but do
+ * honor a real backdated/imported entry on its own matching schedule day.
+ */
+function isHabitAnalyticsOpportunityOnDay(
+  habit: Habit,
+  dayKey: string,
+  dayStatesByHabit: Map<string, Map<string, HabitDayState>>,
+  timeZone?: string,
+): boolean {
+  return isHabitScheduledOnDay(habit, dayKey, timeZone)
+    || (
+      dayStatesByHabit.get(habit.id)?.has(dayKey) === true
+      && matchesHabitScheduleOnDay(habit, dayKey)
+    );
+}
+
+function getScheduledHabitsForAnalyticsDay(
+  habits: Habit[],
+  dayKey: string,
+  dayStatesByHabit: Map<string, Map<string, HabitDayState>>,
+  timeZone?: string,
+): Habit[] {
+  return habits.filter(habit => (
+    isHabitAnalyticsOpportunityOnDay(habit, dayKey, dayStatesByHabit, timeZone)
+  ));
 }
 
 const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -207,7 +236,7 @@ function computeDayOfWeekStats(
   const stats = Array.from({ length: 7 }, () => ({ scheduled: 0, completed: 0 }));
   for (const dk of dayKeys) {
     const dow = new Date(dk + 'T12:00:00Z').getUTCDay();
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     stats[dow].scheduled += scheduled.length;
     for (const habit of scheduled) {
       if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) {
@@ -239,7 +268,7 @@ function groupByWeek(
     const weekNum = getISOWeek(date);
     const weekLabel = `${weekYear}-W${String(weekNum).padStart(2, '0')}`;
     const existing = weekMap.get(weekLabel) ?? { completions: 0, scheduled: 0 };
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     existing.scheduled += scheduled.length;
     for (const habit of scheduled) {
       if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) existing.completions++;
@@ -263,7 +292,7 @@ function computeTrendDirection(
   const computeRangeRate = (keys: string[]) => {
     let s = 0, c = 0;
     for (const dk of keys) {
-      const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+      const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
       s += scheduled.length;
       for (const habit of scheduled) {
         if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) c++;
@@ -426,7 +455,11 @@ export function computeHabitAnalyticsSummary(
     const habit = trackableById.get(habitId);
     if (!habit) continue;
     for (const [dk, state] of dayMap) {
-      if (state.completed && dayKeySet.has(dk) && isHabitScheduledOnDay(habit, dk, timeZone)) {
+      if (
+        state.completed
+        && dayKeySet.has(dk)
+        && isHabitAnalyticsOpportunityOnDay(habit, dk, dayStatesByHabit, timeZone)
+      ) {
         daysWithCompletion.add(dk);
       }
     }
@@ -437,7 +470,7 @@ export function computeHabitAnalyticsSummary(
   let totalScheduled = 0;
   let totalCompleted = 0;
   for (const dk of dayKeys) {
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     totalScheduled += scheduled.length;
     for (const habit of scheduled) {
       const dayMap = dayStatesByHabit.get(habit.id);
@@ -471,7 +504,7 @@ export function computeHabitAnalyticsSummary(
       if (
         dayKeySet.has(dayKey)
         && state.completed
-        && isHabitScheduledOnDay(habit, dayKey, timeZone)
+        && isHabitAnalyticsOpportunityOnDay(habit, dayKey, dayStatesByHabit, timeZone)
       ) totalCompletions++;
     }
   }
@@ -494,7 +527,7 @@ export function computeHabitAnalyticsSummary(
   let daysSinceLastMissed = 0;
   for (let i = dayKeys.length - 1; i >= 0; i--) {
     const dk = dayKeys[i];
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     let allCompleted = scheduled.length > 0;
     for (const habit of scheduled) {
       if (!dayStatesByHabit.get(habit.id)?.get(dk)?.completed) {
@@ -530,7 +563,7 @@ export function computeHabitAnalyticsSummary(
   for (const dk of dayKeys) {
     const dow = new Date(dk + 'T12:00:00Z').getUTCDay();
     const isWeekend = dow === 0 || dow === 6;
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     for (const habit of scheduled) {
       if (isWeekend) {
         weekendScheduled++;
@@ -558,7 +591,7 @@ export function computeHabitAnalyticsSummary(
         if (
           state.completed
           && dayKeySet.has(dk)
-          && isHabitScheduledOnDay(habit, dk, timeZone)
+          && isHabitAnalyticsOpportunityOnDay(habit, dk, dayStatesByHabit, timeZone)
         ) existing.completions++;
       }
     }
@@ -651,7 +684,7 @@ export function computeHeatmapData(
   const dayKeys = generateDayKeyRange(startDayKey, referenceDayKey);
 
   const dataPoints = dayKeys.map(dk => {
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     const scheduledCount = scheduled.length;
     let completedCount = 0;
     for (const habit of scheduled) {
@@ -751,7 +784,7 @@ export function computeTrendData(
     let totalScheduled = 0;
     let totalCompleted = 0;
     for (const dk of weekDayKeys) {
-      const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+      const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
       totalScheduled += scheduled.length;
       for (const habit of scheduled) {
         const dayMap = dayStatesByHabit.get(habit.id);
@@ -803,7 +836,7 @@ export function computeCategoryBreakdown(
   const computeCatRate = (catHabits: Habit[], keys: string[]) => {
     let s = 0, c = 0;
     for (const dk of keys) {
-      const scheduledHabits = getScheduledHabitsForDay(catHabits, dk, timeZone);
+      const scheduledHabits = getScheduledHabitsForAnalyticsDay(catHabits, dk, dayStatesByHabit, timeZone);
       s += scheduledHabits.length;
       for (const habit of scheduledHabits) {
         if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) c++;
@@ -818,7 +851,7 @@ export function computeCategoryBreakdown(
     let totalCompleted = 0;
 
     for (const dk of dayKeys) {
-      const scheduledHabits = getScheduledHabitsForDay(catHabits, dk, timeZone);
+      const scheduledHabits = getScheduledHabitsForAnalyticsDay(catHabits, dk, dayStatesByHabit, timeZone);
       totalScheduled += scheduledHabits.length;
       for (const habit of scheduledHabits) {
         if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) totalCompleted++;
@@ -877,7 +910,7 @@ export function computeInsights(
   const dayOfWeekStats = new Array(7).fill(null).map(() => ({ scheduled: 0, completed: 0 }));
   for (const dk of dayKeys) {
     const dow = new Date(dk + 'T12:00:00Z').getUTCDay();
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     dayOfWeekStats[dow].scheduled += scheduled.length;
     for (const habit of scheduled) {
       if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) {
@@ -916,7 +949,7 @@ export function computeInsights(
     let scheduled = 0;
     let completed = 0;
     for (const dk of dayKeys) {
-      if (getScheduledHabitsForDay([habit], dk, timeZone).length > 0) {
+      if (getScheduledHabitsForAnalyticsDay([habit], dk, dayStatesByHabit, timeZone).length > 0) {
         scheduled++;
         if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) completed++;
       }
@@ -950,7 +983,7 @@ export function computeInsights(
     let consecutiveZeroDays = 0;
     for (let i = dayKeys.length - 1; i >= 0; i--) {
       const dk = dayKeys[i];
-      if (getScheduledHabitsForDay([habit], dk, timeZone).length === 0) continue;
+      if (getScheduledHabitsForAnalyticsDay([habit], dk, dayStatesByHabit, timeZone).length === 0) continue;
       if (dayMap?.get(dk)?.completed) break;
       consecutiveZeroDays++;
     }
@@ -998,7 +1031,7 @@ export function computeInsights(
   for (const dk of dayKeys) {
     const dow = new Date(dk + 'T12:00:00Z').getUTCDay();
     const isWeekend = dow === 0 || dow === 6;
-    const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+    const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
     for (const habit of scheduled) {
       if (isWeekend) {
         weekendScheduled++;
@@ -1037,7 +1070,7 @@ export function computeInsights(
     const computeRangeRate = (keys: string[]) => {
       let s = 0, c = 0;
       for (const dk of keys) {
-        const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+        const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
         s += scheduled.length;
         for (const habit of scheduled) {
           if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) c++;
@@ -1164,7 +1197,7 @@ export function computeRoutineAnalytics(
   const computeHabitRate = (keys: string[]) => {
     let s = 0, c = 0;
     for (const dk of keys) {
-      const scheduled = getScheduledHabitsForDay(trackable, dk, timeZone);
+      const scheduled = getScheduledHabitsForAnalyticsDay(trackable, dk, dayStatesByHabit, timeZone);
       s += scheduled.length;
       for (const habit of scheduled) {
         if (dayStatesByHabit.get(habit.id)?.get(dk)?.completed) c++;

--- a/src/server/services/dayViewService.ts
+++ b/src/server/services/dayViewService.ts
@@ -17,6 +17,7 @@ import { evaluateChecklistSuccess } from './checklistSuccessService';
 import { startOfWeek, endOfWeek, parseISO, format } from 'date-fns';
 import { deriveDailyHabitCompletion } from '../../domain/habits/completion';
 import { deriveWeeklyHabitProgress } from '../../domain/habits/weeklyProgress';
+import { hasExplicitWeeklyQuotaOnDay } from './scheduleEngine';
 
 /**
  * Day View Habit Status
@@ -113,6 +114,7 @@ function deriveDailyCompletion(
         !entry.deletedAt &&
         !entry.note?.startsWith('freeze:'),
     ),
+    dayKey,
   );
 }
 
@@ -216,7 +218,7 @@ function deriveBundleCompletion(
   for (const childHabit of childHabits) {
     let childComplete = false;
 
-    if (childHabit.timesPerWeek != null && childHabit.timesPerWeek > 0) {
+    if (hasExplicitWeeklyQuotaOnDay(childHabit, dayKey)) {
       // Weekly child: check if week is complete
       if (weekStartDayKey && weekEndDayKey) {
         const weekProgress = deriveWeeklyProgress(
@@ -336,7 +338,7 @@ export async function computeDayView(
         completedChildrenCount: bundleStatus.completedChildrenCount,
         totalChildrenCount: bundleStatus.totalChildrenCount,
       };
-    } else if (habit.timesPerWeek != null && habit.timesPerWeek > 0) {
+    } else if (hasExplicitWeeklyQuotaOnDay(habit, dayKey)) {
       // Weekly habit: derive week progress
       const weekProgress = deriveWeeklyProgress(
         habit,

--- a/src/server/services/momentumService.test.ts
+++ b/src/server/services/momentumService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { calculateCategoryMomentum, calculateGlobalMomentum } from './momentumService';
+
+describe('momentumService DayKey boundaries', () => {
+  it('anchors the seven-day window to the caller-supplied local day', () => {
+    const logs = [
+      { habitId: 'habit-1', date: '2026-08-02', completed: true },
+      { habitId: 'habit-1', date: '2026-08-01', completed: true },
+      { habitId: 'habit-1', date: '2026-07-27', completed: true },
+      { habitId: 'habit-1', date: '2026-07-26', completed: true },
+    ];
+
+    expect(calculateGlobalMomentum(logs, '2026-08-02')).toEqual({
+      state: 'Building',
+      activeDays: 3,
+    });
+    expect(calculateGlobalMomentum(logs, '2026-08-01')).toEqual({
+      state: 'Building',
+      activeDays: 3,
+    });
+  });
+
+  it('applies the same local boundary to category momentum', () => {
+    const logs = [
+      { habitId: 'included', date: '2026-08-02', completed: true },
+      { habitId: 'excluded', date: '2026-08-01', completed: true },
+      { habitId: 'included', date: '2026-07-26', completed: true },
+    ];
+
+    expect(calculateCategoryMomentum(logs, ['included'], '2026-08-02')).toEqual({
+      state: 'Building',
+      activeDays: 1,
+    });
+  });
+});

--- a/src/server/services/momentumService.ts
+++ b/src/server/services/momentumService.ts
@@ -1,5 +1,6 @@
 import type { GlobalMomentumState, CategoryMomentumState } from '../../types';
-import { subDays, parseISO, isSameDay } from 'date-fns';
+import { format } from 'date-fns';
+import { addDaysToDayKey, isValidDayKey } from '../../domain/time/dayKey';
 
 /** Minimal record for momentum calculations — replaces deprecated DayLog dependency. */
 export interface CompletionRecord {
@@ -22,17 +23,25 @@ export interface CompletionRecord {
  * Calculates the number of "Active Days" in the last 7 days.
  * An active day is any day where at least one habit was completed.
  */
-function calculateActiveDays(logs: CompletionRecord[], windowSize: number = 7, referenceDate: Date = new Date(), filterFn?: (log: CompletionRecord) => boolean): number {
+function calculateActiveDays(
+    logs: CompletionRecord[],
+    windowSize: number = 7,
+    referenceDayKey?: string,
+    filterFn?: (log: CompletionRecord) => boolean,
+): number {
     let activeDaysCount = 0;
+    const reference = referenceDayKey && isValidDayKey(referenceDayKey)
+        ? referenceDayKey
+        : format(new Date(), 'yyyy-MM-dd');
 
     for (let i = 0; i < windowSize; i++) {
-        const dateToCheck = subDays(referenceDate, i);
+        const dayKeyToCheck = addDaysToDayKey(reference, -i);
 
         // Find if any log exists for this day that is completed
         // And matches the filter (e.g. specific category) if provided
         const hasLogs = logs.some(log => {
             if (log.completed !== true) return false;
-            if (!isSameDay(parseISO(log.date), dateToCheck)) return false;
+            if (log.date !== dayKeyToCheck) return false;
 
             if (filterFn) {
                 return filterFn(log);
@@ -48,8 +57,11 @@ function calculateActiveDays(logs: CompletionRecord[], windowSize: number = 7, r
     return activeDaysCount;
 }
 
-export const calculateGlobalMomentum = (logs: CompletionRecord[]): { state: GlobalMomentumState; activeDays: number } => {
-    const activeDays = calculateActiveDays(logs);
+export const calculateGlobalMomentum = (
+    logs: CompletionRecord[],
+    referenceDayKey?: string,
+): { state: GlobalMomentumState; activeDays: number } => {
+    const activeDays = calculateActiveDays(logs, 7, referenceDayKey);
 
     let state: GlobalMomentumState = 'Ready';
 
@@ -64,10 +76,16 @@ export const calculateGlobalMomentum = (logs: CompletionRecord[]): { state: Glob
 
 export const calculateCategoryMomentum = (
     logs: CompletionRecord[],
-    categoryHabitIds: string[]
+    categoryHabitIds: string[],
+    referenceDayKey?: string,
 ): { state: CategoryMomentumState; activeDays: number } => {
 
-    const activeDays = calculateActiveDays(logs, 7, new Date(), (log) => categoryHabitIds.includes(log.habitId));
+    const activeDays = calculateActiveDays(
+        logs,
+        7,
+        referenceDayKey,
+        (log) => categoryHabitIds.includes(log.habitId),
+    );
 
     let state: CategoryMomentumState = 'Paused';
 

--- a/src/server/services/reminderScheduler.ts
+++ b/src/server/services/reminderScheduler.ts
@@ -77,7 +77,7 @@ async function deriveReminderCompletion(
   if (habit.type !== 'bundle') {
     const entries = await getHabitEntriesForDay(habit.id, dayKey, habit.householdId, habit.userId);
     const activeEntries = entries.filter(entry => !entry.note?.startsWith('freeze:'));
-    return deriveDailyHabitCompletion(habit, activeEntries).isComplete;
+    return deriveDailyHabitCompletion(habit, activeEntries, dayKey).isComplete;
   }
 
   const childIds = await resolveChildIdsForDay(habit, dayKey, habit.householdId, habit.userId);
@@ -91,7 +91,7 @@ async function deriveReminderCompletion(
     ]);
     if (!child) continue;
     const activeEntries = entries.filter(entry => !entry.note?.startsWith('freeze:'));
-    if (deriveDailyHabitCompletion(child, activeEntries).isComplete) completedCount++;
+    if (deriveDailyHabitCompletion(child, activeEntries, dayKey).isComplete) completedCount++;
   }
 
   if (habit.bundleType === 'checklist') {

--- a/src/server/services/scheduleEngine.test.ts
+++ b/src/server/services/scheduleEngine.test.ts
@@ -76,6 +76,39 @@ describe('isHabitScheduledOnDay', () => {
     expect(isHabitScheduledOnDay(habit, '2026-03-31', 'UTC')).toBe(false);
   });
 
+  it('uses the schedule revision effective on each historical day', () => {
+    const habit = makeHabit({
+      assignedDays: [2],
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-01-01',
+          goal: { type: 'boolean', frequency: 'daily' },
+          assignedDays: [1],
+        },
+        {
+          effectiveFromDayKey: '2026-04-01',
+          goal: { type: 'boolean', frequency: 'daily' },
+          assignedDays: [2],
+        },
+      ],
+    });
+
+    expect(isHabitScheduledOnDay(habit, '2026-03-30')).toBe(true); // old Monday rule
+    expect(isHabitScheduledOnDay(habit, '2026-04-06')).toBe(false);
+    expect(isHabitScheduledOnDay(habit, '2026-04-07')).toBe(true); // new Tuesday rule
+  });
+
+  it('excludes inactive archive intervals without deleting history', () => {
+    const habit = makeHabit({
+      inactivePeriods: [{ startDayKey: '2026-04-01', endDayKey: '2026-04-03' }],
+    });
+
+    expect(isHabitScheduledOnDay(habit, '2026-03-31')).toBe(true);
+    expect(isHabitScheduledOnDay(habit, '2026-04-01')).toBe(false);
+    expect(isHabitScheduledOnDay(habit, '2026-04-03')).toBe(false);
+    expect(isHabitScheduledOnDay(habit, '2026-04-04')).toBe(true);
+  });
+
   describe('daily habit with assignedDays', () => {
     // Mon=1, Wed=3, Fri=5
     const habit = makeHabit({ assignedDays: [1, 3, 5] });

--- a/src/server/services/scheduleEngine.test.ts
+++ b/src/server/services/scheduleEngine.test.ts
@@ -4,6 +4,7 @@ import {
   isHabitScheduledOnDay,
   getScheduledHabitsForDay,
   getExpectedOpportunitiesInRange,
+  usesWeeklyQuotaStreak,
 } from './scheduleEngine';
 import type { Habit } from '../../models/persistenceTypes';
 
@@ -33,6 +34,20 @@ describe('isTrackableHabit', () => {
 
   it('returns false for soft-deleted habits', () => {
     expect(isTrackableHabit(makeHabit({ deletedAt: '2026-03-30T12:00:00Z' }))).toBe(false);
+  });
+});
+
+describe('usesWeeklyQuotaStreak', () => {
+  const cases: Array<[string, Partial<Habit>, boolean]> = [
+    ['explicit weekly quota', { timesPerWeek: 3 }, true],
+    ['strict every-day schedule', { assignedDays: [0, 1, 2, 3, 4, 5, 6], requiredDaysPerWeek: 7 }, false],
+    ['strict custom weekdays', { assignedDays: [1, 3, 5], requiredDaysPerWeek: 3 }, false],
+    ['flexible schedule with a grace day', { assignedDays: [1, 2, 3, 4, 5], requiredDaysPerWeek: 4 }, true],
+    ['assigned days without a weekly requirement', { assignedDays: [1, 3, 5] }, false],
+  ];
+
+  it.each(cases)('classifies %s', (_label, schedule, expected) => {
+    expect(usesWeeklyQuotaStreak(makeHabit(schedule))).toBe(expected);
   });
 });
 

--- a/src/server/services/scheduleEngine.ts
+++ b/src/server/services/scheduleEngine.ts
@@ -2,8 +2,11 @@
 export {
   getHabitCreatedDayKey,
   getExpectedOpportunitiesInRange,
+  getWeeklyQuotaTargetOnDay,
   getScheduledHabitsForDay,
+  hasExplicitWeeklyQuotaOnDay,
   isHabitScheduledOnDay,
   isTrackableHabit,
+  matchesHabitScheduleOnDay,
   usesWeeklyQuotaStreak,
 } from '../../domain/habits/schedule';

--- a/src/server/services/scheduleEngine.ts
+++ b/src/server/services/scheduleEngine.ts
@@ -5,4 +5,5 @@ export {
   getScheduledHabitsForDay,
   isHabitScheduledOnDay,
   isTrackableHabit,
+  usesWeeklyQuotaStreak,
 } from '../../domain/habits/schedule';

--- a/src/server/services/streakService.test.ts
+++ b/src/server/services/streakService.test.ts
@@ -109,7 +109,7 @@ describe('streakService', () => {
     expect(metrics.completedToday).toBe(false);
   });
 
-  it('does not include records from before the habit was created', () => {
+  it('lets a real backdated entry start history without inventing earlier misses', () => {
     const habit = createHabit({ createdAt: '2026-02-10T18:00:00.000Z' });
     const dayStates: HabitDayState[] = [
       { dayKey: '2026-02-08', value: 1, completed: true },
@@ -119,8 +119,8 @@ describe('streakService', () => {
 
     const metrics = calculateHabitStreakMetrics(habit, dayStates, parseISO('2026-02-11'), '2026-02-11');
 
-    expect(metrics.currentStreak).toBe(1);
-    expect(metrics.bestStreak).toBe(1);
+    expect(metrics.currentStreak).toBe(3);
+    expect(metrics.bestStreak).toBe(3);
     expect(metrics.lastCompletedDayKey).toBe('2026-02-10');
   });
 
@@ -400,6 +400,130 @@ describe('streakService', () => {
     expect(metrics.lastCompletedDayKey).toBe('2026-02-24');
     expect(metrics.completedToday).toBe(false);
     expect(metrics.atRisk).toBe(true);
+  });
+
+  it('skips restored-habit inactive days without breaking the daily streak', () => {
+    const habit = createHabit({
+      createdAt: '2026-02-23T12:00:00.000Z',
+      inactivePeriods: [{ startDayKey: '2026-02-24', endDayKey: '2026-02-25' }],
+    });
+    const dayStates: HabitDayState[] = [
+      { dayKey: '2026-02-23', value: 1, completed: true },
+      { dayKey: '2026-02-26', value: 1, completed: true },
+    ];
+
+    const metrics = calculateHabitStreakMetrics(
+      habit,
+      dayStates,
+      parseISO('2026-02-27'),
+      '2026-02-27',
+    );
+
+    expect(metrics.currentStreak).toBe(2);
+    expect(metrics.bestStreak).toBe(2);
+    expect(metrics.atRisk).toBe(true);
+  });
+
+  it('skips a paused weekly period without breaking a weekly streak', () => {
+    const habit = createHabit({
+      createdAt: '2026-02-02T12:00:00.000Z',
+      timesPerWeek: 2,
+      inactivePeriods: [{ startDayKey: '2026-02-09', endDayKey: '2026-02-15' }],
+    });
+    const dayStates: HabitDayState[] = [
+      { dayKey: '2026-02-02', value: 1, completed: true },
+      { dayKey: '2026-02-03', value: 1, completed: true },
+      { dayKey: '2026-02-16', value: 1, completed: true },
+      { dayKey: '2026-02-17', value: 1, completed: true },
+    ];
+
+    const metrics = calculateHabitStreakMetrics(
+      habit,
+      dayStates,
+      parseISO('2026-02-20'),
+      '2026-02-20',
+    );
+
+    expect(metrics.currentStreak).toBe(2);
+    expect(metrics.bestStreak).toBe(2);
+    expect(metrics.weekSatisfied).toBe(true);
+  });
+
+  it('uses the quota target that applied to each historical week', () => {
+    const habit = createHabit({
+      createdAt: '2026-02-02T12:00:00.000Z',
+      timesPerWeek: 3,
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-02-02',
+          goal: { type: 'boolean', frequency: 'daily' },
+          timesPerWeek: 2,
+        },
+        {
+          effectiveFromDayKey: '2026-02-16',
+          goal: { type: 'boolean', frequency: 'daily' },
+          timesPerWeek: 3,
+        },
+      ],
+    });
+    const dayStates: HabitDayState[] = [
+      { dayKey: '2026-02-02', value: 1, completed: true },
+      { dayKey: '2026-02-03', value: 1, completed: true },
+      { dayKey: '2026-02-09', value: 1, completed: true },
+      { dayKey: '2026-02-10', value: 1, completed: true },
+      { dayKey: '2026-02-16', value: 1, completed: true },
+      { dayKey: '2026-02-17', value: 1, completed: true },
+      { dayKey: '2026-02-18', value: 1, completed: true },
+    ];
+
+    const metrics = calculateHabitStreakMetrics(
+      habit,
+      dayStates,
+      parseISO('2026-02-20'),
+      '2026-02-20',
+    );
+
+    expect(metrics.currentStreak).toBe(3);
+    expect(metrics.bestStreak).toBe(3);
+    expect(metrics.weekTarget).toBe(3);
+  });
+
+  it('starts a new comparable streak segment when the streak unit changes', () => {
+    const habit = createHabit({
+      createdAt: '2026-02-02T12:00:00.000Z',
+      timesPerWeek: 2,
+      trackingRevisions: [
+        {
+          effectiveFromDayKey: '2026-02-02',
+          goal: { type: 'boolean', frequency: 'daily' },
+        },
+        {
+          effectiveFromDayKey: '2026-02-16',
+          goal: { type: 'boolean', frequency: 'daily' },
+          timesPerWeek: 2,
+        },
+      ],
+    });
+    const dayStates: HabitDayState[] = [
+      ...Array.from({ length: 10 }, (_, index) => ({
+        dayKey: `2026-02-${String(index + 2).padStart(2, '0')}`,
+        value: 1,
+        completed: true,
+      })),
+      { dayKey: '2026-02-16', value: 1, completed: true },
+      { dayKey: '2026-02-17', value: 1, completed: true },
+    ];
+
+    const metrics = calculateHabitStreakMetrics(
+      habit,
+      dayStates,
+      parseISO('2026-02-20'),
+      '2026-02-20',
+    );
+
+    expect(metrics.currentStreak).toBe(1);
+    expect(metrics.bestStreak).toBe(1);
+    expect(metrics.weekTarget).toBe(2);
   });
 
   it('does not let future completions satisfy the current weekly quota', () => {

--- a/src/server/services/streakService.test.ts
+++ b/src/server/services/streakService.test.ts
@@ -125,6 +125,56 @@ describe('streakService', () => {
   });
 
   describe('scheduled daily habits (assignedDays + requiredDaysPerWeek)', () => {
+    it('counts strict all-day schedules as consecutive daily opportunities', () => {
+      const habit = createHabit({
+        goal: { type: 'boolean', frequency: 'daily', target: 1 },
+        assignedDays: [0, 1, 2, 3, 4, 5, 6],
+        requiredDaysPerWeek: 7,
+      });
+      const dayStates: HabitDayState[] = Array.from({ length: 10 }, (_, index) => ({
+        dayKey: `2026-02-${String(index + 10).padStart(2, '0')}`,
+        value: 1,
+        completed: true,
+      }));
+
+      const metrics = calculateHabitStreakMetrics(
+        habit,
+        dayStates,
+        parseISO('2026-02-19'),
+        '2026-02-19',
+      );
+
+      expect(metrics.currentStreak).toBe(10);
+      expect(metrics.bestStreak).toBe(10);
+      expect(metrics.weekSatisfied).toBeUndefined();
+      expect(metrics.weekProgress).toBeUndefined();
+    });
+
+    it('counts strict custom schedules by scheduled occurrence, not calendar adjacency', () => {
+      const habit = createHabit({
+        goal: { type: 'boolean', frequency: 'daily', target: 1 },
+        assignedDays: [1, 3, 5],
+        requiredDaysPerWeek: 3,
+      });
+      const dayStates: HabitDayState[] = [
+        { dayKey: '2026-02-09', value: 1, completed: true }, // Monday
+        { dayKey: '2026-02-11', value: 1, completed: true }, // Wednesday
+        { dayKey: '2026-02-13', value: 1, completed: true }, // Friday
+        { dayKey: '2026-02-16', value: 1, completed: true }, // Monday
+      ];
+
+      const metrics = calculateHabitStreakMetrics(
+        habit,
+        dayStates,
+        parseISO('2026-02-17'),
+        '2026-02-17',
+      );
+
+      expect(metrics.currentStreak).toBe(4);
+      expect(metrics.bestStreak).toBe(4);
+      expect(metrics.weekSatisfied).toBeUndefined();
+    });
+
     it('counts consecutive weeks where completions >= requiredDaysPerWeek', () => {
       const habit = createHabit({
         goal: { type: 'boolean', frequency: 'daily', target: 1 },
@@ -153,7 +203,7 @@ describe('streakService', () => {
       expect(metrics.weekTarget).toBe(2);
     });
 
-    it('does not count completions on non-assigned days toward the weekly threshold', () => {
+    it('does not count completions on non-assigned days for a strict schedule', () => {
       const habit = createHabit({
         goal: { type: 'boolean', frequency: 'daily', target: 1 },
         assignedDays: [0], // Sunday only
@@ -167,8 +217,9 @@ describe('streakService', () => {
       const metrics = calculateHabitStreakMetrics(habit, dayStates, parseISO('2026-02-20'));
 
       expect(metrics.currentStreak).toBe(0);
-      expect(metrics.weekSatisfied).toBe(false);
-      expect(metrics.weekProgress).toBe(0);
+      expect(metrics.bestStreak).toBe(0);
+      expect(metrics.weekSatisfied).toBeUndefined();
+      expect(metrics.weekProgress).toBeUndefined();
     });
 
     it('breaks streak when a week has no completions', () => {
@@ -249,7 +300,7 @@ describe('streakService', () => {
     it('marks atRisk when streak active but current week unsatisfied with <= 2 days left', () => {
       const habit = createHabit({
         goal: { type: 'boolean', frequency: 'daily', target: 1 },
-        assignedDays: [1, 3, 5],
+        assignedDays: [1, 2, 3, 4, 5],
         requiredDaysPerWeek: 3,
       });
       const dayStates: HabitDayState[] = [

--- a/src/server/services/streakService.ts
+++ b/src/server/services/streakService.ts
@@ -8,9 +8,11 @@ import {
 } from '../../domain/time/dayKey';
 import {
   getHabitCreatedDayKey,
-  isHabitScheduledOnDay,
+  getWeeklyQuotaTargetOnDay,
+  matchesHabitScheduleOnDay,
   usesWeeklyQuotaStreak,
 } from './scheduleEngine';
+import { isHabitInactiveOnDay } from '../../domain/habits/trackingHistory';
 
 export interface HabitDayState {
   dayKey: string;
@@ -35,6 +37,7 @@ export interface HabitStreakMetrics {
 type WeeklyProgress = {
   progress: number;
   satisfied: boolean;
+  target: number;
 };
 
 function dateToLocalDayKey(date: Date): string {
@@ -44,36 +47,26 @@ function dateToLocalDayKey(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function filterStatesToHabitLifetime(
+function filterStatesToReferenceDay(
   dayStates: HabitDayState[],
-  createdDayKey: string | null,
   referenceDayKey: string,
 ): HabitDayState[] {
   return dayStates.filter(state => (
     isValidDayKey(state.dayKey)
     && state.dayKey <= referenceDayKey
-    && (!createdDayKey || state.dayKey >= createdDayKey)
   ));
 }
 
-function calculateBestConsecutiveSpan(dayKeys: string[], stepInDays: number): number {
-  if (dayKeys.length === 0) return 0;
-
-  const sorted = [...new Set(dayKeys)].sort();
-  let best = 1;
-  let current = 1;
-
-  for (let i = 1; i < sorted.length; i++) {
-    const difference = differenceInDayKeys(sorted[i], sorted[i - 1]);
-    if (difference === stepInDays) {
-      current += 1;
-      best = Math.max(best, current);
-    } else if (difference > stepInDays) {
-      current = 1;
-    }
+function getTrackingStartDayKey(
+  createdDayKey: string | null,
+  dayStates: HabitDayState[],
+  referenceDayKey: string,
+): string {
+  const earliestRecordedDayKey = dayStates.map(state => state.dayKey).sort()[0];
+  if (createdDayKey && earliestRecordedDayKey) {
+    return createdDayKey < earliestRecordedDayKey ? createdDayKey : earliestRecordedDayKey;
   }
-
-  return best;
+  return createdDayKey ?? earliestRecordedDayKey ?? referenceDayKey;
 }
 
 function qualifiesForStreak(state: HabitDayState): boolean {
@@ -88,6 +81,22 @@ function getLastCompletedDayKey(dayStates: HabitDayState[]): string | null {
   return completedDayKeys.at(-1) ?? null;
 }
 
+/** A daily↔weekly streak-unit change starts a new comparable streak segment. */
+function getCurrentStreakModeStartDayKey(
+  habit: Habit,
+  createdDayKey: string,
+  referenceDayKey: string,
+): string {
+  const currentUsesWeeklyQuota = usesWeeklyQuotaStreak(habit, referenceDayKey);
+  let cursor = referenceDayKey;
+  while (cursor > createdDayKey) {
+    const previousDayKey = addDaysToDayKey(cursor, -1);
+    if (usesWeeklyQuotaStreak(habit, previousDayKey) !== currentUsesWeeklyQuota) break;
+    cursor = previousDayKey;
+  }
+  return cursor < createdDayKey ? createdDayKey : cursor;
+}
+
 /**
  * Daily streaks count scheduled opportunities, not adjacent calendar days.
  * A freeze protects an opportunity but is not itself reported as completion.
@@ -99,7 +108,7 @@ function calculateOpportunityMetrics(
   timeZone?: string,
 ): HabitStreakMetrics {
   const createdDayKey = getHabitCreatedDayKey(habit, timeZone);
-  const eligibleStates = filterStatesToHabitLifetime(dayStates, createdDayKey, referenceDayKey);
+  const eligibleStates = filterStatesToReferenceDay(dayStates, referenceDayKey);
   const protectedDayKeys = new Set(
     eligibleStates
       .filter(state => qualifiesForStreak(state) || state.isFrozen)
@@ -109,14 +118,24 @@ function calculateOpportunityMetrics(
     eligibleStates.filter(state => state.completed).map(state => state.dayKey),
   );
 
-  const effectiveCreatedDayKey = createdDayKey
-    ?? eligibleStates.map(state => state.dayKey).sort()[0]
-    ?? referenceDayKey;
+  // A real backdated/imported entry is evidence that tracking started before
+  // the habit document was created. Start at the earlier boundary, but never
+  // invent missed opportunities before the first such record.
+  const lifetimeStartDayKey = getTrackingStartDayKey(
+    createdDayKey,
+    eligibleStates,
+    referenceDayKey,
+  );
+  const effectiveCreatedDayKey = getCurrentStreakModeStartDayKey(
+    habit,
+    lifetimeStartDayKey,
+    referenceDayKey,
+  );
   const opportunityDayKeys: string[] = [];
   const totalCalendarDays = differenceInDayKeys(referenceDayKey, effectiveCreatedDayKey) + 1;
   for (let offset = 0; offset < totalCalendarDays; offset++) {
     const dayKey = addDaysToDayKey(effectiveCreatedDayKey, offset);
-    if (isHabitScheduledOnDay(habit, dayKey, timeZone)) opportunityDayKeys.push(dayKey);
+    if (matchesHabitScheduleOnDay(habit, dayKey)) opportunityDayKeys.push(dayKey);
   }
 
   let bestStreak = 0;
@@ -158,14 +177,12 @@ function calculateOpportunityMetrics(
 function buildWeeklyProgressMap(
   dayStates: HabitDayState[],
   habit: Habit,
-  target: number,
-  timeZone?: string,
 ): Map<string, WeeklyProgress> {
   const protectedDaysByWeek = new Map<string, Set<string>>();
 
   for (const dayState of dayStates) {
     if (!(qualifiesForStreak(dayState) || dayState.isFrozen)) continue;
-    if (!dayState.isFrozen && !isHabitScheduledOnDay(habit, dayState.dayKey, timeZone)) continue;
+    if (!dayState.isFrozen && !matchesHabitScheduleOnDay(habit, dayState.dayKey)) continue;
     const weekKey = getIsoWeekStartDayKey(dayState.dayKey);
     const protectedDays = protectedDaysByWeek.get(weekKey) ?? new Set<string>();
     protectedDays.add(dayState.dayKey);
@@ -175,45 +192,90 @@ function buildWeeklyProgressMap(
   const weeklyMap = new Map<string, WeeklyProgress>();
   for (const [weekKey, protectedDays] of protectedDaysByWeek) {
     const progress = protectedDays.size;
-    weeklyMap.set(weekKey, { progress, satisfied: progress >= target });
+    const target = getWeeklyQuotaTargetOnDay(habit, addDaysToDayKey(weekKey, 6)) ?? 1;
+    weeklyMap.set(weekKey, { progress, satisfied: progress >= target, target });
   }
   return weeklyMap;
+}
+
+function getEligibleWeeklyPeriodKeys(
+  habit: Habit,
+  createdWeekKey: string,
+  currentWeekKey: string,
+): string[] {
+  const eligible: string[] = [];
+  for (let weekKey = createdWeekKey; weekKey <= currentWeekKey; weekKey = addDaysToDayKey(weekKey, 7)) {
+    const weekEndDayKey = addDaysToDayKey(weekKey, 6);
+    if (!usesWeeklyQuotaStreak(habit, weekEndDayKey)) continue;
+
+    let hasScheduledDay = false;
+    let intersectsInactivePeriod = false;
+    for (let offset = 0; offset < 7; offset++) {
+      const dayKey = addDaysToDayKey(weekKey, offset);
+      if (isHabitInactiveOnDay(habit, dayKey)) intersectsInactivePeriod = true;
+      if (matchesHabitScheduleOnDay(habit, dayKey)) hasScheduledDay = true;
+    }
+
+    // A week touched by an archive/restore interval is excused as one unit.
+    if (hasScheduledDay && !intersectsInactivePeriod) eligible.push(weekKey);
+  }
+  return eligible;
 }
 
 function calculateWeeklyMetrics(
   dayStates: HabitDayState[],
   habit: Habit,
   referenceDayKey: string,
-  target: number,
   timeZone?: string,
 ): HabitStreakMetrics {
   const createdDayKey = getHabitCreatedDayKey(habit, timeZone);
-  const eligibleStates = filterStatesToHabitLifetime(dayStates, createdDayKey, referenceDayKey);
-  const weeklyProgressMap = buildWeeklyProgressMap(eligibleStates, habit, target, timeZone);
+  const eligibleStates = filterStatesToReferenceDay(dayStates, referenceDayKey);
   const currentWeekKey = getIsoWeekStartDayKey(referenceDayKey);
-  const createdWeekKey = getIsoWeekStartDayKey(createdDayKey ?? referenceDayKey);
-  const currentWeek = weeklyProgressMap.get(currentWeekKey) ?? { progress: 0, satisfied: false };
+  const lifetimeStartDayKey = getTrackingStartDayKey(
+    createdDayKey,
+    eligibleStates,
+    referenceDayKey,
+  );
+  const modeStartDayKey = getCurrentStreakModeStartDayKey(
+    habit,
+    lifetimeStartDayKey,
+    referenceDayKey,
+  );
+  const modeEligibleStates = eligibleStates.filter(state => state.dayKey >= modeStartDayKey);
+  const weeklyProgressMap = buildWeeklyProgressMap(modeEligibleStates, habit);
+  const createdWeekKey = getIsoWeekStartDayKey(modeStartDayKey);
+  const currentTarget = getWeeklyQuotaTargetOnDay(habit, addDaysToDayKey(currentWeekKey, 6)) ?? 1;
+  const currentWeek = weeklyProgressMap.get(currentWeekKey) ?? {
+    progress: 0,
+    satisfied: false,
+    target: currentTarget,
+  };
+  const eligibleWeekKeys = getEligibleWeeklyPeriodKeys(
+    habit,
+    createdWeekKey,
+    currentWeekKey,
+  );
+  const currentWeekIndex = eligibleWeekKeys.indexOf(currentWeekKey);
 
   let currentStreak = 0;
-  let cursorWeekKey = currentWeek.satisfied
-    ? currentWeekKey
-    : addDaysToDayKey(currentWeekKey, -7);
-  while (
-    cursorWeekKey >= createdWeekKey
-    && weeklyProgressMap.get(cursorWeekKey)?.satisfied
-  ) {
+  let cursorIndex = currentWeekIndex >= 0
+    ? currentWeekIndex - (currentWeek.satisfied ? 0 : 1)
+    : eligibleWeekKeys.length - 1;
+  while (cursorIndex >= 0 && weeklyProgressMap.get(eligibleWeekKeys[cursorIndex])?.satisfied) {
     currentStreak += 1;
-    cursorWeekKey = addDaysToDayKey(cursorWeekKey, -7);
+    cursorIndex -= 1;
   }
 
-  const satisfiedWeekKeys = [...weeklyProgressMap.entries()]
-    .filter(([weekKey, value]) => (
-      weekKey >= createdWeekKey
-      && weekKey <= currentWeekKey
-      && value.satisfied
-    ))
-    .map(([weekKey]) => weekKey);
-  const bestStreak = calculateBestConsecutiveSpan(satisfiedWeekKeys, 7);
+  let bestStreak = 0;
+  let span = 0;
+  for (const weekKey of eligibleWeekKeys) {
+    if (weeklyProgressMap.get(weekKey)?.satisfied) {
+      span += 1;
+      bestStreak = Math.max(bestStreak, span);
+    } else {
+      span = 0;
+    }
+  }
 
   const completedToday = eligibleStates.some(
     state => state.dayKey === referenceDayKey && state.completed,
@@ -225,17 +287,18 @@ function calculateWeeklyMetrics(
     bestStreak,
     lastCompletedDayKey: getLastCompletedDayKey(eligibleStates),
     completedToday,
-    atRisk: currentStreak > 0 && !currentWeek.satisfied && daysLeftInWeek <= 2,
+    atRisk: currentStreak > 0 && currentWeekIndex >= 0 && !currentWeek.satisfied && daysLeftInWeek <= 2,
     weekSatisfied: currentWeek.satisfied,
     weekProgress: currentWeek.progress,
-    weekTarget: target,
+    weekTarget: currentWeek.target,
   };
 }
 
 /**
  * Calculate canonical streak metrics from day-level completion derived from
  * HabitEntries. The caller-supplied DayKey is the calendar boundary; future
- * states and states before habit creation are excluded.
+ * states are excluded. A backdated/imported state may precede `createdAt` and
+ * becomes the first evidenced opportunity instead of being discarded.
  */
 export function calculateHabitStreakMetrics(
   habit: Habit,
@@ -247,13 +310,11 @@ export function calculateHabitStreakMetrics(
   const referenceDay = referenceDayKey
     ?? (timeZone ? formatDayKeyFromDate(referenceDate, timeZone) : dateToLocalDayKey(referenceDate));
 
-  if (usesWeeklyQuotaStreak(habit)) {
-    const target = habit.timesPerWeek ?? habit.requiredDaysPerWeek ?? 1;
+  if (usesWeeklyQuotaStreak(habit, referenceDay)) {
     return calculateWeeklyMetrics(
       dayStates,
       habit,
       referenceDay,
-      target,
       timeZone,
     );
   }

--- a/src/server/services/streakService.ts
+++ b/src/server/services/streakService.ts
@@ -6,7 +6,11 @@ import {
   getIsoWeekStartDayKey,
   isValidDayKey,
 } from '../../domain/time/dayKey';
-import { getHabitCreatedDayKey, isHabitScheduledOnDay } from './scheduleEngine';
+import {
+  getHabitCreatedDayKey,
+  isHabitScheduledOnDay,
+  usesWeeklyQuotaStreak,
+} from './scheduleEngine';
 
 export interface HabitDayState {
   dayKey: string;
@@ -243,16 +247,13 @@ export function calculateHabitStreakMetrics(
   const referenceDay = referenceDayKey
     ?? (timeZone ? formatDayKeyFromDate(referenceDate, timeZone) : dateToLocalDayKey(referenceDate));
 
-  if (habit.timesPerWeek != null && habit.timesPerWeek > 0) {
-    return calculateWeeklyMetrics(dayStates, habit, referenceDay, habit.timesPerWeek, timeZone);
-  }
-
-  if (habit.assignedDays?.length && habit.requiredDaysPerWeek != null) {
+  if (usesWeeklyQuotaStreak(habit)) {
+    const target = habit.timesPerWeek ?? habit.requiredDaysPerWeek ?? 1;
     return calculateWeeklyMetrics(
       dayStates,
       habit,
       referenceDay,
-      habit.requiredDaysPerWeek,
+      target,
       timeZone,
     );
   }

--- a/src/shared/habitTracking.ts
+++ b/src/shared/habitTracking.ts
@@ -1,0 +1,26 @@
+export interface HabitTrackingGoal {
+  type: 'boolean' | 'number';
+  target?: number;
+  unit?: string;
+  frequency: 'daily' | 'total';
+}
+
+/**
+ * Tracking rules that became effective on one local calendar day.
+ *
+ * Revisions live on the habit document. They preserve how existing entries
+ * were interpreted without copying or rewriting HabitEntry history.
+ */
+export interface HabitTrackingRevision {
+  effectiveFromDayKey: string;
+  goal: HabitTrackingGoal;
+  assignedDays?: number[];
+  timesPerWeek?: number;
+  requiredDaysPerWeek?: number;
+}
+
+/** Inclusive local-day interval during which a restored habit was inactive. */
+export interface HabitInactivePeriod {
+  startDayKey: string;
+  endDayKey?: string;
+}

--- a/src/store/HabitContext.tsx
+++ b/src/store/HabitContext.tsx
@@ -412,11 +412,12 @@ export const HabitProvider: React.FC<{
                 return deriveDailyHabitCompletion(
                     child!,
                     childLog ? [{ value: childLog.value }] : [],
+                    date,
                 ).isComplete;
             });
             const completionValues = new Map<string, number>();
             for (const child of childHabits) {
-                const value = getCompletionEntryValue(child!);
+                const value = getCompletionEntryValue(child!, date);
                 if (value === null) {
                     setLastPersistenceError(`"${child!.name}" needs a valid numeric target before the bundle can be completed.`);
                     return;
@@ -549,7 +550,7 @@ export const HabitProvider: React.FC<{
         const habit = habits.find(h => h.id === habitId);
         if (!habit) return;
 
-        const completed = deriveDailyHabitCompletion(habit, [{ value }]).isComplete;
+        const completed = deriveDailyHabitCompletion(habit, [{ value }], date).isComplete;
 
         const logToSave: DayLog = { habitId, date, value, completed };
         const updatedLogs = {
@@ -861,7 +862,7 @@ export const HabitProvider: React.FC<{
             const habit = habits.find(h => h.id === habitId);
             const value = data.value;
             const completed = habit
-                ? deriveDailyHabitCompletion(habit, [{ value }]).isComplete
+                ? deriveDailyHabitCompletion(habit, [{ value }], dateKey).isComplete
                 : false;
             setLogs(prev => ({
                 ...prev,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { HabitInactivePeriod, HabitTrackingRevision } from '../shared/habitTracking';
+
 export interface Category {
     id: string;
     name: string;
@@ -42,7 +44,7 @@ export interface HabitGoal {
     type: 'boolean' | 'number';
     target?: number; // e.g., 8 (hours), 2000 (calories)
     unit?: string; // e.g., 'hrs', 'kcal'
-    frequency: 'daily' | 'total';
+    frequency: 'daily' | 'total'; // 'total' affects cumulative goal aggregation; habit-day completion stays target-based
 }
 
 export interface Habit {
@@ -58,6 +60,10 @@ export interface Habit {
     archivedAt?: string;
     /** Why the habit is archived. 'user' = user-driven (persists); 'category_deleted' = system (auto-recovered). */
     archivedReason?: 'user' | 'category_deleted';
+    /** Historical completion/schedule rules, recorded only when those rules change. */
+    trackingRevisions?: HabitTrackingRevision[];
+    /** Closed/open local-day ranges excluded from restored-habit opportunities. */
+    inactivePeriods?: HabitInactivePeriod[];
     /** Soft delete marker. Backend filters these out of the active list, so frontend rarely sees it set. */
     deletedAt?: string;
     createdAt: string;

--- a/src/utils/habitAggregation.ts
+++ b/src/utils/habitAggregation.ts
@@ -1,6 +1,7 @@
 import type { Habit, HabitEntry } from '../models/persistenceTypes';
 import { evaluateChecklistSuccess } from '../shared/checklistSuccessRule';
 import { deriveDailyHabitCompletion } from '../domain/habits/completion';
+import { hasExplicitWeeklyQuotaOnDay } from '../domain/habits/schedule';
 import { deriveWeeklyHabitProgress, getIsoWeekEndDayKey } from '../domain/habits/weeklyProgress';
 import { getIsoWeekStartDayKey } from '../domain/time/dayKey';
 
@@ -41,7 +42,7 @@ export function computeHabitStatus(
     const activeEntries = allEntries.filter(entry => !entry.deletedAt && !entry.note?.startsWith('freeze:'));
 
     // 1. Weekly-quota Habit Logic
-    if (habit.timesPerWeek != null && habit.timesPerWeek > 0) {
+    if (hasExplicitWeeklyQuotaOnDay(habit, dateKey)) {
         const weekStartDayKey = getIsoWeekStartDayKey(dateKey);
         return deriveWeeklyHabitProgress(
             habit,
@@ -86,7 +87,7 @@ export function computeHabitStatus(
             // Legacy in-memory schemas may omit the required goal object.
             // Persisted habits are validated and always use canonical derivation.
             const childComplete = child.goal
-                ? deriveDailyHabitCompletion(child, childEntries).isComplete
+                ? deriveDailyHabitCompletion(child, childEntries, dateKey).isComplete
                 : childEntries.length > 0;
             if (childComplete) completedCount++;
         });
@@ -114,5 +115,6 @@ export function computeHabitStatus(
     return deriveDailyHabitCompletion(
         habit,
         activeEntries.filter(entry => entry.habitId === habit.id && entry.dateKey === dateKey),
+        dateKey,
     );
 }

--- a/src/utils/habitRingProgress.test.ts
+++ b/src/utils/habitRingProgress.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 import {
     getRootHabits,
     isHabitComplete,
+    isHabitCompleteOnDay,
     getDailyHabitRingProgress,
     getTodayHabitStats,
     getBundleChildIds,
@@ -410,6 +411,24 @@ describe('Edge cases', () => {
         ];
         const result = getDailyHabitRingProgress(habits, {}, DATE);
         expect(result.total).toBe(3); // daily + timesPerWeek + total
+    });
+
+    it('distinguishes weekly quota status from activity on a specific day', () => {
+        const habit = makeHabit({
+            id: 'h-weekly',
+            name: 'Weekly quota habit',
+            timesPerWeek: 3,
+        });
+        const logs = Object.fromEntries([
+            makeLog(habit.id, '2026-03-23', true),
+            makeLog(habit.id, '2026-03-24', true),
+            makeLog(habit.id, '2026-03-25', true),
+        ]);
+
+        // Saturday shares the satisfied week, but no habit entry occurred then.
+        expect(isHabitComplete(habit, logs, DATE)).toBe(true);
+        expect(isHabitCompleteOnDay(habit, logs, DATE)).toBe(false);
+        expect(isHabitCompleteOnDay(habit, logs, '2026-03-24')).toBe(true);
     });
 
     // --- assignedDays schedule filtering ---

--- a/src/utils/habitUtils.ts
+++ b/src/utils/habitUtils.ts
@@ -63,12 +63,12 @@ export function flattenHabitList(
 
                 // Map Metric Config to Habit Goal
                 // If required: number goal. If none: boolean goal.
-                const virtualGoal = {
+                const virtualGoal: Habit['goal'] = {
                     ...habit.goal, // inherited frequency/target? No, target is per-entry.
                     type: metricMode === 'required' ? 'number' : 'boolean',
                     unit: opt.metricConfig?.unit,
                     target: 0 // Target is arbitrary here, we just want the UI type
-                } as any;
+                };
 
                 return {
                     id: `virtual-${habit.id}-${opt.id}`, // Stable synthetic ID
@@ -77,13 +77,7 @@ export function flattenHabitList(
                     goal: virtualGoal,
                     archived: false,
                     createdAt: habit.createdAt,
-                    type: 'bundle-option-virtual' as any, // Or just 'boolean'/'number'? Let's keep 'bundle' or 'boolean' to not break renderers? 
-                    // Actually, let's use the GOAL type to drive the renderer (checkbox vs #). 
-                    // But we need to flag it as virtual.
-                    // Let's say type = 'boolean' or 'number' based on goal.
-                    // But `isVirtual` flag handles the "Italic" styling.
-
-                    // Actually, for TrackerGrid persistence, it relies on `isVirtual`.
+                    type: metricMode === 'required' ? 'number' : 'boolean',
                     isVirtual: true,
                     associatedOptionId: opt.id,
                     bundleParentId: habit.id,
@@ -294,6 +288,23 @@ export function isHabitComplete(
             getIsoWeekEndDayKey(weekStartDayKey),
             weekEntries,
         ).isComplete;
+    }
+
+    return isHabitCompleteOnDay(habit, logs, date);
+}
+
+/**
+ * Whether this habit had a completed occurrence on one specific calendar day.
+ * Unlike isHabitComplete(), this never paints every day in a satisfied weekly
+ * quota as complete, so it is the correct semantic for activity heatmaps.
+ */
+export function isHabitCompleteOnDay(
+    habit: Habit,
+    logs: Record<string, DayLog>,
+    date: string
+): boolean {
+    if (habit.type === 'bundle' && habit.subHabitIds && habit.subHabitIds.length > 0) {
+        return computeBundleStatus(habit, logs, date).completed;
     }
 
     const log = logs[`${habit.id}-${date}`];

--- a/src/utils/habitUtils.ts
+++ b/src/utils/habitUtils.ts
@@ -3,7 +3,7 @@ import { evaluateChecklistSuccess } from '../shared/checklistSuccessRule';
 import { deriveDailyHabitCompletion } from '../domain/habits/completion';
 import { deriveWeeklyHabitProgress, getIsoWeekEndDayKey } from '../domain/habits/weeklyProgress';
 import { getIsoWeekStartDayKey } from '../domain/time/dayKey';
-import { isHabitScheduledOnDay } from '../domain/habits/schedule';
+import { hasExplicitWeeklyQuotaOnDay, isHabitScheduledOnDay } from '../domain/habits/schedule';
 
 
 export interface FlattenedHabitItem {
@@ -277,7 +277,7 @@ export function isHabitComplete(
         return computeBundleStatus(habit, logs, date).completed;
     }
 
-    if (habit.timesPerWeek != null && habit.timesPerWeek > 0) {
+    if (hasExplicitWeeklyQuotaOnDay(habit, date)) {
         const weekStartDayKey = getIsoWeekStartDayKey(date);
         const weekEntries = Object.values(logs)
             .filter(log => log.habitId === habit.id)
@@ -311,7 +311,7 @@ export function isHabitCompleteOnDay(
     if (!log) return false;
     if (log.isFrozen) return false;
 
-    return deriveDailyHabitCompletion(habit, [{ value: log.value }]).isComplete;
+    return deriveDailyHabitCompletion(habit, [{ value: log.value }], date).isComplete;
 }
 
 export interface TodayHabitStats {


### PR DESCRIPTION
## Summary

- Keeps the Today, Schedule, and dashboard UI mounted during background entry refreshes
- Keeps typed numeric values and actions visible in narrow mobile popovers
- Calculates activity heatmaps from exact-day entries and strict schedule streaks from scheduled occurrences
- Removes inline per-cell trash controls while retaining established clear and delete paths
- Documents the finalized strict versus flexible schedule behavior

## Root causes

- Entry mutations always enabled blocking loaders during refetch.
- The numeric popover was positioned from the trigger without viewport clamping.
- Weekly quota completion was reused for per-day heatmap cells.
- Strict seven-of-seven schedules were treated as one weekly streak event.
- The prior audit introduced redundant per-cell clear buttons in the All grid.

## Validation

- 110 focused tests pass across completion, schedule, streak, route, hooks, and UI regressions
- ESLint passes for every changed source and test file
- TypeScript passes with the repository casing-conflict workaround
- Vite production build passes
- Verified the five reported behaviors in a 390x844 mobile viewport
- Full Vitest run: 961 of 969 pass; 8 pre-existing unrelated failures remain

## Notes

- No schema or data migration is required.
- Repository-wide lint and default typecheck remain blocked by documented pre-existing baseline issues.
- Full audit report: docs/audits/habit-tracking-mobile-regression-follow-up-2026-08-02.md