### PR TITLE
Add clear Done button to routine step editor

### DIFF
--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -423,7 +423,7 @@ graph TB
    - Step title, instructions, timer mode
    - **Linked Habit** (prominent section with searchable tappable chips, not a hidden dropdown)
    - Image upload, tracking fields
-   - Back arrow returns to step list
+   - Sticky **Done** button (footer) or back arrow returns to step list
 7. Optionally: use AI suggestion (Gemini)
 8. Submit → routine created
 

--- a/src/components/StepEditorPanel.tsx
+++ b/src/components/StepEditorPanel.tsx
@@ -7,7 +7,7 @@
  * Key UX improvements:
  * - Habit linking is a prominent, first-class section with tappable chips
  * - All fields are laid out spaciously instead of crammed into an accordion
- * - Back button returns to the step list
+ * - Back button and a sticky Done footer both return to the step list
  */
 import React, { useState, useRef } from 'react';
 import {
@@ -408,6 +408,17 @@ export const StepEditorPanel: React.FC<StepEditorPanelProps> = ({
                         </button>
                     </div>
                 </div>
+            </div>
+
+            {/* Sticky footer — explicit Done action returns to the step list */}
+            <div className="pt-4 border-t border-white/10">
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-emerald-500 text-neutral-900 font-bold rounded-lg hover:bg-emerald-400 transition-colors shadow-lg shadow-emerald-500/20"
+                >
+                    <Check size={18} /> Done
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Problem

When adding or editing a step in the routine creation modal, the step editor panel had no clear "done" affordance. After typing in the step's information, the only way back to the routine was the back arrow in the top-left corner — easy to miss, especially after scrolling down through the form fields (timer, linked habit, image, tracking fields), since it's on the opposite end of the panel from where the user finishes typing.

## Change

- **`src/components/StepEditorPanel.tsx`** — Added a sticky footer with a prominent full-width **Done** button (emerald primary-action style, matching the modal's "Create Routine" button) pinned below the scrollable form content. It returns to the step list. The back arrow is kept as a secondary path. No save logic changes — step edits already apply live via `onChange`, so Done simply closes the panel.
- **`docs/product/HABITFLOW_UI_ARCHITECTURE.md`** — Updated the Routine Editor flow description to reflect the new Done button.

`npm run build` (tsc -b + vite build) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157uPH3xkz9sGbP2qWe7sJW

---
_Generated by [Claude Code](https://claude.ai/code/session_0157uPH3xkz9sGbP2qWe7sJW)_