### PR TITLE
fix(habits): render Remove Habit modal in a portal so it is fully visible

### DIFF
--- a/src/components/DeleteHabitConfirmModal.tsx
+++ b/src/components/DeleteHabitConfirmModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { X, AlertTriangle, Loader2, Target, Archive, Trash2 } from 'lucide-react';
 
 interface RemoveHabitModalProps {
@@ -25,6 +26,12 @@ interface RemoveHabitModalProps {
  *
  * For habits linked to one or more goals, the modal also surfaces the
  * affected goal titles so the user knows what gets disconnected.
+ *
+ * Rendered through a portal into `document.body`. Call sites mount this
+ * inside habit cards (e.g. `HabitGridCell`) whose own styling — an expanded
+ * `scale-[1.02]` transform plus `overflow-hidden` — would otherwise become
+ * the containing block for `position: fixed` and clip the overlay down to
+ * the size of a single habit row.
  */
 export const DeleteHabitConfirmModal: React.FC<RemoveHabitModalProps> = ({
     isOpen,
@@ -75,11 +82,16 @@ export const DeleteHabitConfirmModal: React.FC<RemoveHabitModalProps> = ({
 
     const hasLinkedGoals = linkedGoalTitles.length > 0;
 
-    return (
-        <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-md bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl">
+    return createPortal(
+        <div className="modal-overlay fixed inset-0 z-[110] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+            <div
+                className="w-full max-w-md max-h-full overflow-y-auto modal-scroll bg-neutral-900 border border-white/10 rounded-2xl p-6 shadow-2xl"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="remove-habit-title"
+            >
                 <div className="flex items-center justify-between mb-6">
-                    <h3 className="text-xl font-bold text-white">Remove Habit</h3>
+                    <h3 id="remove-habit-title" className="text-xl font-bold text-white">Remove Habit</h3>
                     <button
                         onClick={handleCancel}
                         disabled={!!busy}
@@ -180,6 +192,7 @@ export const DeleteHabitConfirmModal: React.FC<RemoveHabitModalProps> = ({
                     </div>
                 </div>
             </div>
-        </div>
+        </div>,
+        document.body
     );
 };


### PR DESCRIPTION
## Problem

Deleting a habit from the Habits day view opened the **Remove Habit** modal, but only a thin horizontal band of it was visible — the tail of the Archive description ("…and all its entries are preserved and you can restore it any time from Settings.") and the top edge of the red Delete button. The title, the habit name, both button labels, and Cancel were all clipped away, making the dialog unusable on mobile.

## Root cause

`DeleteHabitConfirmModal` is mounted **inside** `HabitGridCell`'s root element (`src/components/day-view/HabitGridCell.tsx:429`). That element carries:

```
"relative flex flex-col rounded-lg border transition-all duration-300 overflow-hidden"
isExpanded && "bg-neutral-800 border-white/10 shadow-lg scale-[1.02] z-10"
```

Two properties combine to break the overlay:

1. **`scale-[1.02]`** — a `transform` on an ancestor makes that ancestor the containing block for descendant `position: fixed` elements. The modal's `fixed inset-0` therefore resolved to the habit row's box, not the viewport. This always applies in practice: the trash button lives in the expanded action row, so the modal can only be opened while the cell is expanded and scaled.
2. **`overflow-hidden`** — everything outside that ~120px-tall row box was clipped.

Net effect: an overlay sized and centered to a single habit row, showing the vertical middle of a ~450px dialog.

## Fix

- Render the modal through `createPortal(…, document.body)` so no ancestor can establish a containing block or clip it. This covers both call sites (`HabitGridCell` and `TrackerGrid`).
- Cap the panel with `max-h-full overflow-y-auto modal-scroll` (the existing repo utility for iOS-safe modal scrolling) so long content — e.g. a habit linked to several goals — scrolls inside the dialog instead of overflowing on short screens.
- Raise the overlay from `z-50` to `z-[110]`, matching the app's other modals (`ArchivedHabitsModal`, `SettingsModal`, `InfoModal`).
- Add `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing at the existing title.

No behavior change to archive/delete itself — this is purely how the dialog is mounted and sized.

## Verification

- `npm run build` — green (`tsc -b && vite build`).
- `npx vitest run src/components/day-view/HabitGridCell.test.tsx` — 3/3 passing.
- `npm run test:beta` — 23 passing; 5 server suites fail in this sandbox because `mongodb-memory-server` gets a 403 fetching the MongoDB binary through the proxy. Pre-existing environment issue, unrelated to this frontend-only change.
- `npx eslint src/components/DeleteHabitConfirmModal.tsx` — clean.

No docs updated: no screen, flow, feature, or modal inventory entry changed — `docs/product/HABITFLOW_UI_ARCHITECTURE.md:164` already describes this modal accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M1L4ythrYr2M9MkSo9o9G

---
_Generated by [Claude Code](https://claude.ai/code/session_013M1L4ythrYr2M9MkSo9o9G)_