### PR TITLE
Fix goal card reorder showing full-page spinner instead of smooth reorder

### DIFF
--- a/src/lib/useGoalTracks.ts
+++ b/src/lib/useGoalTracks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { fetchGoalTracks } from './persistenceClient';
 import type { GoalTrack } from '../models/persistenceTypes';
 import { getCachedGoalTracks, setCachedGoalTracks, isGoalTracksFresh, subscribeToCacheInvalidation } from './goalDataCache';
@@ -15,15 +15,20 @@ export function useGoalTracks() {
         return getCachedGoalTracks() === null;
     });
     const [error, setError] = useState<string | null>(null);
+    // Tracks whether we've ever successfully loaded tracks, so cache-invalidation-driven
+    // refetches (e.g. after a reorder) can revalidate in the background instead of
+    // blanking already-rendered cards with a blocking spinner.
+    const hasLoadedRef = useRef<boolean>(getCachedGoalTracks() !== null);
 
     const loadTracks = useCallback(async () => {
         const cached = getCachedGoalTracks();
         if (cached) {
             setTracks(cached);
+            hasLoadedRef.current = true;
             setLoading(false);
             setError(null);
             if (isGoalTracksFresh()) return;
-        } else {
+        } else if (!hasLoadedRef.current) {
             setLoading(true);
         }
 
@@ -32,6 +37,7 @@ export function useGoalTracks() {
             const fetched = await fetchGoalTracks();
             setCachedGoalTracks(fetched);
             setTracks(fetched);
+            hasLoadedRef.current = true;
             setLoading(false);
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : 'Failed to load goal tracks';

--- a/src/lib/useGoalsWithProgress.ts
+++ b/src/lib/useGoalsWithProgress.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { fetchGoalsWithProgress } from './persistenceClient';
 import type { GoalWithProgress } from '../models/persistenceTypes';
 import { getCachedGoalsWithProgress, setCachedGoalsWithProgress, isGoalsWithProgressFresh, subscribeToCacheInvalidation } from './goalDataCache';
@@ -30,17 +30,22 @@ export function useGoalsWithProgress() {
         return getCachedGoalsWithProgress() === null;
     });
     const [error, setError] = useState<string | null>(null);
+    // Tracks whether we've ever successfully loaded goals, so cache-invalidation-driven
+    // refetches (e.g. after a reorder) can revalidate in the background instead of
+    // blanking already-rendered cards with a blocking spinner.
+    const hasLoadedRef = useRef<boolean>(getCachedGoalsWithProgress() !== null);
 
     const loadGoals = useCallback(async () => {
         // Check cache first
         const cached = getCachedGoalsWithProgress();
         if (cached) {
             setGoals(cached);
+            hasLoadedRef.current = true;
             setLoading(false);
             setError(null);
             // Skip background fetch if cache is still fresh within TTL
             if (isGoalsWithProgressFresh()) return;
-        } else {
+        } else if (!hasLoadedRef.current) {
             setLoading(true);
         }
 
@@ -50,6 +55,7 @@ export function useGoalsWithProgress() {
             // Update cache
             setCachedGoalsWithProgress(fetchedGoals);
             setGoals(fetchedGoals);
+            hasLoadedRef.current = true;
             setLoading(false);
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : 'Failed to load goals';


### PR DESCRIPTION
## Summary

Dragging a goal card (or track card) to reorder it on the Goals page was blanking the whole list with a "Loading goals..." spinner instead of just smoothly moving the card to its new position.

**Root cause:** `reorderGoals()` / `reorderGoalTracks()` call `invalidateGoalDataCache()` on success, which clears the in-memory cache and notifies all subscribers via `subscribeToCacheInvalidation`. Both `useGoalsWithProgress` and `useGoalTracks` treated "no cache entry" as a first load and set `loading = true`, even though goals were already rendered on screen. That blocking loading state is what replaces the goal cards with the full-page spinner during what should be an invisible background revalidation.

`useProgressOverview.ts` already implements the correct pattern for this (see its `refresh()` comment: *"Keep stale progress visible during mutation-driven revalidation. A blocking loading state is only appropriate before first data."*) — this PR brings `useGoalsWithProgress` and `useGoalTracks` in line with that existing pattern.

## Changes

- `src/lib/useGoalsWithProgress.ts`: track whether goals have ever successfully loaded (`hasLoadedRef`); only set `loading = true` before that first successful load. Cache-invalidation-triggered refetches now keep the current cards visible and swap in the reordered list once the background fetch resolves.
- `src/lib/useGoalTracks.ts`: identical fix, since track reordering hits the same code path and cache invalidation clears both caches together.

## Test plan

- [x] `npm run build` (tsc -b + vite build) passes
- [x] `npx eslint` on both changed files — no errors
- [x] Existing tests touching these caches/hooks pass (`useProgressOverview.test.tsx`, `TrackerGrid.clearEntry.test.tsx`, `AddHabitModal.formState.test.tsx`, `HabitGridCell.test.tsx`)
- [ ] Manual verification: drag-reorder a goal card in the UI and confirm no spinner flash


---
_Generated by [Claude Code](https://claude.ai/code/session_01QmVvZcvqkbFqBSMUCGdRpD)_