### PR TITLE
Add push reminder notifications to routines

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -65,6 +65,7 @@ Every feature area below is **Shipped** unless an item notes otherwise.
 - **Linked Habit Auto-Logging** — Completing a routine auto-marks its linked habits as done
 - **Pinned Routines** — Pin frequently-used routines to the dashboard for quick access
 - **Routine Logs** — Track completion history with timestamps
+- **Push Reminders** — Set a reminder time per routine (create/edit modal); a Web Push notification fires at that local time every day and is skipped once the routine has a completion log for that day (any variant counts). Tapping the notification opens the Routines page. Uses the same per-device enrollment (**Settings → Notifications**), `PUSH_REMINDERS_ENABLED` + VAPID gating, and always-on scheduler as habit reminders; unlike habits, routines have no assigned days, so the reminder fires daily until completed
 
 ## Goals
 

--- a/docs/product/HABITFLOW_UI_ARCHITECTURE.md
+++ b/docs/product/HABITFLOW_UI_ARCHITECTURE.md
@@ -147,7 +147,7 @@ HabitFlow App
 | Bundle Picker | Modal | Habit context menu "Add to Bundle" | Select existing bundle for habit membership | Habits, Bundles |
 | Convert to Bundle Confirm | Modal | "Convert to Bundle" action | Confirmation before converting habit to bundle | Habits, Bundles |
 | Category Picker | Modal | "Move to Category" action | Change habit's category | Habits, Categories |
