### PR TITLE
Fix habit count discrepancy between dashboard category rows and the Habits "All" tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -660,7 +660,12 @@ const HabitTrackerContent: React.FC = () => {
               handleNavigate('goals', { goalId });
             }}
             onSelectCategory={(categoryId) => {
-              setActiveCategoryId(categoryId);
+              // The "No Category" bucket has no tab of its own — it maps to
+              // the Uncategorized chip. Without this, the tracker's default-
+              // category effect silently resets the selection.
+              setActiveCategoryId(
+                noCategoryCategoryIds.has(categoryId) ? UNCATEGORIZED_ID : categoryId
+              );
               handleNavigate('tracker');
             }}
             onNavigateWellbeingHistory={() => handleNavigate('wellbeing-history')}

--- a/src/components/TrackerGrid.bundleChildVisibility.test.tsx
+++ b/src/components/TrackerGrid.bundleChildVisibility.test.tsx
@@ -1,0 +1,119 @@
+/** Bundle-child visibility coverage for the All grid.
+ *
+ * A bundle child must be hidden only when its parent bundle is part of the
+ * same filtered view (it renders inside the parent's drawer). Children whose
+ * parent is archived, deleted, or lives in another category previously
+ * disappeared from the grid entirely while dashboard category counts still
+ * included them.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TrackerGrid } from './TrackerGrid';
+import type { Habit } from '../types';
+
+vi.mock('../store/HabitContext', () => ({ useHabitStore: vi.fn() }));
+vi.mock('../store/RoutineContext', () => ({ useRoutineStore: vi.fn() }));
+vi.mock('../lib/useProgressOverview', () => ({ useProgressOverview: vi.fn() }));
+vi.mock('../lib/useGoalsWithProgress', () => ({ useGoalsWithProgress: vi.fn() }));
+vi.mock('../store/DashboardPrefsContext', () => ({
+    useDashboardPrefs: () => ({ hideStreaks: false }),
+}));
+vi.mock('./Toast', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('./NumericInputPopover', () => ({ NumericInputPopover: () => null }));
+vi.mock('./HabitHistoryModal', () => ({ HabitHistoryModal: () => null }));
+vi.mock('./HabitLogModal', () => ({ HabitLogModal: () => null }));
+
+import { useHabitStore } from '../store/HabitContext';
+import { useRoutineStore } from '../store/RoutineContext';
+import { useProgressOverview } from '../lib/useProgressOverview';
+import { useGoalsWithProgress } from '../lib/useGoalsWithProgress';
+
+const createHabit = (id: string, name: string, extra: Partial<Habit> = {}): Habit => ({
+    id,
+    categoryId: 'cat-1',
+    name,
+    goal: { type: 'boolean', frequency: 'daily' },
+    archived: false,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...extra,
+});
+
+const renderGrid = (habits: Habit[], allHabits?: Habit[]) =>
+    render(
+        <TrackerGrid
+            habits={habits}
+            allHabits={allHabits ?? habits}
+            logs={{}}
+            onAddHabit={() => {}}
+            onEditHabit={() => {}}
+            onViewHistory={() => {}}
+            onToggle={async () => {}}
+            onUpdateValue={async () => {}}
+        />
+    );
+
+describe('TrackerGrid bundle child visibility', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useHabitStore).mockReturnValue({
+            deleteHabit: vi.fn(),
+            archiveHabit: vi.fn(),
+            reorderHabits: vi.fn(),
+            upsertHabitEntry: vi.fn(),
+            deleteHabitEntryByKey: vi.fn(),
+            toggleHabit: vi.fn(),
+        } as unknown as ReturnType<typeof useHabitStore>);
+        vi.mocked(useRoutineStore).mockReturnValue({ routines: [] } as unknown as ReturnType<typeof useRoutineStore>);
+        vi.mocked(useProgressOverview).mockReturnValue({
+            data: undefined,
+            loading: false,
+            error: undefined,
+            refresh: vi.fn(),
+        });
+        vi.mocked(useGoalsWithProgress).mockReturnValue({
+            data: [],
+            loading: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+    });
+
+    it('hides a bundle child when its parent is in the same view', () => {
+        const parent = createHabit('bundle-1', 'Morning Bundle', {
+            type: 'bundle',
+            bundleType: 'checklist',
+            subHabitIds: ['child-1'],
+        });
+        const child = createHabit('child-1', 'Stretch', { bundleParentId: 'bundle-1' });
+
+        renderGrid([parent, child]);
+
+        expect(screen.getByText('Morning Bundle')).toBeInTheDocument();
+        expect(screen.queryByText('Stretch')).not.toBeInTheDocument();
+    });
+
+    it('shows a bundle child as a top-level row when its parent is not in the view (other category or archived)', () => {
+        // The habits prop is the category-filtered set: the parent lives in a
+        // different category (or is archived), so only the child is passed in.
+        const parent = createHabit('bundle-1', 'Morning Bundle', {
+            type: 'bundle',
+            bundleType: 'checklist',
+            subHabitIds: ['child-1'],
+            categoryId: 'cat-other',
+        });
+        const child = createHabit('child-1', 'Stretch', { bundleParentId: 'bundle-1' });
+
+        renderGrid([child], [parent, child]);
+
+        expect(screen.getByText('Stretch')).toBeInTheDocument();
+    });
+
+    it('shows a bundle child as a top-level row when its parent was deleted', () => {
+        const child = createHabit('child-1', 'Stretch', { bundleParentId: 'gone-parent' });
+
+        renderGrid([child]);
+
+        expect(screen.getByText('Stretch')).toBeInTheDocument();
+    });
+});

--- a/src/components/TrackerGrid.tsx
+++ b/src/components/TrackerGrid.tsx
@@ -880,10 +880,15 @@ export const TrackerGrid = ({
     // Use the child's own bundleParentId rather than the parent's subHabitIds array,
     // so that children never slip through as top-level rows when the parent's
     // subHabitIds is momentarily stale (e.g. mid-sync or before a refetch).
-    const rootHabits = useMemo(
-        () => habits.filter(h => !h.bundleParentId),
-        [habits]
-    );
+    // A child is hidden only when its parent is part of the current filtered
+    // view (it renders inside the parent's drawer). Children whose parent is
+    // archived or lives in a different category would otherwise be invisible
+    // here while dashboard category counts still include them, so they
+    // surface as top-level rows.
+    const rootHabits = useMemo(() => {
+        const visibleIds = new Set(habits.map(h => h.id));
+        return habits.filter(h => !h.bundleParentId || !visibleIds.has(h.bundleParentId));
+    }, [habits]);
 
     // Initial Split based on Roots
     const dailyHabits = useMemo(() => rootHabits.filter(h => !h.goal?.frequency || h.goal.frequency === 'daily' || h.goal.frequency === 'total'), [rootHabits]);

--- a/src/components/day-view/ScheduleView.tsx
+++ b/src/components/day-view/ScheduleView.tsx
@@ -5,6 +5,7 @@ import { CategoryPickerModal } from '../CategoryPickerModal';
 import { format, startOfWeek, endOfWeek, addDays, subWeeks, addWeeks } from 'date-fns';
 import { Calendar, ChevronLeft, ChevronRight, ChevronDown, ChevronUp } from 'lucide-react';
 import { getLocalTimeZone } from '../../lib/persistenceClient';
+import { getBundleChildIds } from '../../utils/habitUtils';
 
 import type { Habit } from '../../types';
 import { resolveLocalHabitStatuses, type DayViewHabitStatus } from './habitStatusResolution';
@@ -52,16 +53,9 @@ export const ScheduleView = () => {
         return new Map(dayViewData.habits.map(status => [status.habit.id, status]));
     }, [dayViewData]);
 
-    // Build child ID set
-    const childIds = useMemo(() => {
-        const ids = new Set<string>();
-        habits.forEach(h => {
-            if (h.type === 'bundle' && h.subHabitIds) {
-                h.subHabitIds.forEach(id => ids.add(id));
-            }
-        });
-        return ids;
-    }, [habits]);
+    // Build child ID set. Shared helper: only ACTIVE parents hide their
+    // children, so children of archived/deleted bundles stay reachable.
+    const childIds = useMemo(() => getBundleChildIds(habits), [habits]);
 
     // Separate scheduled habits vs daily habits
     const { scheduledHabits, dailyHabits } = useMemo(() => {

--- a/src/server/routes/__tests__/habits.orphaned-bundle-child.test.ts
+++ b/src/server/routes/__tests__/habits.orphaned-bundle-child.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { setupTestMongo, teardownTestMongo, getTestDb } from '../../../test/mongoTestHelper';
+import { getHabits } from '../habits';
+
+// Self-heal runs once per user per server process, so each test uses its own
+// user id to get a fresh recovery pass.
+function makeApp(userId: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).householdId = 'default-household';
+    (req as any).userId = userId;
+    next();
+  });
+  app.get('/api/habits', getHabits);
+  return app;
+}
+
+const baseHabit = (userId: string) => ({
+  goal: { type: 'boolean', frequency: 'daily' },
+  archived: false,
+  createdAt: new Date().toISOString(),
+  householdId: 'default-household',
+  userId,
+});
+
+describe('GET /api/habits orphaned bundle child recovery', () => {
+  beforeAll(async () => {
+    await setupTestMongo();
+  });
+
+  afterAll(async () => {
+    await teardownTestMongo();
+  });
+
+  it('clears bundleParentId when the parent bundle no longer exists', async () => {
+    const userId = 'test-orphaned-child-user';
+    const testDb = await getTestDb();
+    await testDb.collection('categories').insertOne({
+      id: 'cat-1',
+      name: 'Physical Health',
+      color: 'bg-emerald-600',
+      householdId: 'default-household',
+      userId,
+    });
+    // Child pointing at a parent id that has no habit document at all
+    await testDb.collection('habits').insertOne({
+      id: 'ghost-child',
+      name: 'Ghost Child',
+      categoryId: 'cat-1',
+      bundleParentId: 'deleted-parent-id',
+      ...baseHabit(userId),
+    });
+
+    const res = await request(makeApp(userId)).get('/api/habits');
+    expect(res.status).toBe(200);
+
+    const healed = res.body.habits.find((h: any) => h.id === 'ghost-child');
+    expect(healed).toBeDefined();
+    expect(healed.bundleParentId ?? null).toBeNull();
+
+    const doc = await testDb.collection('habits').findOne({ id: 'ghost-child' });
+    expect(doc?.bundleParentId ?? null).toBeNull();
+  });
+
+  it('clears bundleParentId when the parent bundle is soft-deleted', async () => {
+    const userId = 'test-orphaned-child-softdel-user';
+    const testDb = await getTestDb();
+    await testDb.collection('categories').insertOne({
+      id: 'cat-2',
+      name: 'Physical Health',
+      color: 'bg-emerald-600',
+      householdId: 'default-household',
+      userId,
+    });
+    await testDb.collection('habits').insertMany([
+      {
+        id: 'soft-deleted-parent',
+        name: 'Old Bundle',
+        categoryId: 'cat-2',
+        type: 'bundle',
+        subHabitIds: ['stranded-child'],
+        deletedAt: new Date().toISOString(),
+        ...baseHabit(userId),
+      },
+      {
+        id: 'stranded-child',
+        name: 'Stranded Child',
+        categoryId: 'cat-2',
+        bundleParentId: 'soft-deleted-parent',
+        ...baseHabit(userId),
+      },
+    ]);
+
+    const res = await request(makeApp(userId)).get('/api/habits');
+    expect(res.status).toBe(200);
+
+    const healed = res.body.habits.find((h: any) => h.id === 'stranded-child');
+    expect(healed).toBeDefined();
+    expect(healed.bundleParentId ?? null).toBeNull();
+  });
+
+  it('keeps bundleParentId when the parent exists (even archived)', async () => {
+    const userId = 'test-orphaned-child-intact-user';
+    const testDb = await getTestDb();
+    await testDb.collection('categories').insertOne({
+      id: 'cat-3',
+      name: 'Physical Health',
+      color: 'bg-emerald-600',
+      householdId: 'default-household',
+      userId,
+    });
+    await testDb.collection('habits').insertMany([
+      {
+        id: 'live-parent',
+        name: 'Live Bundle',
+        categoryId: 'cat-3',
+        type: 'bundle',
+        subHabitIds: ['live-child'],
+        ...baseHabit(userId),
+      },
+      {
+        id: 'live-child',
+        name: 'Live Child',
+        categoryId: 'cat-3',
+        bundleParentId: 'live-parent',
+        ...baseHabit(userId),
+      },
+      {
+        id: 'archived-parent',
+        name: 'Archived Bundle',
+        categoryId: 'cat-3',
+        type: 'bundle',
+        subHabitIds: ['archived-parent-child'],
+        ...baseHabit(userId),
+        archived: true,
+        archivedReason: 'user',
+      },
+      {
+        id: 'archived-parent-child',
+        name: 'Child Of Archived',
+        categoryId: 'cat-3',
+        bundleParentId: 'archived-parent',
+        ...baseHabit(userId),
+      },
+    ]);
+
+    const res = await request(makeApp(userId)).get('/api/habits');
+    expect(res.status).toBe(200);
+
+    const liveChild = res.body.habits.find((h: any) => h.id === 'live-child');
+    expect(liveChild.bundleParentId).toBe('live-parent');
+
+    const archivedParentChild = res.body.habits.find((h: any) => h.id === 'archived-parent-child');
+    expect(archivedParentChild.bundleParentId).toBe('archived-parent');
+  });
+});

--- a/src/server/routes/habits.ts
+++ b/src/server/routes/habits.ts
@@ -129,6 +129,27 @@ export async function getHabits(req: Request, res: Response): Promise<void> {
           const updatedMap = new Map(updatedHabits.filter(Boolean).map(h => [h!.id, h!]));
           habits = habits.map(h => updatedMap.get(h.id) ?? h);
         }
+
+        // Clear dangling bundleParentId on children whose parent bundle no
+        // longer exists (deleting a bundle never cascades to its children).
+        // A dangling parent reference hides the habit from every habit view
+        // (All/Today/Schedule treat any bundleParentId as "rendered under the
+        // parent") while per-category counts still include it. Archived
+        // parents are left intact — unarchiving restores the bundle.
+        const habitIds = new Set(habits.map(h => h.id));
+        const orphanedChildren = habits.filter(
+          h => h.bundleParentId && !habitIds.has(h.bundleParentId)
+        );
+        if (orphanedChildren.length > 0) {
+          console.log(`[Self-heal] Clearing dangling bundleParentId on ${orphanedChildren.length} habits for user ${userId}`);
+          const updatedOrphans = await Promise.all(
+            orphanedChildren.map(h =>
+              updateHabit(h.id, householdId, userId, { bundleParentId: null })
+            )
+          );
+          const orphanMap = new Map(updatedOrphans.filter(Boolean).map(h => [h!.id, h!]));
+          habits = habits.map(h => orphanMap.get(h.id) ?? h);
+        }
       }
     }
 

--- a/src/utils/habitRingProgress.test.ts
+++ b/src/utils/habitRingProgress.test.ts
@@ -535,3 +535,48 @@ describe('Edge cases', () => {
         expect(root.map(h => h.id)).not.toContain('orphan-child');
     });
 });
+
+// =============================================================================
+// Archived / missing parent — children must surface as roots
+// =============================================================================
+describe('getBundleChildIds — inactive parents do not hide children', () => {
+    it('children of an archived parent surface as roots', () => {
+        const habits = [
+            makeHabit({
+                id: 'archived-bundle',
+                name: 'Old Bundle',
+                type: 'bundle',
+                bundleType: 'checklist',
+                subHabitIds: ['ab-child-1', 'ab-child-2'],
+                archived: true,
+            }),
+            makeHabit({ id: 'ab-child-1', name: 'Child 1', bundleParentId: 'archived-bundle' }),
+            makeHabit({ id: 'ab-child-2', name: 'Child 2', bundleParentId: 'archived-bundle' }),
+        ];
+
+        const childIds = getBundleChildIds(habits);
+        expect(childIds.has('ab-child-1')).toBe(false);
+        expect(childIds.has('ab-child-2')).toBe(false);
+
+        const root = getRootHabits(habits);
+        expect(root.map(h => h.id)).toEqual(['ab-child-1', 'ab-child-2']);
+    });
+
+    it('children whose parent is not in the list (deleted) surface as roots', () => {
+        const habits = [
+            makeHabit({ id: 'ghost-child', name: 'Ghost Child', bundleParentId: 'deleted-parent' }),
+            makeHabit({ id: 'h1', name: 'Standalone' }),
+        ];
+
+        const childIds = getBundleChildIds(habits);
+        expect(childIds.has('ghost-child')).toBe(false);
+
+        expect(getHabitsForDate(habits, DATE).map(h => h.id)).toContain('ghost-child');
+    });
+
+    it('children of an active parent stay hidden', () => {
+        const { parent, children } = checklistBundle();
+        const childIds = getBundleChildIds([parent, ...children]);
+        children.forEach(c => expect(childIds.has(c.id)).toBe(true));
+    });
+});

--- a/src/utils/habitUtils.ts
+++ b/src/utils/habitUtils.ts
@@ -241,13 +241,21 @@ export function getBundleStats(
  * Uses both parent's subHabitIds and child's bundleParentId for robustness.
  */
 export function getBundleChildIds(habits: Habit[]): Set<string> {
+    const byId = new Map(habits.map(h => [h.id, h]));
     const childIds = new Set<string>();
     habits.forEach(h => {
-        if (h.type === 'bundle' && h.subHabitIds) {
+        // Only ACTIVE parents hide their children: a child is rendered inside
+        // its parent's drawer, so when the parent is archived or deleted the
+        // child must surface as a root habit or it becomes unreachable while
+        // category counts still include it.
+        if (h.type === 'bundle' && !h.archived && h.subHabitIds) {
             h.subHabitIds.forEach(id => childIds.add(id));
         }
         if (h.bundleParentId) {
-            childIds.add(h.id);
+            const parent = byId.get(h.bundleParentId);
+            if (parent && !parent.archived) {
+                childIds.add(h.id);
+            }
         }
     });
     return childIds;


### PR DESCRIPTION
## Problem

The dashboard's Activity → By Category section showed **"No Category — 3 habits"** while the Habits page's "All" tab with the Uncategorized chip selected rendered **no habits at all** (just the empty-state education panel).

## Root cause

The two views disagree on which habits exist in a category:

- The dashboard row counts every non-archived habit by its own `categoryId` (`ActivitySection.tsx`), **including bundle children**.
- The Habits "All" grid unconditionally hides every habit with a `bundleParentId` (`TrackerGrid.tsx`), expecting it to render inside its parent bundle's drawer.

That expectation breaks in three ways, each producing habits that are counted but rendered nowhere:

1. **Deleted parent** — deleting a bundle never clears its children's `bundleParentId`, so children point at a soft-deleted habit forever and vanish from every habit view (All, Today, Schedule).
2. **Archived parent** — the parent row isn't shown, so the drawer (and children) are unreachable.
3. **Parent in a different category** — moving a bundle deliberately doesn't cascade to children (`HabitContext.moveHabitToCategory`), so a child's own category tab shows nothing while its count includes the child.

**Concrete impact:** a user with 3 bundle children stranded in "No Category" sees the dashboard claim 3 habits there, taps through, and lands on an empty tab that claims they have no habits — with no way to see or manage those 3 habits at all.

## Fix

1. **Server self-heal** (`src/server/routes/habits.ts`): the existing one-time recovery pass in `GET /api/habits` now also clears `bundleParentId` when the referenced parent no longer exists. Orphaned children become normal, visible root habits everywhere. Children of *archived* parents are left intact so unarchiving restores the bundle.
2. **TrackerGrid visibility rule** (`src/components/TrackerGrid.tsx`): a bundle child is hidden only when its parent is part of the same filtered view (where it renders in the parent's drawer). Children whose parent is archived or lives in another category now surface as top-level rows on their own category's tab.
3. **Dashboard navigation** (`src/App.tsx`): clicking the "No Category" heatmap row now maps to the Uncategorized chip on the Habits page. Previously it set the raw No-Category id, which the tracker's default-category effect silently reset to Physical Health.

After this change the dashboard's "No Category — 3 habits" and the Uncategorized tab show the same 3 habits.

## Tests

- `src/server/routes/__tests__/habits.orphaned-bundle-child.test.ts` — self-heal clears dangling `bundleParentId` (missing and soft-deleted parents) and preserves live/archived parent links.
- `src/components/TrackerGrid.bundleChildVisibility.test.tsx` — child hidden when parent is in view; shown when parent is absent (other category/archived) or deleted.
- `npm run build` green; component/utils/domain suites pass (the one failure, `goalUtils.test.ts`, is pre-existing on `main` and untouched by this diff). MongoDB-backed suites couldn't run in the sandbox (binary download blocked) — covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGUsU1aoj8T82soCnUVQRY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGUsU1aoj8T82soCnUVQRY)_