-| Routine Editor | Modal | "+ Routine" or edit routine | Create/edit routines with variants; step list navigates to dedicated Step Editor panel. "Suggest with AI" (Gemini BYOK) drafts Quick/Standard/Deep variants; shown when a key is present, and also in the read-only demo where it injects pre-authored sample drafts instead of calling the model | Routines, Habits |
+| Routine Editor | Modal | "+ Routine" or edit routine | Create/edit routines with variants; optional daily push reminder time + "Send push reminder" toggle (below Category); step list navigates to dedicated Step Editor panel. "Suggest with AI" (Gemini BYOK) drafts Quick/Standard/Deep variants; shown when a key is present, and also in the read-only demo where it injects pre-authored sample drafts instead of calling the model | Routines, Habits |
 | Routine Runner | Modal | "Play" button on routine card | Step-by-step routine execution with timers | Routines, Habits, Entries |
 | Routine Preview | Modal | Preview button on routine card | Read-only routine view before starting | Routines |
 | Wellbeing Overview | Modal | Wellbeing card chevron | Today's status (Morning/Evening/Sleep), 7-day trend cards, quick actions | Wellbeing Entries |

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -231,12 +231,13 @@ export function InfoModal({ isOpen, onClose }: InfoModalProps) {
                   <span className="font-bold text-emerald-400">Reminders</span>
                 </p>
                 <p className="text-sm text-neutral-300 mt-1">
-                  Give any habit — including bundles — a reminder time (when creating or
-                  editing it) and HabitFlow sends a push notification at that time on the
-                  habit's scheduled days, skipped automatically once it's done for the day
-                  (for bundles, once the children satisfy the bundle's rule). Turn
-                  notifications on per device in{' '}
-                  <span className="text-neutral-200">Settings → Notifications</span>.
+                  Give any habit — including bundles — or routine a reminder time (when
+                  creating or editing it) and HabitFlow sends a push notification at that
+                  time. Habit reminders fire on the habit's scheduled days and are skipped
+                  automatically once it's done for the day (for bundles, once the children
+                  satisfy the bundle's rule); routine reminders fire daily and are skipped
+                  once the routine is completed that day. Turn notifications on per device
+                  in <span className="text-neutral-200">Settings → Notifications</span>.
                 </p>
                 <p className="text-xs text-neutral-500 mt-1.5">
                   iPhone/iPad: add HabitFlow to your Home Screen first (Share → Add to Home

--- a/src/components/RoutineEditorModal.tsx
+++ b/src/components/RoutineEditorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { X, Plus, Copy, Loader2, Image as ImageIcon, Sparkles } from 'lucide-react';
+import { X, Plus, Copy, Loader2, Image as ImageIcon, Sparkles, Bell } from 'lucide-react';
 import { uploadRoutineImage, deleteRoutineImage, suggestVariants, getActiveUserMode } from '../lib/persistenceClient';
 import { getGeminiApiKey, hasGeminiApiKey } from '../lib/geminiClient';
 import { getDemoSuggestedVariants } from '../lib/demoRoutineSuggestions';
@@ -70,6 +70,8 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
     // Form State
     const [title, setTitle] = useState('');
     const [categoryId, setCategoryId] = useState<string | undefined>(undefined);
+    const [reminderTime, setReminderTime] = useState('');
+    const [reminderEnabled, setReminderEnabled] = useState(true);
     const [variants, setVariants] = useState<RoutineVariant[]>([createEmptyVariant()]);
     const [activeVariantIndex, setActiveVariantIndex] = useState(0);
 
@@ -118,6 +120,8 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
         if (mode === 'edit' && initialRoutine) {
             setTitle(initialRoutine.title);
             setCategoryId(initialRoutine.categoryId);
+            setReminderTime(initialRoutine.reminderTime || '');
+            setReminderEnabled(initialRoutine.reminderEnabled !== false);
             const converted = routineToVariants(initialRoutine);
             setVariants(converted);
             const targetIndex = initialVariantId
@@ -128,6 +132,8 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
         } else {
             setTitle('');
             setCategoryId(undefined);
+            setReminderTime('');
+            setReminderEnabled(true);
             setVariants([createEmptyVariant()]);
             setActiveVariantIndex(0);
             setCurrentRoutineImageUrl(null);
@@ -291,6 +297,8 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                 linkedHabitIds,
                 defaultVariantId: variants[0]?.id,
                 steps: [], // Empty — steps now live inside variants
+                reminderTime: reminderTime || null,
+                reminderEnabled,
             };
 
             let savedRoutine: Routine;
@@ -380,6 +388,48 @@ export const RoutineEditorModal: React.FC<RoutineEditorModalProps> = ({
                                         <option key={cat.id} value={cat.id}>{cat.name}</option>
                                     ))}
                                 </select>
+                            </div>
+
+                            {/* Reminder — routines have no per-day schedule, so the
+                                push fires daily and skips days the routine is logged */}
+                            <div>
+                                <label htmlFor="routine-reminder-time" className="text-sm font-medium text-neutral-400 mb-2 flex items-center gap-1.5">
+                                    <Bell size={14} /> Reminder (Optional)
+                                </label>
+                                <div className="flex items-center gap-2">
+                                    <input
+                                        id="routine-reminder-time"
+                                        type="time"
+                                        value={reminderTime}
+                                        onChange={e => setReminderTime(e.target.value)}
+                                        className="px-4 py-3 rounded-lg bg-neutral-800 text-white border border-white/10 focus:outline-none focus:border-emerald-500 [color-scheme:dark]"
+                                    />
+                                    {reminderTime && (
+                                        <button
+                                            type="button"
+                                            onClick={() => setReminderTime('')}
+                                            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-neutral-500 hover:text-neutral-300 rounded-lg hover:bg-white/5"
+                                            aria-label="Clear reminder time"
+                                        >
+                                            <X size={16} />
+                                        </button>
+                                    )}
+                                </div>
+                                {reminderTime && (
+                                    <label className="flex items-center gap-2 text-sm text-neutral-300 cursor-pointer mt-2">
+                                        <input
+                                            type="checkbox"
+                                            checked={reminderEnabled}
+                                            onChange={e => setReminderEnabled(e.target.checked)}
+                                            className="w-4 h-4 rounded border-white/20 bg-neutral-800 accent-emerald-500"
+                                        />
+                                        Send push reminder
+                                    </label>
+                                )}
+                                <p className="text-[11px] text-neutral-500 mt-2">
+                                    Reminders go to devices where you've enabled notifications
+                                    (Settings → Notifications). Skipped on days the routine is already completed.
+                                </p>
                             </div>
 
                             {/* Routine Image Upload (edit mode only) */}

--- a/src/models/persistenceTypes.ts
+++ b/src/models/persistenceTypes.ts
@@ -576,6 +576,20 @@ export interface Routine {
      */
     defaultVariantId?: string;
 
+    /**
+     * Optional: Push reminder time ("HH:mm"), interpreted in each subscribed
+     * device's local timezone. Routines have no per-day schedule, so reminders
+     * fire every day and skip days the routine already has a completion log.
+     * null clears the reminder on PATCH (and may round-trip from storage).
+     */
+    reminderTime?: string | null;
+
+    /**
+     * Optional: Toggle push reminders without losing the configured time.
+     * Absent means enabled when reminderTime is set.
+     */
+    reminderEnabled?: boolean;
+
     /** ISO 8601 timestamp of when the routine was created */
     createdAt: string;
 

--- a/src/server/repositories/pushSendLogRepository.ts
+++ b/src/server/repositories/pushSendLogRepository.ts
@@ -2,9 +2,14 @@
  * Push Send Log Repository
  *
  * Dedup ledger for reminder sends: at most one push per
- * (habitId, dayKey, endpoint), enforced by a unique index so the scheduler is
+ * (sourceId, dayKey, endpoint), enforced by a unique index so the scheduler is
  * idempotent across restarts, overlapping ticks, and multiple instances.
  * Rows expire via TTL — dedup only needs to outlive the day it protects.
+ *
+ * sourceId is the reminding entity: a habit id, or a namespaced "routine:<id>"
+ * for routine reminders (habit ids are UUIDs, so the prefix can't collide).
+ * The stored field (and unique index) keeps its original name `habitId` so
+ * existing deployments need no index migration.
  */
 
 import { getDb } from '../lib/mongoClient';
@@ -31,11 +36,11 @@ async function ensureIndexes(): Promise<void> {
 }
 
 /**
- * Claim the right to send this (habit, day, device) reminder by inserting the
+ * Claim the right to send this (source, day, device) reminder by inserting the
  * dedup row first. Returns false if another tick/instance already claimed it.
  */
 export async function tryClaimSend(
-  habitId: string,
+  sourceId: string,
   dayKey: string,
   endpoint: string,
   householdId: string,
@@ -47,7 +52,7 @@ export async function tryClaimSend(
   const col = db.collection(COLLECTION);
   try {
     await col.insertOne({
-      habitId,
+      habitId: sourceId,
       dayKey,
       endpoint,
       householdId: scope.householdId,
@@ -66,7 +71,7 @@ export async function tryClaimSend(
 
 /** Record the outcome of a claimed send. */
 export async function markSendResult(
-  habitId: string,
+  sourceId: string,
   dayKey: string,
   endpoint: string,
   status: 'sent' | 'gone'
@@ -74,7 +79,7 @@ export async function markSendResult(
   await ensureIndexes();
   const db = await getDb();
   const col = db.collection(COLLECTION);
-  await col.updateOne({ habitId, dayKey, endpoint }, { $set: { status } });
+  await col.updateOne({ habitId: sourceId, dayKey, endpoint }, { $set: { status } });
 }
 
 /**
@@ -82,12 +87,12 @@ export async function markSendResult(
  * (bounded by the scheduler's catch-up window).
  */
 export async function releaseClaim(
-  habitId: string,
+  sourceId: string,
   dayKey: string,
   endpoint: string
 ): Promise<void> {
   await ensureIndexes();
   const db = await getDb();
   const col = db.collection(COLLECTION);
-  await col.deleteOne({ habitId, dayKey, endpoint });
+  await col.deleteOne({ habitId: sourceId, dayKey, endpoint });
 }

--- a/src/server/repositories/routineLogRepository.ts
+++ b/src/server/repositories/routineLogRepository.ts
@@ -85,6 +85,25 @@ export async function saveRoutineLog(
 }
 
 /**
+ * Does the routine have a completion log (any variant) for the given day?
+ * Used by the reminder scheduler to skip reminders once the routine is done.
+ */
+export async function hasRoutineLogForDay(
+    routineId: string,
+    date: string,
+    userId: string
+): Promise<boolean> {
+    const db = await getDb();
+    const collection = db.collection(COLLECTION_NAME);
+
+    const log = await collection.findOne(
+        { routineId, date, userId },
+        { projection: { _id: 1 } }
+    );
+    return log !== null;
+}
+
+/**
  * Get all routine logs for a user.
  *
  * @param userId - User ID to filter logs

--- a/src/server/repositories/routineRepository.ts
+++ b/src/server/repositories/routineRepository.ts
@@ -96,6 +96,38 @@ export async function getRoutine(
   return stripScope(routine);
 }
 
+/**
+ * SCHEDULER-ONLY: cross-scope query for routines with a reminder due at one of
+ * the given "HH:mm" times, restricted to the scopes that actually have active
+ * push subscriptions. Returns routines WITH their scope fields so the scheduler
+ * can match them to subscriptions — a deliberate exception to the per-request
+ * scoping rule; never call this from a request handler.
+ * (Routines are hard-deleted and have no archive state, so unlike the habit
+ * counterpart there are no deletedAt/archived filters.)
+ */
+export async function findReminderRoutinesForScopes(
+  scopes: Array<{ householdId: string; userId: string }>,
+  times: string[]
+): Promise<Array<Routine & { householdId: string; userId: string }>> {
+  if (scopes.length === 0 || times.length === 0) return [];
+
+  const db = await getDb();
+  const collection = db.collection(COLLECTION);
+
+  const docs = await collection
+    .find({
+      $or: scopes.map((s) => ({ householdId: s.householdId, userId: s.userId })),
+      reminderTime: { $in: times },
+      reminderEnabled: { $ne: false },
+    })
+    .toArray();
+
+  return docs.map((doc) => {
+    const { householdId, userId } = doc as any;
+    return { ...stripScope(doc), householdId, userId };
+  });
+}
+
 export async function createRoutine(
   householdId: string,
   userId: string,

--- a/src/server/routes/__tests__/routines.reminder.test.ts
+++ b/src/server/routes/__tests__/routines.reminder.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Routine Reminder Field Tests
+ *
+ * Validates that POST/PATCH /api/routines correctly handles the
+ * reminderTime ("HH:mm") and reminderEnabled fields, including
+ * format validation and the clear-with-null contract — the same
+ * contract habits use (see habits.reminder.test.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import { createRoutineRoute, updateRoutineRoute } from '../routines';
+
+const TEST_HOUSEHOLD_ID = 'test-routine-reminder-household';
+const TEST_USER_ID = 'test-routine-reminder-user';
+
+describe('Routine Reminder Fields (reminderTime + reminderEnabled)', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    await setupTestMongo();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).householdId = TEST_HOUSEHOLD_ID;
+      (req as any).userId = TEST_USER_ID;
+      next();
+    });
+
+    app.post('/api/routines', createRoutineRoute);
+    app.patch('/api/routines/:id', updateRoutineRoute);
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  beforeEach(async () => {
+    const testDb = await getTestDb();
+    await testDb.collection('routines').deleteMany({});
+  });
+
+  async function createRoutine(extra: Record<string, unknown> = {}) {
+    return request(app)
+      .post('/api/routines')
+      .send({
+        title: 'Wind Down',
+        steps: [],
+        ...extra,
+      });
+  }
+
+  it('creates a routine with a valid reminderTime', async () => {
+    const res = await createRoutine({ reminderTime: '21:00' });
+    expect(res.status).toBe(201);
+    expect(res.body.routine.reminderTime).toBe('21:00');
+  });
+
+  it('accepts boundary times 00:00 and 23:59', async () => {
+    const early = await createRoutine({ reminderTime: '00:00' });
+    expect(early.status).toBe(201);
+    const late = await createRoutine({ reminderTime: '23:59' });
+    expect(late.status).toBe(201);
+  });
+
+  it.each(['9:00', '25:00', '09:60', '0900', '09:00:00', 'evening'])(
+    'rejects malformed reminderTime %s on create',
+    async (bad) => {
+      const res = await createRoutine({ reminderTime: bad });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    }
+  );
+
+  it('treats null reminderTime as unset on create', async () => {
+    const res = await createRoutine({ reminderTime: null });
+    expect(res.status).toBe(201);
+    expect(res.body.routine.reminderTime ?? undefined).toBeUndefined();
+  });
+
+  it('sets reminderTime via PATCH', async () => {
+    const created = await createRoutine();
+    const res = await request(app)
+      .patch(`/api/routines/${created.body.routine.id}`)
+      .send({ reminderTime: '07:30' });
+    expect(res.status).toBe(200);
+    expect(res.body.routine.reminderTime).toBe('07:30');
+  });
+
+  it('rejects malformed reminderTime via PATCH', async () => {
+    const created = await createRoutine({ reminderTime: '07:30' });
+    const res = await request(app)
+      .patch(`/api/routines/${created.body.routine.id}`)
+      .send({ reminderTime: '7:30pm' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('toggles reminderEnabled without losing reminderTime', async () => {
+    const created = await createRoutine({ reminderTime: '07:30' });
+    const id = created.body.routine.id;
+
+    const off = await request(app).patch(`/api/routines/${id}`).send({ reminderEnabled: false });
+    expect(off.status).toBe(200);
+    expect(off.body.routine.reminderEnabled).toBe(false);
+    expect(off.body.routine.reminderTime).toBe('07:30');
+
+    const on = await request(app).patch(`/api/routines/${id}`).send({ reminderEnabled: true });
+    expect(on.status).toBe(200);
+    expect(on.body.routine.reminderEnabled).toBe(true);
+    expect(on.body.routine.reminderTime).toBe('07:30');
+  });
+
+  it('clears reminderTime with null while keeping other fields', async () => {
+    const created = await createRoutine({ reminderTime: '07:30' });
+    const id = created.body.routine.id;
+
+    const res = await request(app).patch(`/api/routines/${id}`).send({ reminderTime: null });
+    expect(res.status).toBe(200);
+    expect(res.body.routine.reminderTime ?? undefined).toBeUndefined();
+    expect(res.body.routine.title).toBe('Wind Down');
+  });
+});

--- a/src/server/routes/routines.ts
+++ b/src/server/routes/routines.ts
@@ -53,6 +53,13 @@ const routineImageUpload = multer({
 
 export const uploadRoutineImageMiddleware = routineImageUpload.single('file');
 
+// 24h "HH:mm" — the format stored for reminderTime (same contract as habits).
+const REMINDER_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function isValidReminderTime(value: unknown): value is string {
+  return typeof value === 'string' && REMINDER_TIME_PATTERN.test(value);
+}
+
 /**
  * Validate a RoutineStep object.
  * 
@@ -320,7 +327,18 @@ export async function getRoutineRoute(req: Request, res: Response): Promise<void
 export async function createRoutineRoute(req: Request, res: Response): Promise<void> {
   try {
     // Validate request body
-    const { title, categoryId, steps, linkedHabitIds, variants, defaultVariantId } = req.body;
+    const { title, categoryId, steps, linkedHabitIds, variants, defaultVariantId, reminderTime, reminderEnabled } = req.body;
+
+    // null is treated as "no reminder" so create and PATCH share one contract
+    if (reminderTime !== undefined && reminderTime !== null && !isValidReminderTime(reminderTime)) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'reminderTime must be a 24h "HH:mm" string (e.g. "09:00")',
+        },
+      });
+      return;
+    }
 
     if (!title || typeof title !== 'string' || title.trim().length === 0) {
       res.status(400).json({
@@ -399,6 +417,8 @@ export async function createRoutineRoute(req: Request, res: Response): Promise<v
         steps: (steps as RoutineStep[]) || [],
         linkedHabitIds: linkedHabitIds || [],
         ...(variants ? { variants: variants as RoutineVariant[], defaultVariantId } : {}),
+        reminderTime: reminderTime ?? undefined,
+        reminderEnabled: reminderEnabled === undefined ? undefined : !!reminderEnabled,
       }
     );
 
@@ -432,7 +452,7 @@ export async function createRoutineRoute(req: Request, res: Response): Promise<v
 export async function updateRoutineRoute(req: Request, res: Response): Promise<void> {
   try {
     const { id } = req.params;
-    const { title, categoryId, steps, linkedHabitIds, variants, defaultVariantId, icon, color } = req.body;
+    const { title, categoryId, steps, linkedHabitIds, variants, defaultVariantId, icon, color, reminderTime, reminderEnabled } = req.body;
 
     if (!id) {
       res.status(400).json({
@@ -552,6 +572,21 @@ export async function updateRoutineRoute(req: Request, res: Response): Promise<v
       }
       patch.color = color.trim();
     }
+
+    // Clear with null, set with a valid "HH:mm" string (same contract as habits).
+    if (reminderTime !== undefined) {
+      if (reminderTime !== null && !isValidReminderTime(reminderTime)) {
+        res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'reminderTime must be a 24h "HH:mm" string (e.g. "09:00")',
+          },
+        });
+        return;
+      }
+      patch.reminderTime = reminderTime === null ? undefined : reminderTime;
+    }
+    if (reminderEnabled !== undefined) patch.reminderEnabled = !!reminderEnabled;
 
     if (Object.keys(patch).length === 0) {
       res.status(400).json({

--- a/src/server/services/__tests__/reminderScheduler.test.ts
+++ b/src/server/services/__tests__/reminderScheduler.test.ts
@@ -4,7 +4,8 @@
  * Drives runReminderTick() with fixed Dates against memory Mongo, with the
  * web-push sender mocked. Covers timezone matching, the catch-up window,
  * schedule/completion/enablement exclusions, dedup, gone-endpoint cleanup,
- * transient-error retry, local-midnight windows, and multi-device fan-out.
+ * transient-error retry, local-midnight windows, multi-device fan-out, and
+ * routine reminders (fire daily, skipped once the routine is logged).
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
@@ -22,7 +23,8 @@ import { sendPush } from '../../lib/webPush';
 import { runReminderTick, formatLocalHHmm } from '../reminderScheduler';
 import { upsertPushSubscription, getActivePushSubscriptions } from '../../repositories/pushSubscriptionRepository';
 import { createHabit } from '../../repositories/habitRepository';
-import type { Habit } from '../../../models/persistenceTypes';
+import { createRoutine } from '../../repositories/routineRepository';
+import type { Habit, Routine } from '../../../models/persistenceTypes';
 
 const HH = 'sched-household';
 const USER = 'sched-user';
@@ -81,6 +83,8 @@ describe('reminderScheduler', () => {
     await db.collection('pushSendLog').deleteMany({});
     await db.collection('habits').deleteMany({});
     await db.collection('habitEntries').deleteMany({});
+    await db.collection('routines').deleteMany({});
+    await db.collection('routineLogs').deleteMany({});
     vi.mocked(sendPush).mockClear();
     vi.mocked(sendPush).mockResolvedValue('sent');
   });
@@ -345,6 +349,117 @@ describe('reminderScheduler', () => {
     vi.mocked(sendPush).mockClear();
     await runReminderTick(utc('2026-07-16T13:00:10Z'));
     expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+  });
+
+  describe('routine reminders (fire daily, skipped once logged)', () => {
+    async function makeRoutine(overrides: Partial<Record<string, unknown>> = {}, userId = USER) {
+      const data = {
+        title: (overrides.title as string) ?? 'Wind Down',
+        steps: [],
+        linkedHabitIds: [],
+        reminderTime: '08:00',
+        ...overrides,
+      } as Omit<Routine, 'id' | 'userId' | 'createdAt' | 'updatedAt'>;
+      return createRoutine(HH, userId, data);
+    }
+
+    async function logRoutine(routineId: string, date = '2026-07-16', variantId?: string) {
+      const db = await getTestDb();
+      await db.collection('routineLogs').insertOne({
+        routineId,
+        date,
+        userId: USER,
+        completedAt: `${date}T11:00:00.000Z`,
+        compositeKey: variantId ? `${routineId}-${variantId}-${date}` : `${routineId}-${date}`,
+        ...(variantId ? { variantId } : {}),
+      });
+    }
+
+    it('sends when the local minute matches, deep-linking to the routines view', async () => {
+      await subscribe();
+      const routine = await makeRoutine();
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z')); // 08:00 NY
+
+      expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+      const [target, payload] = vi.mocked(sendPush).mock.calls[0];
+      expect(target.endpoint).toBe(ENDPOINT);
+      expect(payload.title).toBe('Wind Down');
+      expect(payload.tag).toBe(`routine-${routine.id}-2026-07-16`);
+      expect(payload.data?.url).toBe('/?view=routines');
+    });
+
+    it('skips a routine already logged for the local day', async () => {
+      await subscribe();
+      const routine = await makeRoutine();
+      await logRoutine(routine.id);
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+      expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+    });
+
+    it('counts a variant-scoped log as done for the day', async () => {
+      await subscribe();
+      const routine = await makeRoutine();
+      await logRoutine(routine.id, '2026-07-16', 'variant-quick');
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+      expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+    });
+
+    it('still sends when only a previous day is logged', async () => {
+      await subscribe();
+      const routine = await makeRoutine();
+      await logRoutine(routine.id, '2026-07-15');
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+      expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips reminderEnabled=false routines', async () => {
+      await subscribe();
+      await makeRoutine({ reminderEnabled: false });
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+      expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+    });
+
+    it('dedups across consecutive ticks (at most one send per routine/day/device)', async () => {
+      await subscribe();
+      await makeRoutine();
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+      await runReminderTick(utc('2026-07-16T12:01:10Z'));
+      await runReminderTick(utc('2026-07-16T12:02:10Z'));
+
+      expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a habit and a routine reminder independently at the same minute', async () => {
+      await subscribe();
+      await makeHabit({ name: 'Meditate' });
+      await makeRoutine({ title: 'Morning Startup' });
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+      expect(vi.mocked(sendPush)).toHaveBeenCalledTimes(2);
+      const titles = vi.mocked(sendPush).mock.calls.map(([, p]) => p.title).sort();
+      expect(titles).toEqual(['Meditate', 'Morning Startup']);
+    });
+
+    it('does not cross-fire routines between users', async () => {
+      await subscribe({ endpoint: ENDPOINT, userId: USER });
+      // OTHER_USER has the routine but no subscription
+      await makeRoutine({ title: 'Other user routine' }, OTHER_USER);
+
+      await runReminderTick(utc('2026-07-16T12:00:10Z'));
+
+      expect(vi.mocked(sendPush)).not.toHaveBeenCalled();
+    });
   });
 
   it('does not cross-fire habits between users', async () => {

--- a/src/server/services/reminderScheduler.ts
+++ b/src/server/services/reminderScheduler.ts
@@ -1,15 +1,17 @@
 /**
  * Reminder Scheduler
  *
- * In-process scheduler for Web Push habit reminders. Every TICK_MS it
- * computes, per subscription timezone, the current local minute plus a small
- * catch-up window of recent minutes (so a delayed/skipped tick after a deploy
- * or restart still delivers), finds habits whose reminderTime matches, and
- * pushes to each subscribed device — unless the habit is already completed
- * for that local day.
+ * In-process scheduler for Web Push habit and routine reminders. Every
+ * TICK_MS it computes, per subscription timezone, the current local minute
+ * plus a small catch-up window of recent minutes (so a delayed/skipped tick
+ * after a deploy or restart still delivers), finds habits and routines whose
+ * reminderTime matches, and pushes to each subscribed device — unless the
+ * habit is already completed (routine already logged) for that local day.
+ * Habits fire only on their assigned days; routines have no per-day schedule,
+ * so their reminders fire every day.
  *
- * Idempotency: pushSendLog's unique (habitId, dayKey, endpoint) index with
- * claim-by-insert makes sends at-most-once per habit per day per device, even
+ * Idempotency: pushSendLog's unique (sourceId, dayKey, endpoint) index with
+ * claim-by-insert makes sends at-most-once per source per day per device, even
  * across overlapping ticks, restarts, and multiple instances. The dayKey is
  * computed per offset minute so the catch-up window behaves correctly across
  * local midnight; dayKey-scoped dedup also makes the DST fall-back repeated
@@ -21,19 +23,21 @@
  * adapt runReminderTick() behind a cron-triggered endpoint.
  */
 
-import type { Habit } from '../../models/persistenceTypes';
+import type { Habit, Routine } from '../../models/persistenceTypes';
 import {
   getActivePushSubscriptions,
   disablePushSubscriptionByEndpoint,
 } from '../repositories/pushSubscriptionRepository';
 import { tryClaimSend, markSendResult, releaseClaim } from '../repositories/pushSendLogRepository';
 import { findReminderHabitsForScopes, getHabitById } from '../repositories/habitRepository';
+import { findReminderRoutinesForScopes } from '../repositories/routineRepository';
+import { hasRoutineLogForDay } from '../repositories/routineLogRepository';
 import { getHabitEntriesForDay } from '../repositories/habitEntryRepository';
 import { isHabitScheduledOnDay } from './scheduleEngine';
 import { resolveChildIdsForDay } from './dayViewService';
 import { evaluateChecklistSuccess } from './checklistSuccessService';
 import { getDayKeyForDate } from '../utils/dayKey';
-import { sendPush, isPushConfigured } from '../lib/webPush';
+import { sendPush, isPushConfigured, type PushPayload } from '../lib/webPush';
 import { deriveDailyHabitCompletion } from '../../domain/habits/completion';
 
 const TICK_MS = 60_000;
@@ -141,10 +145,13 @@ export async function runReminderTick(now: Date): Promise<void> {
     scopes.push({ householdId: sub.householdId, userId: sub.userId });
   }
   const allTimes = [...new Set([...tzCandidates.values()].flat().map((c) => c.hhmm))];
-  const habits = await findReminderHabitsForScopes(scopes, allTimes);
-  if (habits.length === 0) return;
+  const [habits, routines] = await Promise.all([
+    findReminderHabitsForScopes(scopes, allTimes),
+    findReminderRoutinesForScopes(scopes, allTimes),
+  ]);
+  if (habits.length === 0 && routines.length === 0) return;
 
-  // Completion lookups are cached per (habit, dayKey) within the tick.
+  // Completion lookups are cached per (source, dayKey) within the tick.
   const completionCache = new Map<string, boolean>();
   async function isCompleted(
     habit: Habit & { householdId: string; userId: string },
@@ -158,7 +165,47 @@ export async function runReminderTick(now: Date): Promise<void> {
     return completed;
   }
 
-  // 3. Match each subscription's local candidate minutes against its user's habits.
+  // Routine "done today" = any completion log (any variant) for the dayKey.
+  async function isRoutineLogged(
+    routine: Routine & { userId: string },
+    dayKey: string
+  ): Promise<boolean> {
+    const cacheKey = `routine:${routine.id}|${dayKey}`;
+    const cached = completionCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+    const logged = await hasRoutineLogForDay(routine.id, dayKey, routine.userId);
+    completionCache.set(cacheKey, logged);
+    return logged;
+  }
+
+  type ActiveSub = (typeof subscriptions)[number];
+
+  // 4. Claim-then-send: the unique dedup index makes this at-most-once per
+  //    (source, day, device). On transient error the claim is released so the
+  //    next tick can retry while the minute is inside the catch-up window.
+  async function claimAndSend(
+    sub: ActiveSub,
+    sourceId: string,
+    dayKey: string,
+    payload: PushPayload
+  ): Promise<void> {
+    const claimed = await tryClaimSend(sourceId, dayKey, sub.endpoint, sub.householdId, sub.userId);
+    if (!claimed) return;
+
+    const result = await sendPush({ endpoint: sub.endpoint, keys: sub.keys }, payload);
+
+    if (result === 'sent') {
+      await markSendResult(sourceId, dayKey, sub.endpoint, 'sent');
+    } else if (result === 'gone') {
+      await markSendResult(sourceId, dayKey, sub.endpoint, 'gone');
+      await disablePushSubscriptionByEndpoint(sub.householdId, sub.userId, sub.endpoint);
+    } else {
+      await releaseClaim(sourceId, dayKey, sub.endpoint);
+    }
+  }
+
+  // 3. Match each subscription's local candidate minutes against its user's
+  //    habits and routines.
   for (const sub of subscriptions) {
     const candidates = tzCandidates.get(sub.timeZone) ?? [];
     for (const habit of habits) {
@@ -168,36 +215,26 @@ export async function runReminderTick(now: Date): Promise<void> {
       if (!isHabitScheduledOnDay(habit, candidate.dayKey, sub.timeZone)) continue;
       if (await isCompleted(habit, candidate.dayKey)) continue;
 
-      // 4. Claim-then-send: the unique dedup index makes this at-most-once.
-      const claimed = await tryClaimSend(
-        habit.id,
-        candidate.dayKey,
-        sub.endpoint,
-        sub.householdId,
-        sub.userId
-      );
-      if (!claimed) continue;
+      await claimAndSend(sub, habit.id, candidate.dayKey, {
+        title: habit.name,
+        body: `Time for ${habit.name}`,
+        tag: `habit-${habit.id}-${candidate.dayKey}`,
+        data: { url: '/?view=tracker' },
+      });
+    }
 
-      const result = await sendPush(
-        { endpoint: sub.endpoint, keys: sub.keys },
-        {
-          title: habit.name,
-          body: `Time for ${habit.name}`,
-          tag: `habit-${habit.id}-${candidate.dayKey}`,
-          data: { url: '/?view=tracker' },
-        }
-      );
+    for (const routine of routines) {
+      if (routine.householdId !== sub.householdId || routine.userId !== sub.userId) continue;
+      const candidate = candidates.find((c) => c.hhmm === routine.reminderTime);
+      if (!candidate) continue;
+      if (await isRoutineLogged(routine, candidate.dayKey)) continue;
 
-      if (result === 'sent') {
-        await markSendResult(habit.id, candidate.dayKey, sub.endpoint, 'sent');
-      } else if (result === 'gone') {
-        await markSendResult(habit.id, candidate.dayKey, sub.endpoint, 'gone');
-        await disablePushSubscriptionByEndpoint(sub.householdId, sub.userId, sub.endpoint);
-      } else {
-        // Transient failure: release the claim so the next tick can retry
-        // while the minute is still inside the catch-up window.
-        await releaseClaim(habit.id, candidate.dayKey, sub.endpoint);
-      }
+      await claimAndSend(sub, `routine:${routine.id}`, candidate.dayKey, {
+        title: routine.title,
+        body: `Time for ${routine.title}`,
+        tag: `routine-${routine.id}-${candidate.dayKey}`,
+        data: { url: '/?view=routines' },
+      });
     }
   }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,12 +2,12 @@
 
 Bring habit-style push reminders (`reminderTime` / `reminderEnabled`) to routines.
 
-- [ ] 1. Model + API: add `reminderTime`/`reminderEnabled` to `Routine`, validate on POST/PATCH `/api/routines` (commit 1)
-- [ ] 2. Scheduler: `findReminderRoutinesForScopes`, routine-log completion skip, send-log dedup namespacing, routine send loop in `reminderScheduler` (commit 2)
-- [ ] 3. UI: reminder time + enable controls in `RoutineEditorModal` (commit 3)
-- [ ] 4. Tests: `routines.reminder.test.ts` + scheduler routine cases (commit 4)
-- [ ] 5. Docs: FEATURES.md, HABITFLOW_UI_ARCHITECTURE.md, InfoModal Reminders blurb (commit 5)
-- [ ] 6. `npm run build` + relevant test runs, push, open PR
+- [x] 1. Model + API: add `reminderTime`/`reminderEnabled` to `Routine`, validate on POST/PATCH `/api/routines` (commit 1)
+- [x] 2. Scheduler: `findReminderRoutinesForScopes`, routine-log completion skip, send-log dedup namespacing, routine send loop in `reminderScheduler` (commit 2)
+- [x] 3. UI: reminder time + enable controls in `RoutineEditorModal` (commit 3)
+- [x] 4. Tests: `routines.reminder.test.ts` + scheduler routine cases (commit 4)
+- [x] 5. Docs: FEATURES.md, HABITFLOW_UI_ARCHITECTURE.md, InfoModal Reminders blurb (commit 5)
+- [x] 6. `npm run build` + relevant test runs, push, open PR
 
 Design decisions:
 - Routines have no schedule concept (no assignedDays) → reminders fire every day, skipped when the routine already has a log for that local dayKey (any variant).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,122 +1,15 @@
-# Interactive Product Tour + Public Demo Mode
+# Routine Push Reminders
 
-Goal: replace the static Take a Tour feature list with an interactive guided tour,
-add a production-safe read-only Demo Mode with seeded showcase data, a
-mobile/desktop preview toggle, and a dedicated Roadmap page. Portfolio-first:
-a visitor should understand HabitFlow in under 3 minutes without an account.
+Bring habit-style push reminders (`reminderTime` / `reminderEnabled`) to routines.
 
-Architecture decisions (locked):
-- Demo Mode is **server-backed**: real screens, real API, real derived views,
-  scoped to seeded demo data. No fixture drift, no fake copies of screens.
-- Public demo identity: persistenceClient attaches `X-Demo-Mode: true` when the
-  active user mode is `demo`; server maps it to a fixed demo household/user when
-  `PUBLIC_DEMO_ENABLED=true`. Works in production (unlike dev-only
-  DEMO_MODE_ENABLED path, which stays unchanged).
-- Read-only enforcement in BOTH layers: server middleware rejects mutating
-  methods for the public demo identity (403), client intercepts writes in
-  `apiRequest` and shows a friendly toast instead of firing the request.
-- Tour previews the REAL app via an iframe (`?demo=1&embed=1`): the
-  mobile/desktop toggle changes the iframe viewport (390px vs full), so actual
-  Tailwind breakpoints and the real mobile nav render — not a scaled screenshot.
-  `embed=1` → replaceState instead of pushState so iframe navigation doesn't
-  pollute parent history; the tour drives the iframe via postMessage.
-- Beta pages (Analytics, Insights) become viewable by the demo identity, always
-  labeled Beta. Apple Health stays allowlisted (described honestly, not shown).
-- Honesty rules: roadmap items never mixed into implemented features; the seeded
-  sample AI report is labeled as an illustrative example of the report format,
-  never claimed to be a live Gemini generation.
+- [ ] 1. Model + API: add `reminderTime`/`reminderEnabled` to `Routine`, validate on POST/PATCH `/api/routines` (commit 1)
+- [ ] 2. Scheduler: `findReminderRoutinesForScopes`, routine-log completion skip, send-log dedup namespacing, routine send loop in `reminderScheduler` (commit 2)
+- [ ] 3. UI: reminder time + enable controls in `RoutineEditorModal` (commit 3)
+- [ ] 4. Tests: `routines.reminder.test.ts` + scheduler routine cases (commit 4)
+- [ ] 5. Docs: FEATURES.md, HABITFLOW_UI_ARCHITECTURE.md, InfoModal Reminders blurb (commit 5)
+- [ ] 6. `npm run build` + relevant test runs, push, open PR
 
-## Commits
-
-- [x] 1. FEATURE_AUDIT.md — honest audit: Implemented / Partial / Roadmap
-       (verified against code by 4 exploration passes).
-- [x] 2. Backend: public demo identity + read-only guard middleware
-       (src/shared/demo.ts additions, src/server/middleware/publicDemo.ts,
-       app.ts wiring, tests).
-- [x] 3. Backend: comprehensive demo showcase seed (categories, habits incl.
-       numeric/weekly/bundles, ~10 weeks of entries, goals + milestones + a
-       track, tasks, journal, wellbeing/sleep, medications, routines + logs,
-       pinned prefs, sample AI report) — idempotent, startup-invoked when
-       PUBLIC_DEMO_ENABLED, plus npm run seed:showcase.
-- [x] 4. Frontend: demo mode entry/exit + read-only UX (persistenceClient header
-       + write guard, AuthContext demo session, Layout demo banner + exit,
-       LoginPage "Explore the demo" CTA, ?demo=1 / embed=1 boot params, demo
-       access to beta pages).
-- [x] 5. Frontend: interactive TourPage rewrite — step-based guided walkthrough
-       (Welcome → Dashboard → Habits → Goals → Tasks → Journal → Routines →
-       Weekly AI Review → Journal Intelligence → Insights/Analytics → Sleep →
-       Settings → Roadmap/CTA) with live embedded demo preview and
-       mobile/desktop toggle + contextual honesty callouts.
-- [x] 6. Frontend: dedicated Roadmap page (?view=roadmap), reachable from tour,
-       login screen, and app; content mirrors ROADMAP.md with status chips.
-- [x] 7. Docs: docs/DEMO_ARCHITECTURE.md (how demo works), FEATURES.md,
-       HABITFLOW_UI_ARCHITECTURE.md, README pointer.
-
-## Verification
-- [x] npm run build (tsc -b + vite build): GREEN
-- [x] npm run lint:beta: 0 errors (pre-existing `any` warnings only)
-- [x] npm run test:beta: 4 suites / 20 tests pass; 5 suites fail ONLY because
-      mongodb-memory-server cannot download its binary in this sandbox
-      (HTTP 403 via proxy — environmental, same as previous sessions)
-- [x] publicDemo middleware tests: 17/17 pass
-- [x] Frontend component tests: pass except TrackerGrid.clearEntry (3 tests),
-      which fails identically on main — pre-existing, unrelated
-- [x] Playwright smoke test (vite dev server): login CTAs render, tour renders
-      13 step chips, postMessage step navigation drives the embedded preview,
-      Desktop/Mobile toggle renders a real 390px viewport, Roadmap page renders
-- [x] Live end-to-end verification (second pass): MongoDB binaries are
-      proxy-blocked, so a locally-built FerretDB v1.24 (Mongo wire protocol,
-      SQLite backend) stood in — patched locally with $addToSet/$size/$ifNull
-      and two upstream fixes (per-accumulator group iterators, $-path renames
-      in $project). Sandbox-only tooling; nothing committed to the repo.
-      Verified against the running stack:
-      - startup seed runs, detects freshness, skips when fresh; --force reseeds
-      - demo-header reads return seeded data; writes 403 demoReadOnly;
-        headerless requests 401; read-only toast fires in the UI
-      - every screen renders real seeded data (dashboard ring, habits grid
-        with bundle + streaks, goal track completed→active 72%→locked,
-        milestones, tasks, journal, routines, insights, sleep)
-      - the Insights correlation engine genuinely detects the seeded
-        wind-down↔sleep/energy pattern (Cohen's d, n=30 vs 15)
-      - sample Weekly AI Review opens from history without a Gemini key
-- [ ] After production deploy (real MongoDB): set PUBLIC_DEMO_ENABLED=true,
-      confirm /api/health reports publicDemo:true, click "Explore the live demo".
-
-## Tour section deep-links (trust fix)
-
-Problem: several tour stops didn't land on the section they named — Weekly
-Review (AI) dropped visitors on the Habits tracker instead of a completed
-review, Settings pointed at the gear icon, Sleep landed on the Analytics
-Habits tab, and Journal→AI Review tab switches were ignored by the persistent
-iframe.
-
-- [x] Embedded demo navigation supports section deep-links: `modal: 'ai'|'settings'`
-      (+ `focus` for the AI hub card), `routineEditor: '<title>'`, and `tab`
-      for Analytics; overlays from the previous stop close on every step change
-- [x] Journal/Analytics keyed by tab so `?tab=` deep-links apply even when the
-      page is already mounted (fixes tour step Journal → AI Journal Review)
-- [x] Tour stops updated: Weekly Review opens the AI hub with the completed
-      archived review on top; Routine Builder opens the Morning Kickstart
-      editor; Sleep opens the Sleep tab; Settings opens the Settings modal
-- [x] Docs: HABITFLOW_UI_ARCHITECTURE.md + FEATURES.md tour entries updated
-- [x] Verified: `npm run build` green; aiCardsArchived tests pass; demo seeds
-      an archived weekly_review report so the card renders it without a key
-
-## Merge with tour-streamline PR (#512/#513)
-
-Main independently removed the Routine Builder/Sleep/Settings tour stops
-while this branch was in flight. Resolved by merge:
-- [x] Kept main's stop removal (11 stops, 3 AI stops)
-- [x] Kept this branch's routineEditor deep-link, applied to the surviving
-      Routines stop — it now opens Morning Kickstart in the editor directly
-      (main's version only pointed at the routines list)
-- [x] docs/FEATURES.md + HABITFLOW_UI_ARCHITECTURE.md rewritten to match
-      the final 11-stop tour and its deep-links
-- [x] Verified: tsc -b + vite build green; Playwright smoke against the
-      merged tour (mocking /api/routines + /api/routineLogs, since this
-      sandbox has no MongoDB backend) confirms all 12 checks pass —
-      11 chips, Weekly Review opens AI hub with review on top, Journal
-      lands on History, Journal Review on the AI tab, Routines opens the
-      Morning Kickstart editor with Suggest with AI visible, Wellbeing
-      deep-links correctly, Sleep/Settings chips are gone, and overlays
-      close when moving to the next stop
+Design decisions:
+- Routines have no schedule concept (no assignedDays) → reminders fire every day, skipped when the routine already has a log for that local dayKey (any variant).
+- Dedup ledger keeps the existing `{habitId, dayKey, endpoint}` unique index; routine sends namespace the id as `routine:<id>` (no migration, no collision — habit ids are UUIDs).
+- Notification deep-link: `/?view=routines`, tag `routine-<id>-<dayKey>`.


### PR DESCRIPTION
## Summary

Routines now support push reminder notifications with the exact same contract habits already use: a `reminderTime` ("HH:mm", device-local) plus a `reminderEnabled` toggle, delivered by the existing Web Push scheduler.

**Example:** set a 21:30 reminder on a "Wind Down" routine and every subscribed device gets a push at 21:30 local time — unless you already ran the routine that day (any variant counts), in which case the reminder is silently skipped. Tapping the notification opens the Routines page.

## Changes

- **Model + API** — `Routine.reminderTime` / `Routine.reminderEnabled` added to the shared type; POST/PATCH `/api/routines` validate the 24h "HH:mm" format and support the clear-with-null PATCH contract, mirroring the habit routes.
- **Scheduler** — `reminderScheduler` now queries reminder-due routines alongside habits each tick (`findReminderRoutinesForScopes`). A routine counts as done for the day when any `routineLog` exists for that local dayKey. Since routines have no per-day schedule, reminders fire daily until completed (habits keep gating on `assignedDays`).
- **Dedup without migration** — the `pushSendLog` unique index `{habitId, dayKey, endpoint}` is reused as-is; routine sends claim a namespaced `routine:<id>` (habit ids are UUIDs, so no collision). Repository params renamed to `sourceId` for clarity; the stored field name is unchanged.
- **UI** — Routine Editor modal gains the same reminder controls as the habit modal: time picker, clear button, and a "Send push reminder" checkbox once a time is set. Device enrollment stays in Settings → Notifications (entity-agnostic, unchanged).
- **No service worker / push infra changes** — subscriptions, VAPID config, and `sw.js` are payload-driven and work as-is; routine notifications just carry a `routine-<id>-<dayKey>` tag and `/?view=routines` deep link.
- **Docs** — FEATURES.md (Routines section), UI architecture doc (Routine Editor row), and the "How HabitFlow Works" InfoModal Reminders blurb updated.

## Tests

- `routines.reminder.test.ts` (new) — HH:mm validation on create/PATCH, boundary times, malformed-value rejection, null-clears contract, `reminderEnabled` toggle preserving the time.
- `reminderScheduler.test.ts` (extended) — routine payload (title/tag/deep link), skip-once-logged including variant-scoped and previous-day logs, `reminderEnabled=false` exclusion, cross-tick dedup, habit+routine firing independently at the same minute, no cross-user sends.

**Verification note:** `npm run build` (tsc -b + vite) and `lint:beta` are green, and the frontend `RoutineContext` suite passes. The mongo-backed suites (including the new reminder tests) could not be executed in this sandbox because its network policy blocks the MongoDB binary download for `mongodb-memory-server` — please run `npx vitest run src/server/routes/__tests__/routines.reminder.test.ts src/server/services/__tests__/reminderScheduler.test.ts` locally or rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ADPMkurxYrzuRwMvvdx4y

---
_Generated by [Claude Code](https://claude.ai/code/session_015ADPMkurxYrzuRwMvvdx4y)_